### PR TITLE
MODKBEKBJ-19 - Implement GET /eholdings/providers/{provider_id}

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -32,11 +32,13 @@
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/eholdings/providers"
+          "pathPattern": "/eholdings/providers",
+          "permissionsRequired": ["kb-ebsco.providerCollection.get"]
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/eholdings/providers/{providerId}"
+          "pathPattern": "/eholdings/providers/{providerId}",
+          "permissionsRequired" :["kb-ebsco.provider.get"]
         },
         {
           "methods": ["PUT"],
@@ -125,6 +127,11 @@
       "description": "Get providers"
     },
     {
+      "permissionName": "kb-ebsco.provider.get",
+      "displayName": "get single provider",
+      "description": "Get single provider"
+    },
+    {
       "permissionName": "kb-ebsco.all",
       "displayName": "EBSCO KB Broker - all permissions",
       "description": "All permissions for EBSCO KB module",
@@ -132,7 +139,8 @@
         "kb-ebsco.configuration.get",
         "kb-ebsco.configuration.put",
         "kb-ebsco.status.get",
-        "kb-ebsco.providerCollection.get"
+        "kb-ebsco.providerCollection.get",
+        "kb-ebsco.provider.get"
       ]
     }
   ],

--- a/src/main/java/org/folio/rest/converter/VendorConverter.java
+++ b/src/main/java/org/folio/rest/converter/VendorConverter.java
@@ -1,15 +1,10 @@
 package org.folio.rest.converter;
 
-import org.folio.rest.jaxrs.model.MetaDataIncluded;
-import org.folio.rest.jaxrs.model.MetaTotalResults;
-import org.folio.rest.jaxrs.model.Packages;
-import org.folio.rest.jaxrs.model.ProviderCollection;
-import org.folio.rest.jaxrs.model.ProviderListDataAttributes;
-import org.folio.rest.jaxrs.model.Providers;
-import org.folio.rest.jaxrs.model.Relationships;
-import org.folio.rest.jaxrs.model.Token;
+import org.folio.rest.jaxrs.model.*;
 import org.folio.rest.util.RestConstants;
 import org.folio.rmapi.model.Vendor;
+import org.folio.rmapi.model.VendorById;
+import org.folio.rmapi.model.VendorToken;
 import org.folio.rmapi.model.Vendors;
 
 import java.util.List;
@@ -18,9 +13,11 @@ import java.util.stream.Collectors;
 public class VendorConverter {
 
   private static final Relationships EMPTY_PACKAGE_RELATIONSHIP = new Relationships()
-    .withPackages(new Packages().withMeta(
-      new MetaDataIncluded()
-            .withIncluded(false)));
+    .withPackages(new Packages()
+      .withMeta(new MetaDataIncluded()
+        .withIncluded(false))
+      .withData(null));
+  private final String PROVIDERS_TYPE = "providers";
 
   public ProviderCollection convert(Vendors vendors) {
     List<Providers> providerList = vendors.getVendorList().stream()
@@ -33,16 +30,45 @@ public class VendorConverter {
   }
 
   private Providers convertVendor(Vendor vendor) {
-    String token = vendor.getVendorToken();
+    VendorToken token = vendor.getVendorToken();
     return new Providers()
       .withId(String.valueOf(vendor.getVendorId()))
-      .withType("providers")
+      .withType(PROVIDERS_TYPE)
       .withAttributes(new ProviderListDataAttributes()
         .withName(vendor.getVendorName())
         .withPackagesTotal(vendor.getPackagesTotal())
         .withPackagesSelected(vendor.getPackagesSelected())
         .withSupportsCustomPackages(vendor.isCustomer())
-        .withProviderToken(token != null ? new Token().withValue(token) : null))
+        .withProviderToken(token != null ? new Token().withValue((String) token.getValue()) : null))
       .withRelationships(EMPTY_PACKAGE_RELATIONSHIP);
+  }
+
+  public Provider convertToVendor(VendorById vendor) {
+    VendorToken vendorToken = vendor.getVendorToken();
+    return new Provider()
+      .withData(new ProviderData()
+        .withId(String.valueOf(vendor.getVendorId()))
+        .withType(PROVIDERS_TYPE)
+        .withAttributes(new ProviderDataAttributes()
+          .withName(vendor.getVendorName())
+          .withPackagesTotal(vendor.getPackagesTotal())
+          .withPackagesSelected(vendor.getPackagesSelected())
+          .withSupportsCustomPackages(vendor.isCustomer())
+          .withProviderToken(vendorToken != null ? convertToken(vendorToken) : null)
+          .withProxy(new Proxy()
+            .withId(vendor.getProxy().getId())
+            .withInherited(vendor.getProxy().getInherited()))
+        )
+        .withRelationships(EMPTY_PACKAGE_RELATIONSHIP))
+      .withIncluded(null)
+      .withJsonapi(RestConstants.JSONAPI);
+  }
+
+  private Token convertToken(VendorToken vendorToken) {
+    return new Token()
+      .withFactName(vendorToken.getFactName())
+      .withHelpText(vendorToken.getHelpText())
+      .withPrompt(vendorToken.getPrompt())
+      .withValue(vendorToken.getValue() == null ? null : (String) vendorToken.getValue());
   }
 }

--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -12,6 +12,8 @@ import org.folio.rmapi.exception.RMAPIResourceNotFoundException;
 import org.folio.rmapi.exception.RMAPIResultsProcessingException;
 import org.folio.rmapi.exception.RMAPIServiceException;
 import org.folio.rmapi.exception.RMAPIUnAuthorizedException;
+import org.folio.rmapi.model.Vendor;
+import org.folio.rmapi.model.VendorById;
 import org.folio.rmapi.model.Vendors;
 
 import java.util.concurrent.CompletableFuture;
@@ -108,6 +110,14 @@ public class RMAPIService {
         .sort(sort)
         .build();
     return this.getRequest(constructURL(path), Vendors.class);
+  }
+
+    public CompletableFuture<VendorById> retrieveProvider(String id, String include) {
+
+    final String path = "vendors/" + id;
+//    TODO: add support of include parameter when MODKBEKBJ-22 is completed
+
+    return this.getRequest(constructURL(path), VendorById.class);
   }
 
   /**

--- a/src/main/java/org/folio/rmapi/model/Proxy.java
+++ b/src/main/java/org/folio/rmapi/model/Proxy.java
@@ -1,0 +1,29 @@
+package org.folio.rmapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Proxy {
+
+  @JsonProperty("id")
+  private String id;
+  @JsonProperty("inherited")
+  private Boolean inherited;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public Boolean getInherited() {
+    return inherited;
+  }
+
+  public void setInherited(Boolean inherited) {
+    this.inherited = inherited;
+  }
+}

--- a/src/main/java/org/folio/rmapi/model/Vendor.java
+++ b/src/main/java/org/folio/rmapi/model/Vendor.java
@@ -16,7 +16,7 @@ public class Vendor {
   @JsonProperty("isCustomer")
   private boolean isCustomer;
   @JsonProperty("vendorToken")
-  private String vendorToken;
+  private VendorToken vendorToken;
 
   public int getVendorId() {
     return vendorId;
@@ -58,11 +58,11 @@ public class Vendor {
     isCustomer = customer;
   }
 
-  public String getVendorToken() {
+  public VendorToken getVendorToken() {
     return vendorToken;
   }
 
-  public void setVendorToken(String vendorToken) {
+  public void setVendorToken(VendorToken vendorToken) {
     this.vendorToken = vendorToken;
   }
 }

--- a/src/main/java/org/folio/rmapi/model/VendorById.java
+++ b/src/main/java/org/folio/rmapi/model/VendorById.java
@@ -1,0 +1,19 @@
+package org.folio.rmapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VendorById extends Vendor {
+
+  @JsonProperty("proxy")
+  private Proxy proxy;
+
+  public Proxy getProxy() {
+    return proxy;
+  }
+
+  public void setProxy(Proxy proxy) {
+    this.proxy = proxy;
+  }
+}

--- a/src/main/java/org/folio/rmapi/model/VendorToken.java
+++ b/src/main/java/org/folio/rmapi/model/VendorToken.java
@@ -1,0 +1,55 @@
+package org.folio.rmapi.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class VendorToken {
+
+  @JsonProperty("factName")
+  private String factName;
+  @JsonProperty("prompt")
+  private String prompt;
+  @JsonProperty("helpText")
+  private String helpText;
+  @JsonProperty("value")
+  private Object value;
+
+  @JsonProperty("factName")
+  public String getFactName() {
+    return factName;
+  }
+
+  @JsonProperty("factName")
+  public void setFactName(String factName) {
+    this.factName = factName;
+  }
+
+  @JsonProperty("prompt")
+  public String getPrompt() {
+    return prompt;
+  }
+
+  @JsonProperty("prompt")
+  public void setPrompt(String prompt) {
+    this.prompt = prompt;
+  }
+
+  @JsonProperty("helpText")
+  public String getHelpText() {
+    return helpText;
+  }
+
+  @JsonProperty("helpText")
+  public void setHelpText(String helpText) {
+    this.helpText = helpText;
+  }
+
+  @JsonProperty("value")
+  public Object getValue() {
+    return value;
+  }
+
+  @JsonProperty("value")
+  public void setValue(Object value) {
+    this.value = value;
+  }
+}

--- a/src/test/java/org/folio/util/TestUtil.java
+++ b/src/test/java/org/folio/util/TestUtil.java
@@ -6,7 +6,10 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 import com.google.common.io.Files;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.filter.log.LogDetail;
 import org.folio.rest.jaxrs.model.Configs;
+import org.folio.rest.util.RestConstants;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,5 +51,19 @@ public final class TestUtil {
       WireMock.get(new UrlPathPattern(new EqualToPattern("/configurations/entries"), false))
         .willReturn(new ResponseDefinitionBuilder()
           .withBody(mapper.writeValueAsString(configurations))));
+  }
+
+  /**
+   * Creates request specification with predefined common headers
+   *
+   * @param uri base uri
+   * @return {@link RequestSpecBuilder}
+   */
+  public static RequestSpecBuilder getRequestSpecificationBuilder(String uri) {
+    return new RequestSpecBuilder()
+      .addHeader(RestConstants.OKAPI_TENANT_HEADER, "fs")
+      .addHeader(RestConstants.OKAPI_TOKEN_HEADER, "TEST_OKAPI_TOKEN")
+      .setBaseUri(uri)
+      .log(LogDetail.ALL);
   }
 }

--- a/src/test/resources/responses/rmapi/vendors/get-vendor-by-id-response.json
+++ b/src/test/resources/responses/rmapi/vendors/get-vendor-by-id-response.json
@@ -1,0 +1,12 @@
+{
+  "isCustomer": false,
+  "packagesSelected": 11,
+  "packagesTotal": 625,
+  "vendorId": 19,
+  "vendorName": "EBSCO",
+  "proxy": {
+    "id": "<n>",
+    "inherited": true
+  },
+  "vendorToken": null
+}

--- a/src/test/resources/responses/rmapi/vendors/get-vendors-response.json
+++ b/src/test/resources/responses/rmapi/vendors/get-vendors-response.json
@@ -7,7 +7,12 @@
       "isCustomer": false,
       "packagesTotal": 1,
       "packagesSelected": 0,
-      "vendorToken": "sampleToken"
+      "vendorToken": {
+        "factName": null,
+        "prompt": null,
+        "helpText": null,
+        "value":"sampleToken"
+      }
     },
     {
       "vendorId": 66221,


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-19 we want to have the ability to get provider by id by supporting '/eholdings/providers/{provider_id}' endpoint

## Approach
_How does this change fulfill the purpose?_
 * Implement get providers by id method.
* Map vendor returned from RM API to a single Provider
* Add permissions to the request

#### TODOS and Open Questions
- [ ] update the code to support parameter '?include=packages' after packages story is done.

