### PR TITLE
MODKBEKBJ-54: Validate that providerId is a number

### DIFF
--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -132,7 +132,7 @@ public class RMAPIService {
     return this.getRequest(constructURL("titles?" + path), Titles.class);
   }
 
-    public CompletableFuture<VendorById> retrieveProvider(String id, String include) {
+    public CompletableFuture<VendorById> retrieveProvider(long id, String include) {
 
     final String path = "vendors/" + id;
 //    TODO: add support of include parameter when MODKBEKBJ-22 is completed

--- a/src/test/java/org/folio/rest/impl/EholdingsProvidersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsProvidersImplTest.java
@@ -193,14 +193,9 @@ public class EholdingsProvidersImplTest {
   }
 
   @Test
-  public void shouldReturn500WhenInvalidProviderId() throws IOException, URISyntaxException {
-
+  public void shouldReturn400WhenInvalidProviderId() throws IOException, URISyntaxException {
     String wiremockUrl = host + ":" + userMockServer.port();
     TestUtil.mockConfiguration(configurationStubFile, wiremockUrl);
-    WireMock.stubFor(
-      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors.*"), true))
-        .willReturn(new ResponseDefinitionBuilder()
-          .withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)));
 
     RequestSpecification  requestSpecification = getRequestSpecification();
     JsonapiError error = RestAssured.given()
@@ -208,7 +203,7 @@ public class EholdingsProvidersImplTest {
       .when()
       .get("eholdings/providers/19191919as")
       .then()
-      .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+      .statusCode(HttpStatus.SC_BAD_REQUEST)
       .extract().as(JsonapiError.class);
 
     assertThat(error.getErrors().get(0).getTitle(), notNullValue());


### PR DESCRIPTION
MODKBEKBJ-54

## Purpose
Add validation for providerId to make api tests pass

## Approach
Parse providerId before sending request to RM API

## Learning
It appears that "type: integer" is not supported for path parameters, so I had to parse providerId manually