### PR TITLE
MODKBEKBJ-35: Make relevance default sort option

### DIFF
--- a/ramls/traits/sortable.raml
+++ b/ramls/traits/sortable.raml
@@ -4,4 +4,5 @@ queryParameters:
     type: string
     description: Option by which results are sorted. Defaults to relevance if query or name if no query. Possible values are name, relevance.
     example : name
+    default: relevance
     required: false

--- a/src/main/java/org/folio/rest/impl/EholdingsProvidersImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsProvidersImpl.java
@@ -64,16 +64,15 @@ public class EholdingsProvidersImpl implements EholdingsProviders {
   @HandleValidationErrors
   public void getEholdingsProviders(String q, String sort, int page, int count, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     headerValidator.validate(okapiHeaders);
-    if(sort != null && !Sort.contains(sort.toUpperCase())){
+    if(!Sort.contains(sort.toUpperCase())){
       throw new ValidationException("Invalid sort parameter");
     }
-    Sort nameSort = sort != null ? Sort.valueOf(sort.toUpperCase()) : null;
     CompletableFuture.completedFuture(null)
     .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
     .thenCompose(rmapiConfiguration -> {
       RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
         rmapiConfiguration.getUrl(), vertxContext.owner());
-      return rmapiService.retrieveProviders(q, page, count, nameSort);
+      return rmapiService.retrieveProviders(q, page, count, Sort.valueOf(sort.toUpperCase()));
     })
     .thenAccept(vendors ->
       asyncResultHandler.handle(Future.succeededFuture(GetEholdingsProvidersResponse

--- a/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
@@ -63,7 +63,7 @@ public class EholdingsTitlesImpl implements EholdingsTitles {
                                  Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     headerValidator.validate(okapiHeaders);
     parametersValidator.validate(filterSelected, filterType, filterName, filterIsxn, filterSubject, filterPublisher, sort);
-    Sort nameSort = sort != null ? Sort.valueOf(sort.toUpperCase()) : null;
+    Sort nameSort = Sort.valueOf(sort.toUpperCase());
     CompletableFuture.completedFuture(null)
       .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
       .thenCompose(rmapiConfiguration -> {

--- a/src/main/java/org/folio/rest/validator/TitleParametersValidator.java
+++ b/src/main/java/org/folio/rest/validator/TitleParametersValidator.java
@@ -1,6 +1,5 @@
 package org.folio.rest.validator;
 
-import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.model.Sort;
 
 import javax.validation.ValidationException;
@@ -29,7 +28,7 @@ public class TitleParametersValidator {
       .anyMatch(""::equals)){
       throw new ValidationException("Required parameter 'search' is missing.");
     }
-    if ((Objects.nonNull(sort) && !Sort.contains(sort.toUpperCase()))){
+    if (!Sort.contains(sort.toUpperCase())){
       throw new ValidationException("Invalid sort parameter");
     }
     if (Objects.nonNull(filterSelected) && !FILTER_SELECTED_VALUES.contains(filterSelected)){

--- a/src/main/java/org/folio/rmapi/builder/QueriableUrlBuilder.java
+++ b/src/main/java/org/folio/rmapi/builder/QueriableUrlBuilder.java
@@ -60,9 +60,8 @@ public class QueriableUrlBuilder {
   }
 
   private String determineSortValue(Sort sort, String query) {
-    if(sort == null){
-      return query == null ? nameParameter : RELEVANCE_PARAMETER;
-    }
+    if(query == null)
+      return nameParameter;
     switch (sort){
       case RELEVANCE:
         return RELEVANCE_PARAMETER;

--- a/src/test/java/org/folio/rest/validator/TitleParametersValidatorTest.java
+++ b/src/test/java/org/folio/rest/validator/TitleParametersValidatorTest.java
@@ -11,30 +11,30 @@ public class TitleParametersValidatorTest {
   @Test
   public void shouldNotThrowExceptionWhenParametersAreValid() {
     validator.validate("true", "book", "ebsco",
-      null, null, null, null);
+      null, null, null, "relevance");
   }
 
   @Test(expected = ValidationException.class)
   public void shouldThrowExceptionWhenSelectedParameterIsInvalid() {
     validator.validate("doNotEnter", "book", "ebsco",
-      null, null, null, null);
+      null, null, null, "relevance");
   }
 
   @Test(expected = ValidationException.class)
   public void shouldThrowExceptionWhenTypeParameterIsInvalid() {
     validator.validate("true", "doNotEnter", "ebsco",
-      null, null, null, null);
+      null, null, null, "relevance");
   }
 
   @Test(expected = ValidationException.class)
   public void shouldThrowExceptionWhenThereAreConflictingParameters() {
     validator.validate("true", "book", "ebsco",
-      null, "history", null, null);
+      null, "history", null, "relevance");
   }
 
   @Test(expected = ValidationException.class)
   public void shouldThrowExceptionWhenSearchParameterIsEmpty() {
     validator.validate("true", "book", "",
-      null, null, null, null);
+      null, null, null, "relevance");
   }
 }

--- a/src/test/java/org/folio/rmapi/builder/QueriableUrlBuilderTest.java
+++ b/src/test/java/org/folio/rmapi/builder/QueriableUrlBuilderTest.java
@@ -8,25 +8,20 @@ import static org.junit.Assert.assertEquals;
 public class QueriableUrlBuilderTest {
   @Test
   public void shouldBuildUrlForNameSortWhenSortName(){
-    String path = new QueriableUrlBuilder().nameParameter("vendorname").sort(Sort.NAME).build();
-    assertEquals("offset=1&count=25&orderby=vendorname", path);
+    String path = new QueriableUrlBuilder().q("ebsco").nameParameter("vendorname").sort(Sort.NAME).build();
+    assertEquals("search=ebsco&offset=1&count=25&orderby=vendorname", path);
   }
 
   @Test
   public void shouldBuildUrlForRelevanceSortWhenSortRelevance(){
-    String path = new QueriableUrlBuilder().sort(Sort.RELEVANCE).build();
-    assertEquals("offset=1&count=25&orderby=relevance", path);
+    String path = new QueriableUrlBuilder().sort(Sort.RELEVANCE).q("ebsco").build();
+    assertEquals("search=ebsco&offset=1&count=25&orderby=relevance", path);
   }
 
   @Test
-  public void shouldBuildUrlForNameSortWhenSortIsNotSet(){
+  public void shouldBuildUrlForNameSortWhenQueryIsNotSet(){
     String path = new QueriableUrlBuilder().nameParameter("vendorname").build();
     assertEquals("offset=1&count=25&orderby=vendorname", path);
   }
 
-  @Test
-  public void shouldBuildUrlForRelevanceSortWhenSortIsNotSetAndQueryIsSet(){
-    String path = new QueriableUrlBuilder().q("higher education").build();
-    assertEquals("search=higher+education&offset=1&count=25&orderby=relevance", path);
-  }
 }

--- a/src/test/java/org/folio/rmapi/builder/TitlesFilterableUrlBuilderTest.java
+++ b/src/test/java/org/folio/rmapi/builder/TitlesFilterableUrlBuilderTest.java
@@ -11,6 +11,7 @@ public class TitlesFilterableUrlBuilderTest {
     String url = new TitlesFilterableUrlBuilder()
       .filterName("ebsco")
       .count(5)
+      .sort(Sort.RELEVANCE)
       .build();
     assertEquals("searchfield=titlename&selection=all&resourcetype=all&searchtype=advanced&search=ebsco" +
       "&offset=1&count=5&orderby=relevance", url);
@@ -31,6 +32,7 @@ public class TitlesFilterableUrlBuilderTest {
     String url = new TitlesFilterableUrlBuilder()
       .filterName("ebsco")
       .page(2)
+      .sort(Sort.RELEVANCE)
       .build();
     assertEquals("searchfield=titlename&selection=all&resourcetype=all&searchtype=advanced&search=ebsco" +
       "&offset=2&count=25&orderby=relevance", url);
@@ -42,6 +44,7 @@ public class TitlesFilterableUrlBuilderTest {
       .filterName("news")
       .filterType("book")
       .filterSelected("true")
+      .sort(Sort.RELEVANCE)
       .build();
     assertEquals("searchfield=titlename&selection=selected&resourcetype=book&searchtype=advanced&search=news" +
       "&offset=1&count=25&orderby=relevance", url);
@@ -51,6 +54,7 @@ public class TitlesFilterableUrlBuilderTest {
   public void shouldBuildUrlForFilterByIsxn(){
     String url = new TitlesFilterableUrlBuilder()
       .filterIsxn("1362-3613")
+      .sort(Sort.RELEVANCE)
       .build();
     assertEquals("searchfield=isxn&selection=all&resourcetype=all&searchtype=advanced&search=1362-3613" +
       "&offset=1&count=25&orderby=relevance", url);
@@ -60,6 +64,7 @@ public class TitlesFilterableUrlBuilderTest {
   public void shouldBuildUrlForFilterBySubject(){
     String url = new TitlesFilterableUrlBuilder()
       .filterSubject("history")
+      .sort(Sort.RELEVANCE)
       .build();
     assertEquals("searchfield=subject&selection=all&resourcetype=all&searchtype=advanced&search=history" +
       "&offset=1&count=25&orderby=relevance", url);
@@ -69,6 +74,7 @@ public class TitlesFilterableUrlBuilderTest {
   public void shouldBuildUrlForFilterByPublisher(){
     String url = new TitlesFilterableUrlBuilder()
       .filterPublisher("publisherName")
+      .sort(Sort.RELEVANCE)
       .build();
     assertEquals("searchfield=publisher&selection=all&resourcetype=all&searchtype=advanced&search=publisherName" +
       "&offset=1&count=25&orderby=relevance", url);


### PR DESCRIPTION
## Purpose
Change default value of sort parameter to "relevance"

## Approach
Made "relevance" to be default value for sort,
if search query is not specified then sort option is ignored and is treated
as "name"