### PR TITLE
Update pom.xml to use latest version of io.vertx 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
   <properties>
     <raml-module-builder.version>21.0.4</raml-module-builder.version>
-    <vertx.version>3.5.3</vertx.version>
+    <vertx.version>3.5.4</vertx.version>
     <junit.version>4.12</junit.version>
     <aspectj.version>1.9.1</aspectj.version>
     <rest-assured.version>3.1.1</rest-assured.version>


### PR DESCRIPTION
## Purpose
Received alerts through GitHub about a potential security vulnerability in our code repository in the version of io.vertx:vertx-core and io-vertx:vertx-web. 

## Approach
Upgrade version as suggested to 3.5.4