### PR TITLE
MODKBEKBJ-50 - Verify configuration setup

### DIFF
--- a/src/main/java/org/folio/config/RMAPIConfigurationServiceCache.java
+++ b/src/main/java/org/folio/config/RMAPIConfigurationServiceCache.java
@@ -44,8 +44,6 @@ public class RMAPIConfigurationServiceCache implements RMAPIConfigurationService
   public CompletableFuture<Boolean> verifyCredentials(RMAPIConfiguration rmapiConfiguration, Context vertxContext) {
     if(rmapiConfiguration.getConfigValid() != null){
       return CompletableFuture.completedFuture(rmapiConfiguration.getConfigValid());
-    } else if(isConfigurationParametersInvalid(rmapiConfiguration)){
-      return CompletableFuture.completedFuture(false);
     }
     return rmapiConfigurationService.verifyCredentials(rmapiConfiguration, vertxContext)
       .thenCompose(isValid -> {
@@ -54,8 +52,4 @@ public class RMAPIConfigurationServiceCache implements RMAPIConfigurationService
       });
   }
 
-  private boolean isConfigurationParametersInvalid(RMAPIConfiguration rmapiConfiguration) {
-    return rmapiConfiguration.getUrl() == null || rmapiConfiguration.getAPIKey() == null
-      || rmapiConfiguration.getCustomerId() == null;
-  }
 }

--- a/src/main/java/org/folio/config/RMAPIConfigurationServiceCache.java
+++ b/src/main/java/org/folio/config/RMAPIConfigurationServiceCache.java
@@ -1,11 +1,10 @@
 package org.folio.config;
 
 import io.vertx.core.Context;
+import java.util.concurrent.CompletableFuture;
 import org.folio.config.api.RMAPIConfigurationService;
 import org.folio.config.cache.RMAPIConfigurationCache;
 import org.folio.rest.model.OkapiData;
-
-import java.util.concurrent.CompletableFuture;
 
 public class RMAPIConfigurationServiceCache implements RMAPIConfigurationService {
 
@@ -45,11 +44,18 @@ public class RMAPIConfigurationServiceCache implements RMAPIConfigurationService
   public CompletableFuture<Boolean> verifyCredentials(RMAPIConfiguration rmapiConfiguration, Context vertxContext) {
     if(rmapiConfiguration.getConfigValid() != null){
       return CompletableFuture.completedFuture(rmapiConfiguration.getConfigValid());
+    } else if(isConfigurationParametersInvalid(rmapiConfiguration)){
+      return CompletableFuture.completedFuture(false);
     }
     return rmapiConfigurationService.verifyCredentials(rmapiConfiguration, vertxContext)
       .thenCompose(isValid -> {
         rmapiConfiguration.setConfigValid(isValid);
         return CompletableFuture.completedFuture(isValid);
       });
+  }
+
+  private boolean isConfigurationParametersInvalid(RMAPIConfiguration rmapiConfiguration) {
+    return rmapiConfiguration.getUrl() == null || rmapiConfiguration.getAPIKey() == null
+      || rmapiConfiguration.getCustomerId() == null;
   }
 }

--- a/src/main/java/org/folio/config/RMAPIConfigurationServiceImpl.java
+++ b/src/main/java/org/folio/config/RMAPIConfigurationServiceImpl.java
@@ -71,6 +71,9 @@ public class RMAPIConfigurationServiceImpl implements RMAPIConfigurationService 
 
   @Override
   public CompletableFuture<Boolean> verifyCredentials(RMAPIConfiguration rmapiConfiguration, Context vertxContext){
+    if(isConfigurationParametersInvalid(rmapiConfiguration)) {
+      return CompletableFuture.completedFuture(false);
+    }
     return new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
       rmapiConfiguration.getUrl(), vertxContext.owner())
       .verifyCredentials()
@@ -233,5 +236,10 @@ public class RMAPIConfigurationServiceImpl implements RMAPIConfigurationService 
       .withDescription(description)
       .withEnabled(true)
       .withValue(apiKey);
+  }
+
+  private boolean isConfigurationParametersInvalid(RMAPIConfiguration rmapiConfiguration) {
+    return rmapiConfiguration.getUrl() == null || rmapiConfiguration.getAPIKey() == null
+      || rmapiConfiguration.getCustomerId() == null;
   }
 }

--- a/src/main/java/org/folio/rest/converter/RMAPIConfigurationConverter.java
+++ b/src/main/java/org/folio/rest/converter/RMAPIConfigurationConverter.java
@@ -2,6 +2,7 @@ package org.folio.rest.converter;
 
 import org.apache.commons.lang3.StringUtils;
 import org.folio.config.RMAPIConfiguration;
+import org.folio.properties.PropertyConfiguration;
 import org.folio.rest.jaxrs.model.ConfigurationAttributes;
 import org.folio.rest.jaxrs.model.Configuration;
 import org.folio.rest.jaxrs.model.ConfigurationPutRequest;
@@ -12,7 +13,7 @@ import org.folio.rest.util.RestConstants;
  * Converts objects between REST API representation and internal representation
  */
 public class RMAPIConfigurationConverter {
-  private static final String DEFAULT_URL = "https://sandbox.ebsco.io";
+  private static final String DEFAULT_URL = PropertyConfiguration.getInstance().getConfiguration().getString("configuration.base.url.default");
 
   public Configuration convertToConfiguration(RMAPIConfiguration rmAPIConfig) {
     Configuration jsonConfig = new Configuration();
@@ -24,7 +25,9 @@ public class RMAPIConfigurationConverter {
       jsonConfig.getData().getAttributes().setApiKey(StringUtils.repeat("*", 40));
     }
     jsonConfig.getData().getAttributes().setCustomerId(rmAPIConfig.getCustomerId());
-    jsonConfig.getData().getAttributes().setRmapiBaseUrl(rmAPIConfig.getUrl());
+    String baseUrl = rmAPIConfig.getUrl();
+    baseUrl = baseUrl != null ? baseUrl : DEFAULT_URL;
+    jsonConfig.getData().getAttributes().setRmapiBaseUrl(baseUrl);
     jsonConfig.setJsonapi(RestConstants.JSONAPI);
     return jsonConfig;
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 configuration.cache.expire=120
+configuration.base.url.default=https://sandbox.ebsco.io

--- a/src/test/java/org/folio/rest/impl/EholdingsProvidersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsProvidersImplTest.java
@@ -165,7 +165,7 @@ public class EholdingsProvidersImplTest {
       .when()
       .get(providerByIdEndpoint)
       .then()
-      .statusCode(org.eclipse.jetty.http.HttpStatus.OK_200).extract().as(Provider.class);
+      .statusCode(HttpStatus.SC_OK).extract().as(Provider.class);
 
     compareProviders(provider, expected);
 

--- a/src/test/java/org/folio/util/TestUtil.java
+++ b/src/test/java/org/folio/util/TestUtil.java
@@ -45,7 +45,9 @@ public final class TestUtil {
   public static void mockConfiguration(String configurationsFile, String wiremockUrl) throws IOException, URISyntaxException {
     ObjectMapper mapper = new ObjectMapper();
     Configs configurations = mapper.readValue(TestUtil.getFile(configurationsFile), Configs.class);
-    configurations.getConfigs().get(0).setValue(wiremockUrl);
+    if (!configurations.getConfigs().isEmpty()) {
+      configurations.getConfigs().get(0).setValue(wiremockUrl);
+    }
 
     WireMock.stubFor(
       WireMock.get(new UrlPathPattern(new EqualToPattern("/configurations/entries"), false))

--- a/src/test/resources/responses/configuration/get-configuration-empty.json
+++ b/src/test/resources/responses/configuration/get-configuration-empty.json
@@ -1,0 +1,8 @@
+{
+  "configs" : [ ],
+  "totalRecords" : 0,
+  "resultInfo" : {
+    "totalRecords" : 0,
+    "facets" : [ ]
+  }
+}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-50 we need to change the behavior of backend validation if the configuration is not currently set up. 
For the situation when we do not have a configuration entity and perform 
`GET /status`
we recieve following response 
`Internal server error` with code 500
## Approach
Added additional check for RMAPI configuration parameters.
This check will prevent retriving configuration details if configuration credentials are empty.
In case we do not have configuration and and perform 
`GET /status`
we will recieve 
`{
   “data”: {
       “id”: “status”,
       “type”: “statuses”,
       “attributes”: {
           “isConfigurationValid”: false
       }
   },
   “jsonapi”: {
       “version”: “1.0”
   }
}`
with response code 200 
#### TODOS and Open Questions
- [ ] There is should be UI story for behavior investigation when backend returns  `  “isConfigurationValid”: false` because for the current moment seems UI does not provide option to set up configuration
<img width="1677" alt="screen shot 2018-11-06 at 5 34 46 pm" src="https://user-images.githubusercontent.com/37537790/48126745-a49e4480-e28a-11e8-8a77-fb142eecaad8.png">

## Learning
there is the issue with maven-surface-plugin, which brokes Jenkins build and already reported https://issues.folio.org/browse/FOLIO-1609 and https://issues.apache.org/jira/browse/SUREFIRE-1588
