### PR TITLE
MODKBEKBJ-40: GET /eholdings/configuration endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -88,7 +88,8 @@
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/eholdings/configuration"
+          "pathPattern": "/eholdings/configuration",
+          "permissionRequired" :["kb-ebsco.configuration.get"]
         },
         {
           "methods": ["PUT"],
@@ -101,7 +102,21 @@
       ]
     }
   ],
-  "permissionSets" : [],
+  "permissionSets": [
+    {
+      "permissionName": "kb-ebsco.configuration.get",
+      "displayName": "get RM API configuration",
+      "description": "Get RM API configuration"
+    },
+    {
+      "permissionName": "kb-ebsco.all",
+      "displayName": "EBSCO KB Broker - all permissions",
+      "description": "All permissions for EBSCO KB module",
+      "subPermissions": [
+        "kb-ebsco.configuration.get"
+      ]
+    }
+  ],
   "requires": [],
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <rest-assured.version>3.1.1</rest-assured.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <mod-configuration-client.version>4.0.3</mod-configuration-client.version>
   </properties>
 
   <dependencies>
@@ -57,7 +58,39 @@
       <version>${rest-assured.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.7.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>2.19.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>mod-configuration-client</artifactId>
+      <version>${mod-configuration-client.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.23.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>net.sf.jopt-simple</groupId>
+        <artifactId>jopt-simple</artifactId>
+        <version>4.6</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <resources>

--- a/ramls/eholdings.raml
+++ b/ramls/eholdings.raml
@@ -77,6 +77,11 @@ mediaType: "application/vnd.api+json"
           application/vnd.api+json:
             description: Details of KB configuration currently being used.
             example: !include examples/configuration/kb_configuration_get_200_response.json
+      500:
+        description: "Internal server error"
+        body:
+          text/plain:
+            example: "Internal server error, contact administrator"
   put:
     description: |
       Update the currently set KB configuration.

--- a/src/main/java/org/folio/config/RMAPIConfiguration.java
+++ b/src/main/java/org/folio/config/RMAPIConfiguration.java
@@ -1,0 +1,40 @@
+package org.folio.config;
+
+/**
+ * Contains the RM API connection details from mod-configuration.
+ */
+public final class RMAPIConfiguration {
+  private String customerId;
+  private String apiKey;
+  private String url;
+
+  public String getCustomerId() {
+    return customerId;
+  }
+
+  public String getAPIKey() {
+    return apiKey;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setCustomerId(String customerId) {
+    this.customerId = customerId;
+  }
+
+  public void setApiKey(String apiKey) {
+    this.apiKey = apiKey;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  @Override
+  public String toString() {
+    return "RMAPIConfiguration [customerId=" + customerId
+      + ", apiKey=" + apiKey + ", url=" + url + ']';
+  }
+}

--- a/src/main/java/org/folio/config/RMAPIConfigurationClient.java
+++ b/src/main/java/org/folio/config/RMAPIConfigurationClient.java
@@ -34,7 +34,9 @@ public class RMAPIConfigurationClient {
    * Returns the RM API configuration for the tenant.
    *
    * @param apiToken token used to call okapi
-   * @return The RMI API configuration for the tenant.
+   * @param tenant tenant for which configuration is retrieved
+   * @param okapiURL url of OKAPI server
+   * @return The RM API configuration for the tenant.
    */
   public CompletableFuture<RMAPIConfiguration> retrieveConfiguration(String apiToken, String tenant, String okapiURL) {
     final String tenantId = TenantTool.calculateTenantId(tenant);

--- a/src/main/java/org/folio/config/RMAPIConfigurationClient.java
+++ b/src/main/java/org/folio/config/RMAPIConfigurationClient.java
@@ -23,6 +23,7 @@ public class RMAPIConfigurationClient {
   private static final String EBSCO_URL_CODE = "kb.ebsco.url";
   private static final String EBSCO_API_KEY_CODE = "kb.ebsco.apiKey";
   private static final String EBSCO_CUSTOMER_ID_CODE = "kb.ebsco.customerId";
+  private static final int QUERY_LIMIT = 100;
 
   private ConfigurationClientProvider configurationClientProvider;
 
@@ -46,8 +47,9 @@ public class RMAPIConfigurationClient {
 
     try {
       URL url = new URL(okapiURL);
-      ConfigurationsClient configurationsClient = configurationClientProvider.createClient(url.getHost(), url.getPort(), tenantId, apiToken);
-      configurationsClient.getEntries("module=EKB", 0, Integer.MAX_VALUE, null, null, response ->
+      int port = url.getPort() != -1? url.getPort() : url.getDefaultPort();
+      ConfigurationsClient configurationsClient = configurationClientProvider.createClient(url.getHost(), port, tenantId, apiToken);
+      configurationsClient.getEntries("module=EKB", 0, QUERY_LIMIT, null, null, response ->
         response.bodyHandler(body -> {
           if (!Response.isSuccess(response.statusCode())) {
             LOG.error("Cannot get configuration data: error code - {} response body - {}", response.statusCode(), body);

--- a/src/main/java/org/folio/config/RMAPIConfigurationClient.java
+++ b/src/main/java/org/folio/config/RMAPIConfigurationClient.java
@@ -1,0 +1,96 @@
+package org.folio.config;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.folio.http.ConfigurationClientProvider;
+import org.folio.rest.client.ConfigurationsClient;
+import org.folio.rest.tools.client.Response;
+import org.folio.rest.tools.utils.TenantTool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Retrieves the RM API connection details from mod-configuration.
+ */
+public class RMAPIConfigurationClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RMAPIConfigurationClient.class);
+
+  private static final String EBSCO_URL_CODE = "kb.ebsco.url";
+  private static final String EBSCO_API_KEY_CODE = "kb.ebsco.apiKey";
+  private static final String EBSCO_CUSTOMER_ID_CODE = "kb.ebsco.customerId";
+
+  private ConfigurationClientProvider configurationClientProvider;
+
+  /**
+   * @param configurationClientProvider object used to get http client for sending request to okapi
+   */
+  public RMAPIConfigurationClient(ConfigurationClientProvider configurationClientProvider) {
+    this.configurationClientProvider = configurationClientProvider;
+  }
+
+  /**
+   * Returns the RM API configuration for the tenant.
+   *
+   * @param apiToken token used to call okapi
+   * @return The RMI API configuration for the tenant.
+   */
+  public CompletableFuture<RMAPIConfiguration> retrieveConfiguration(String apiToken, String tenant, String okapiURL) {
+    final String tenantId = TenantTool.calculateTenantId(tenant);
+
+    CompletableFuture<RMAPIConfiguration> future = new CompletableFuture<>();
+
+    try {
+      URL url = new URL(okapiURL);
+      ConfigurationsClient configurationsClient = configurationClientProvider.createClient(url.getHost(), url.getPort(), tenantId, apiToken);
+      configurationsClient.getEntries("module=EKB", 0, Integer.MAX_VALUE, null, null, response ->
+        response.bodyHandler(body -> {
+          if (!Response.isSuccess(response.statusCode())) {
+            LOG.error("Cannot get configuration data: error code - {} response body - {}", response.statusCode(), body);
+            future.completeExceptionally(new IllegalStateException(body.toString()));
+          }
+          JsonObject entries = body.toJsonObject();
+          future.complete(mapResults(entries.getJsonArray("configs")));
+        }));
+    } catch (IOException e) {
+      LOG.error("Cannot get configuration data: " + e.getMessage(), e);
+      future.completeExceptionally(e);
+    }
+    return future;
+  }
+
+  /**
+   * Simple mapper for the results of mod-configuration to RMAPIConfiguration.
+   *
+   * @param configs All the RM API related configurations returned by
+   *                mod-configuration.
+   */
+  private RMAPIConfiguration mapResults(JsonArray configs) {
+    RMAPIConfiguration config = new RMAPIConfiguration();
+    configs.stream()
+      .filter(JsonObject.class::isInstance)
+      .map(JsonObject.class::cast)
+      .forEach(entry -> {
+        String code = entry.getString("code");
+        String value = entry.getString("value");
+        if (EBSCO_CUSTOMER_ID_CODE.equalsIgnoreCase(code)) {
+          config.setCustomerId(value);
+        } else if (EBSCO_API_KEY_CODE.equalsIgnoreCase(code)) {
+          config.setApiKey(value);
+        } else if (EBSCO_URL_CODE.equalsIgnoreCase(code)) {
+          config.setUrl(value);
+        }
+      });
+
+    if (config.getCustomerId() == null || config.getAPIKey() == null ||
+      config.getUrl() == null) {
+      throw new IllegalStateException("Configuration data is invalid");
+    }
+
+    return config;
+  }
+}

--- a/src/main/java/org/folio/http/ConfigurationClientProvider.java
+++ b/src/main/java/org/folio/http/ConfigurationClientProvider.java
@@ -1,0 +1,12 @@
+package org.folio.http;
+
+import org.folio.rest.client.ConfigurationsClient;
+
+/**
+ * Class used to create ConfigurationsClient, to allow mocking of client in unit tests
+ */
+public class ConfigurationClientProvider {
+  public ConfigurationsClient createClient(String url, int port, String tenantId, String apiToken) {
+    return new ConfigurationsClient(url, port, tenantId, apiToken);
+  }
+}

--- a/src/main/java/org/folio/rest/converter/RMAPIConfigurationConverter.java
+++ b/src/main/java/org/folio/rest/converter/RMAPIConfigurationConverter.java
@@ -1,0 +1,21 @@
+package org.folio.rest.converter;
+
+import org.apache.commons.lang3.StringUtils;
+import org.folio.config.RMAPIConfiguration;
+import org.folio.rest.jaxrs.model.EholdingsConfigurationPutApplicationVndApiJsonImpl;
+
+/**
+ * Converts internal RMAPIConfiguration object into object that will be returned in response
+ */
+public class RMAPIConfigurationConverter {
+  public EholdingsConfigurationPutApplicationVndApiJsonImpl convert(RMAPIConfiguration rmAPIConfig) {
+    EholdingsConfigurationPutApplicationVndApiJsonImpl jsonConfig = new EholdingsConfigurationPutApplicationVndApiJsonImpl();
+    jsonConfig.setData(new EholdingsConfigurationPutApplicationVndApiJsonImpl.DataTypeImpl());
+    jsonConfig.getData().setType("configurations");
+    jsonConfig.getData().setAttributes(new EholdingsConfigurationPutApplicationVndApiJsonImpl.DataTypeImpl.AttributesTypeImpl());
+    jsonConfig.getData().getAttributes().setApiKey(StringUtils.repeat("*", 40));
+    jsonConfig.getData().getAttributes().setCustomerId(rmAPIConfig.getCustomerId());
+    jsonConfig.getData().getAttributes().setRmapiBaseUrl(rmAPIConfig.getUrl());
+    return jsonConfig;
+  }
+}

--- a/src/main/java/org/folio/rest/impl/EholdingsConfigurationImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsConfigurationImpl.java
@@ -4,6 +4,8 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import org.folio.config.RMAPIConfigurationClient;
 import org.folio.http.ConfigurationClientProvider;
 import org.folio.rest.converter.RMAPIConfigurationConverter;
@@ -17,6 +19,8 @@ import javax.ws.rs.core.Response;
 import java.util.Map;
 
 public class EholdingsConfigurationImpl implements EholdingsConfiguration {
+
+  private final Logger logger = LoggerFactory.getLogger(EholdingsConfigurationImpl.class);
 
   private RMAPIConfigurationClient configurationClient;
   private RMAPIConfigurationConverter converter;
@@ -45,8 +49,9 @@ public class EholdingsConfigurationImpl implements EholdingsConfiguration {
         EholdingsConfigurationPutApplicationVndApiJsonImpl configuration = converter.convert(rmAPIconfiguration);
         asyncResultHandler.handle(Future.succeededFuture(GetEholdingsConfigurationResponse.respond200WithApplicationVndApiJson(configuration)));
       })
-      .exceptionally(throwable -> {
-        asyncResultHandler.handle(Future.failedFuture(throwable));
+      .exceptionally(e -> {
+        logger.error("Failed to get configuration", e);
+        asyncResultHandler.handle(Future.failedFuture(e));
         return null;
       });
   }

--- a/src/main/java/org/folio/rest/impl/EholdingsConfigurationImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsConfigurationImpl.java
@@ -51,7 +51,7 @@ public class EholdingsConfigurationImpl implements EholdingsConfiguration {
       })
       .exceptionally(e -> {
         logger.error("Failed to get configuration", e);
-        asyncResultHandler.handle(Future.failedFuture(e));
+        asyncResultHandler.handle(Future.succeededFuture(GetEholdingsConfigurationResponse.respond500WithTextPlain("Internal Server Error")));
         return null;
       });
   }

--- a/src/main/java/org/folio/rest/impl/EholdingsConfigurationImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsConfigurationImpl.java
@@ -1,0 +1,58 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import org.folio.config.RMAPIConfigurationClient;
+import org.folio.http.ConfigurationClientProvider;
+import org.folio.rest.converter.RMAPIConfigurationConverter;
+import org.folio.rest.jaxrs.model.EholdingsConfigurationPutApplicationVndApiJson;
+import org.folio.rest.jaxrs.model.EholdingsConfigurationPutApplicationVndApiJsonImpl;
+import org.folio.rest.jaxrs.resource.EholdingsConfiguration;
+import org.folio.rest.util.HeaderConstants;
+import org.folio.rest.validator.HeaderValidator;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+public class EholdingsConfigurationImpl implements EholdingsConfiguration {
+
+  private RMAPIConfigurationClient configurationClient;
+  private RMAPIConfigurationConverter converter;
+  private HeaderValidator headerValidator;
+
+  public EholdingsConfigurationImpl() {
+    this(new RMAPIConfigurationClient(new ConfigurationClientProvider()), new RMAPIConfigurationConverter(), new HeaderValidator());
+  }
+
+  public EholdingsConfigurationImpl(RMAPIConfigurationClient configurationClient, RMAPIConfigurationConverter converter, HeaderValidator headerValidator) {
+    this.configurationClient = configurationClient;
+    this.converter = converter;
+    this.headerValidator = headerValidator;
+  }
+
+  @Override
+  public void getEholdingsConfiguration(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    if (!headerValidator.validate(okapiHeaders, asyncResultHandler)) {
+      return;
+    }
+    configurationClient.retrieveConfiguration(
+      okapiHeaders.get(HeaderConstants.OKAPI_TOKEN_HEADER),
+      okapiHeaders.get(HeaderConstants.OKAPI_TENANT_HEADER),
+      okapiHeaders.get(HeaderConstants.OKAPI_URL_HEADER))
+      .thenAccept(rmAPIconfiguration -> {
+        EholdingsConfigurationPutApplicationVndApiJsonImpl configuration = converter.convert(rmAPIconfiguration);
+        asyncResultHandler.handle(Future.succeededFuture(GetEholdingsConfigurationResponse.respond200WithApplicationVndApiJson(configuration)));
+      })
+      .exceptionally(throwable -> {
+        asyncResultHandler.handle(Future.failedFuture(throwable));
+        return null;
+      });
+  }
+
+  @Override
+  public void putEholdingsConfiguration(String contentType, EholdingsConfigurationPutApplicationVndApiJson entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.succeededFuture(PutEholdingsConfigurationResponse.status(Response.Status.NOT_IMPLEMENTED).build()));
+  }
+}

--- a/src/main/java/org/folio/rest/util/HeaderConstants.java
+++ b/src/main/java/org/folio/rest/util/HeaderConstants.java
@@ -1,0 +1,9 @@
+package org.folio.rest.util;
+
+public final class HeaderConstants {
+  public static final String OKAPI_TOKEN_HEADER = "x-okapi-token";
+  public static final String OKAPI_URL_HEADER = "x-okapi-url";
+  public static final String OKAPI_TENANT_HEADER = "x-okapi-tenant";
+
+  private HeaderConstants(){ }
+}

--- a/src/main/java/org/folio/rest/validator/HeaderValidator.java
+++ b/src/main/java/org/folio/rest/validator/HeaderValidator.java
@@ -23,7 +23,7 @@ public class HeaderValidator {
 
   /**
    * @param okapiHeaders request headers
-   * @param asyncResultHandler handler that will be called with error response if headers are invalid invalid
+   * @param asyncResultHandler handler that will be called with error response if headers are invalid
    * @return true if request is valid
    */
   public boolean validate(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler) {

--- a/src/main/java/org/folio/rest/validator/HeaderValidator.java
+++ b/src/main/java/org/folio/rest/validator/HeaderValidator.java
@@ -1,0 +1,42 @@
+package org.folio.rest.validator;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import org.folio.rest.jaxrs.resource.EholdingsConfiguration;
+import org.folio.rest.util.HeaderConstants;
+
+import javax.ws.rs.core.Response;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Verifies that headers are valid
+ */
+public class HeaderValidator {
+
+  private final Collection<String> expectedHeaders = Arrays.asList(
+    HeaderConstants.OKAPI_TOKEN_HEADER,
+    HeaderConstants.OKAPI_URL_HEADER,
+    HeaderConstants.OKAPI_TENANT_HEADER);
+
+  /**
+   * @param okapiHeaders request headers
+   * @param asyncResultHandler handler that will be called with error response if headers are invalid invalid
+   * @return true if request is valid
+   */
+  public boolean validate(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler) {
+    for (String header : expectedHeaders) {
+      if (!okapiHeaders.containsKey(header)) {
+        asyncResultHandler.handle(Future.succeededFuture(
+          EholdingsConfiguration.GetEholdingsConfigurationResponse
+            .status(400)
+            .entity("Missing header " + header)
+            .build()));
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/main/java/org/folio/rest/validator/HeaderValidator.java
+++ b/src/main/java/org/folio/rest/validator/HeaderValidator.java
@@ -17,9 +17,8 @@ import java.util.Map;
 public class HeaderValidator {
 
   private final Collection<String> expectedHeaders = Arrays.asList(
-    HeaderConstants.OKAPI_TOKEN_HEADER,
-    HeaderConstants.OKAPI_URL_HEADER,
-    HeaderConstants.OKAPI_TENANT_HEADER);
+    HeaderConstants.OKAPI_URL_HEADER
+  );
 
   /**
    * @param okapiHeaders request headers

--- a/src/test/java/org/folio/config/RMAPIConfigurationClientTest.java
+++ b/src/test/java/org/folio/config/RMAPIConfigurationClientTest.java
@@ -1,0 +1,47 @@
+package org.folio.config;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.impl.HttpClientResponseImpl;
+import org.folio.http.ConfigurationClientProvider;
+import org.folio.rest.client.ConfigurationsClient;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RMAPIConfigurationClientTest {
+  private ConfigurationClientProvider configurationClientProvider = mock(ConfigurationClientProvider.class);
+  private ConfigurationsClient mockHttpClient = mock(ConfigurationsClient.class);
+  private RMAPIConfigurationClient configurationClient = new RMAPIConfigurationClient(configurationClientProvider);
+
+  @Test
+  public void shouldCompleteExceptionallyWhenRequestFails() throws Exception {
+    HttpClientResponse response = mock(HttpClientResponseImpl.class);
+    when(response.statusCode()).thenReturn(400);
+    when(configurationClientProvider.createClient(anyString(), anyInt(), anyString(), anyString())).thenReturn(mockHttpClient);
+    doAnswer(invocation -> {
+      ((Handler<HttpClientResponse>) invocation.getArgument(4)).handle(response);
+      return null;
+    }).when(mockHttpClient).getEntries(anyString(), anyInt(), anyInt(), any(), any(), any());
+    CompletableFuture<RMAPIConfiguration> future = configurationClient.retrieveConfiguration("token", "tenant", "url");
+    assertTrue(future.isCompletedExceptionally());
+  }
+
+  @Test
+  public void shouldCompleteExceptionallyWhenHttpClientThrowsException() throws Exception {
+    when(configurationClientProvider.createClient(anyString(), anyInt(), anyString(), anyString())).thenReturn(mockHttpClient);
+    doThrow(new UnsupportedEncodingException()).when(mockHttpClient).getEntries(anyString(), anyInt(), anyInt(), any(), any(), any());
+    CompletableFuture<RMAPIConfiguration> future = configurationClient.retrieveConfiguration("token", "tenant", "url");
+    assertTrue(future.isCompletedExceptionally());
+  }
+}

--- a/src/test/java/org/folio/rest/impl/EholdingsConfigurationTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsConfigurationTest.java
@@ -91,6 +91,26 @@ public class EholdingsConfigurationTest {
   }
 
   @Test
+  public void shouldReturn500IfConfigurationIsInvalid() {
+    WireMock.stubFor(
+      WireMock.get(new UrlPathPattern(new AnythingPattern(), false))
+        .withHeader(TENANT_HEADER.getName(), new EqualToPattern(TENANT_HEADER.getValue()))
+        .withHeader(TOKEN_HEADER.getName(), new EqualToPattern(TOKEN_HEADER.getValue()))
+        .willReturn(new ResponseDefinitionBuilder()
+          .withBody("{}")));
+
+    RestAssured.given()
+      .spec(spec).port(port)
+      .header(new Header(HeaderConstants.OKAPI_URL_HEADER, host + ":" + userMockServer.port()))
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .when()
+      .get("eholdings/configuration")
+      .then()
+      .statusCode(500);
+  }
+
+  @Test
   public void shouldReturn400OnGetWithoutUrlHeader() throws IOException, URISyntaxException {
     RestAssured.given()
       .spec(spec).port(port)

--- a/src/test/java/org/folio/rest/impl/EholdingsConfigurationTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsConfigurationTest.java
@@ -1,0 +1,133 @@
+package org.folio.rest.impl;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.matching.AnythingPattern;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+import com.google.common.io.Files;
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.Header;
+import io.restassured.specification.RequestSpecification;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.rest.util.HeaderConstants;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.Matchers.equalTo;
+
+@RunWith(VertxUnitRunner.class)
+public class EholdingsConfigurationTest {
+  private static final Header TENANT_HEADER = new Header(HeaderConstants.OKAPI_TENANT_HEADER, "fs");
+  private static final Header TOKEN_HEADER = new Header(HeaderConstants.OKAPI_TOKEN_HEADER, "TEST_OKAPI_TOKEN");
+
+  private static RequestSpecification spec;
+  private static int port;
+  private static String host;
+
+  @org.junit.Rule
+  public WireMockRule userMockServer = new WireMockRule(
+    WireMockConfiguration.wireMockConfig()
+      .dynamicPort()
+      .notifier(new ConsoleNotifier(true)));
+
+  @BeforeClass
+  public static void setUpClass(final TestContext context) throws Exception {
+    Vertx vertx = Vertx.vertx();
+    vertx.exceptionHandler(context.exceptionHandler());
+    port = NetworkUtils.nextFreePort();
+    host = "http://localhost";
+
+    DeploymentOptions restVerticleDeploymentOptions = new DeploymentOptions().setConfig(new JsonObject().put("http.port", port));
+    vertx.deployVerticle(RestVerticle.class.getName(), restVerticleDeploymentOptions, context.asyncAssertSuccess());
+
+    spec = new RequestSpecBuilder()
+      .setBaseUri(host + ":" + port)
+      .build();
+  }
+
+  @Test
+  public void shouldReturnConfigurationOnGet() throws IOException, URISyntaxException {
+    String stubResponseFilename = "responses/get-configuration.json";
+    String stubCustomerId = "TEST_CUSTOMER_ID";
+    String stubUrl = "https://api.ebsco.io";
+    String expectedMaskedApiKey = "****************************************";
+
+    WireMock.stubFor(
+      WireMock.get(new UrlPathPattern(new AnythingPattern(), false))
+        .withHeader(TENANT_HEADER.getName(), new EqualToPattern(TENANT_HEADER.getValue()))
+        .withHeader(TOKEN_HEADER.getName(), new EqualToPattern(TOKEN_HEADER.getValue()))
+        .willReturn(new ResponseDefinitionBuilder()
+          .withBody(readFile(stubResponseFilename))));
+
+    RestAssured.given()
+      .spec(spec).port(port)
+      .header(new Header(HeaderConstants.OKAPI_URL_HEADER, host + ":" + userMockServer.port()))
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .when()
+      .get("eholdings/configuration")
+      .then()
+      .statusCode(200)
+      .body("data.attributes.customerId", equalTo(stubCustomerId))
+      .body("data.attributes.apiKey", equalTo(expectedMaskedApiKey))
+      .body("data.attributes.rmapiBaseUrl", equalTo(stubUrl));
+  }
+
+  @Test
+  public void shouldReturn400OnGetWithoutUrlHeader() throws IOException, URISyntaxException {
+    RestAssured.given()
+      .spec(spec).port(port)
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .when()
+      .get("eholdings/configuration")
+      .then()
+      .statusCode(400);
+  }
+
+  @Test
+  public void shouldReturn400OnGetWithoutTenant() throws IOException, URISyntaxException {
+    RestAssured.given()
+      .spec(spec).port(port)
+      .header(new Header(HeaderConstants.OKAPI_URL_HEADER, host + ":" + userMockServer.port()))
+      .header(TOKEN_HEADER)
+      .when()
+      .get("eholdings/configuration")
+      .then()
+      .statusCode(400);
+  }
+
+  @Test
+  public void shouldReturn400OnGetWithoutToken() throws IOException, URISyntaxException {
+    RestAssured.given()
+      .spec(spec).port(port)
+      .header(new Header(HeaderConstants.OKAPI_URL_HEADER, host + ":" + userMockServer.port()))
+      .header(TENANT_HEADER)
+      .when()
+      .get("eholdings/configuration")
+      .then()
+      .statusCode(400);
+  }
+
+  private String readFile(String filename) throws IOException, URISyntaxException {
+    return Files.toString(new File(this.getClass().getClassLoader()
+      .getResource(filename).toURI()), StandardCharsets.UTF_8);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/EholdingsConfigurationTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsConfigurationTest.java
@@ -48,7 +48,7 @@ public class EholdingsConfigurationTest {
       .notifier(new ConsoleNotifier(true)));
 
   @BeforeClass
-  public static void setUpClass(final TestContext context) throws Exception {
+  public static void setUpClass(final TestContext context) {
     Vertx vertx = Vertx.vertx();
     vertx.exceptionHandler(context.exceptionHandler());
     port = NetworkUtils.nextFreePort();
@@ -111,35 +111,11 @@ public class EholdingsConfigurationTest {
   }
 
   @Test
-  public void shouldReturn400OnGetWithoutUrlHeader() throws IOException, URISyntaxException {
+  public void shouldReturn400OnGetWithoutUrlHeader() {
     RestAssured.given()
       .spec(spec).port(port)
       .header(TENANT_HEADER)
       .header(TOKEN_HEADER)
-      .when()
-      .get("eholdings/configuration")
-      .then()
-      .statusCode(400);
-  }
-
-  @Test
-  public void shouldReturn400OnGetWithoutTenant() throws IOException, URISyntaxException {
-    RestAssured.given()
-      .spec(spec).port(port)
-      .header(new Header(HeaderConstants.OKAPI_URL_HEADER, host + ":" + userMockServer.port()))
-      .header(TOKEN_HEADER)
-      .when()
-      .get("eholdings/configuration")
-      .then()
-      .statusCode(400);
-  }
-
-  @Test
-  public void shouldReturn400OnGetWithoutToken() throws IOException, URISyntaxException {
-    RestAssured.given()
-      .spec(spec).port(port)
-      .header(new Header(HeaderConstants.OKAPI_URL_HEADER, host + ":" + userMockServer.port()))
-      .header(TENANT_HEADER)
       .when()
       .get("eholdings/configuration")
       .then()

--- a/src/test/resources/responses/get-configuration.json
+++ b/src/test/resources/responses/get-configuration.json
@@ -1,0 +1,50 @@
+{
+  "configs" : [ {
+    "id" : "efadf3d8-59c3-4508-99d4-3e36e9247d87",
+    "module" : "EKB",
+    "configName" : "api_access",
+    "code" : "kb.ebsco.url",
+    "description" : "EBSCO RM-API URL",
+    "enabled" : true,
+    "value" : "https://api.ebsco.io",
+    "metadata" : {
+      "createdDate" : "2018-09-12T12:34:52.189+0000",
+      "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+      "updatedDate" : "2018-09-12T12:34:52.189+0000",
+      "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+    }
+  }, {
+    "id" : "6b24b703-243a-4261-a7bf-0336d34f8c94",
+    "module" : "EKB",
+    "configName" : "api_access",
+    "code" : "kb.ebsco.customerId",
+    "description" : "EBSCO RM-API Customer ID",
+    "enabled" : true,
+    "value" : "TEST_CUSTOMER_ID",
+    "metadata" : {
+      "createdDate" : "2018-09-12T12:34:52.466+0000",
+      "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+      "updatedDate" : "2018-09-12T12:34:52.466+0000",
+      "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+    }
+  }, {
+    "id" : "8038c4f3-0b09-4d97-be46-8a5236ef3f2f",
+    "module" : "EKB",
+    "configName" : "api_access",
+    "code" : "kb.ebsco.apiKey",
+    "description" : "EBSCO RM-API API Key",
+    "enabled" : true,
+    "value" : "TEST_API_KEY",
+    "metadata" : {
+      "createdDate" : "2018-09-12T12:34:52.788+0000",
+      "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+      "updatedDate" : "2018-09-12T12:34:52.788+0000",
+      "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+    }
+  } ],
+  "totalRecords" : 3,
+  "resultInfo" : {
+    "totalRecords" : 3,
+    "facets" : [ ]
+  }
+}


### PR DESCRIPTION
## Purpose
Implement GET /eholdings/configuration endpoint

## Approach
Used ruby mod-kb-ebsco as reference.
Adapted RMAPIConfiguration class from mod-codex-ekb module to get configuration from RMAPI.
Used Wiremock to implement tests simlar to tests from ruby module.

#### TODOS and Open Questions
* We need to wait until [initial module setup PR](https://github.com/folio-org/mod-kb-ebsco-java/pull/12 ) is merged, before merging this PR. 
This PR is only for commit https://github.com/folio-org/mod-kb-ebsco-java/pull/13/commits/a5d661fd279d27b474bc5733f67366481bf021b8

* Ruby module returns several field that seem to be specific to jsonapi:
Response from ruby module
```json
{
    "data": {
        "id": "configuration",
        "type": "configurations",
        "attributes": {
            "customerId": "apidvcorp",
            "apiKey": "****************************************",
            "rmapiBaseUrl": "https://api.ebsco.io"
        }
    },
    "jsonapi": {
        "version": "1.0"
    }
}
```
Current response from java implementation
```json
{
    "data": {
        "type": "configurations",
        "attributes": {
            "customerId": "apidvcorp",
            "apiKey": "****************************************",
            "rmapiBaseUrl": "https://api.ebsco.io"
        }
    }
}
```
Ruby module has "id": "configuration", and   "jsonapi": { "version": "1.0" }.
Those fields are not part of RAML definition, so I am not sure if we need to return them from java module.