### PR TITLE
replace token's helpText with simple value to resolve invalid unicode character issue

### DIFF
--- a/ramls/types/token.json
+++ b/ramls/types/token.json
@@ -19,7 +19,7 @@
     "helpText": {
       "type": "string",
       "description": "Help text",
-      "example": "\u003cul\u003e\r\n    \u003cli\u003eEnter your Gale\u003csup\u003e®\u003c/sup\u003e site ID in the space provided below. The site ID may contain a combination of alpha/numeric characters, varying in length. \u003cblockquote style=\"margin-right: 0px;\" dir=\"ltr\"\u003e\r\n    \u003cp\u003e Example: The site ID immediately follows /itweb/ in a URL. The site ID in the following URL is \u003ci\u003eaa11bb22\u003c/i\u003e. \u003c/p\u003e\r\n    \u003c/blockquote\u003e\u003c/li\u003e\r\n\u003c/ul\u003e\r\n\u003cblockquote style=\"margin-right: 0px;\" dir=\"ltr\"\u003e\u003cblockquote style=\"margin-right: 0px;\" dir=\"ltr\"\u003e\r\n\u003cp\u003e\u003cspan style=\"text-decoration: underline;\"\u003ehttp://infotrac.galegroup.com/itweb/aa11bb22?db=AIM\u003c/span\u003e\u003c/p\u003e\r\n\u003c/blockquote\u003e\u003c/blockquote\u003e\u003cbr /\u003e\r\n\u003cul\u003e\r\n    \u003cli\u003eIf no site ID is specified, your Gale Group links may not function properly, as Gale Group requires this information for authentication. \u003c/li\u003e\r\n    \u003cli\u003eIf you are unable to locate the site ID, please contact Gale Group. For contact information, visit: \u003ca href=\"http://access.gale.com/authentication/\"\u003ehttp://access.gale.com/authentication/\u003c/a\u003e. \u003c/li\u003e\r\n\u003c/ul\u003e\r\n"
+      "example": "What is token and how to use it"
     },
     "value": {
       "type": "string",


### PR DESCRIPTION
## Purpose
There is an issue with invalid unicode character contained inside token's helpText. The problem can only be observed on win machine, mac/linux doesn't have one.

## Approach
Replace token's helpText with simple value
