### PR TITLE
MODKBEKBJ-35: Update error handling for titles endpoint

### DIFF
--- a/src/main/java/org/folio/rest/validator/TitleParametersValidator.java
+++ b/src/main/java/org/folio/rest/validator/TitleParametersValidator.java
@@ -1,6 +1,5 @@
 package org.folio.rest.validator;
 
-import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.model.Sort;
 
 import javax.validation.ValidationException;
@@ -25,9 +24,12 @@ public class TitleParametersValidator {
     if(nonNullFilters > 1){
       throw new ValidationException("Conflicting filter parameters");
     }
+    if(nonNullFilters < 1){
+      throw new ValidationException("All of filter[name], filter[isxn], filter[subject] and filter[publisher] cannot be missing.");
+    }
     if(searchParameters.stream()
       .anyMatch(""::equals)){
-      throw new ValidationException("Required parameter 'search' is missing.");
+      throw new ValidationException("Value of required parameter filter[name], filter[isxn], filter[subject] or filter[publisher] is missing.");
     }
     if ((Objects.nonNull(sort) && !Sort.contains(sort.toUpperCase()))){
       throw new ValidationException("Invalid sort parameter");

--- a/src/test/java/org/folio/rest/validator/TitleParametersValidatorTest.java
+++ b/src/test/java/org/folio/rest/validator/TitleParametersValidatorTest.java
@@ -31,10 +31,35 @@ public class TitleParametersValidatorTest {
     validator.validate("true", "book", "ebsco",
       null, "history", null, null);
   }
+  
+  /* One of filter[name], filter[isxn], filter[subject] or filter[publisher] is required */
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenAtLeastOneRequiredFilterParametersIsNotProvided() {
+    validator.validate("true", "book", null,
+      null, null, null, null);
+  }
 
   @Test(expected = ValidationException.class)
-  public void shouldThrowExceptionWhenSearchParameterIsEmpty() {
+  public void shouldThrowExceptionWhenFilterNameParameterIsEmpty() {
     validator.validate("true", "book", "",
       null, null, null, null);
+  }
+  
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenFilterIsxnParameterIsEmpty() {
+    validator.validate("true", "book", null,
+      "", null, null, null);
+  }
+  
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenFilterSubjectParameterIsEmpty() {
+    validator.validate("true", "book", null,
+      null, "", null, null);
+  }
+  
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenFilterPublisherParameterIsEmpty() {
+    validator.validate("true", "book", null,
+      null, null, "", null);
   }
 }


### PR DESCRIPTION
## Purpose
https://github.com/folio-org/mod-kb-ebsco-java/pull/27 addressed most of the implementation of /eholdings/titles endpoint. While testing the endpoint, identified a couple of errors which could be handled better. Before this PR, code was passing through error messages from RM API whose terminology differs from this module's for certain terms. This PR adds additional validation before passing the request to RM API and gives specific error messages in terms of consumers of this API.

## Approach
- Add a couple more validations of query params that can be added to this endpoint.
- Add specific error messages to be returned after validations.
- Add associated unit tests.

## Screenshots
*Before*
![titles_before](https://user-images.githubusercontent.com/33662516/48284629-f29f7d80-e42d-11e8-8b51-1325e3c3a241.gif)

*After*
![titles_after](https://user-images.githubusercontent.com/33662516/48284638-f92df500-e42d-11e8-8112-77282886f66b.gif)