### PR TITLE
Update pom.xml to use latest jackson-databind version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.7.3</version>
+      <version>2.8.11.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>


### PR DESCRIPTION
Purpose
GitHub alert about a potential security vulnerability in our code repository in the version of com.fasterxml.jackson.core:jackson-databind.

Approach
Upgrade pom.xml with version 2.8.11.1
![image](https://user-images.githubusercontent.com/37537790/47147088-1e6b8f80-d2d6-11e8-8505-9afe512bda38.png)

