### PR TITLE
MODKBEKBJ-93: Implement GET /eholdings/root-proxy endpoint

### DIFF
--- a/src/main/java/org/folio/rest/converter/RootProxyConverter.java
+++ b/src/main/java/org/folio/rest/converter/RootProxyConverter.java
@@ -1,0 +1,23 @@
+package org.folio.rest.converter;
+
+import org.folio.rest.jaxrs.model.RootProxyData;
+import org.folio.rest.jaxrs.model.RootProxyDataAttributes;
+import org.folio.rest.util.RestConstants;
+import org.folio.rmapi.model.RootProxyCustomLabels;
+
+
+public class RootProxyConverter {
+  private static final String ROOT_PROXY_ID = "root-proxy";
+  private static final String ROOT_PROXY_TYPE = "rootProxies";
+
+  public org.folio.rest.jaxrs.model.RootProxy convertRootProxy(RootProxyCustomLabels proxy) {
+    return new org.folio.rest.jaxrs.model.RootProxy()
+      .withData(new RootProxyData()
+          .withId(ROOT_PROXY_ID)
+          .withType(ROOT_PROXY_TYPE)
+          .withAttributes(new RootProxyDataAttributes()
+              .withId(ROOT_PROXY_ID)
+              .withProxyTypeId(proxy.getProxy().getId())))
+      .withJsonapi(RestConstants.JSONAPI);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/EHoldingsRootProxyImpl.java
+++ b/src/main/java/org/folio/rest/impl/EHoldingsRootProxyImpl.java
@@ -1,0 +1,93 @@
+package org.folio.rest.impl;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.http.HttpStatus;
+import org.folio.config.RMAPIConfigurationServiceCache;
+import org.folio.config.RMAPIConfigurationServiceImpl;
+import org.folio.config.api.RMAPIConfigurationService;
+import org.folio.http.ConfigurationClientProvider;
+import org.folio.rest.aspect.HandleValidationErrors;
+import org.folio.rest.converter.RootProxyConverter;
+import org.folio.rest.jaxrs.model.RootProxyPutRequest;
+import org.folio.rest.jaxrs.resource.EholdingsRootProxy;
+import org.folio.rest.model.OkapiData;
+import org.folio.rest.util.ErrorUtil;
+import org.folio.rest.validator.HeaderValidator;
+import org.folio.rmapi.RMAPIService;
+import org.folio.rmapi.exception.RMAPIUnAuthorizedException;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+public class EHoldingsRootProxyImpl implements EholdingsRootProxy {
+  
+  private RMAPIConfigurationService configurationService;
+  private HeaderValidator headerValidator;
+  private RootProxyConverter converter;
+  
+  private static final String CONTENT_TYPE_HEADER = "Content-Type";
+  private static final String CONTENT_TYPE_VALUE = "application/vnd.api+json";
+  
+  public EHoldingsRootProxyImpl() {
+    this(
+      new RMAPIConfigurationServiceCache(
+        new RMAPIConfigurationServiceImpl(new ConfigurationClientProvider())),
+      new HeaderValidator(),
+      new RootProxyConverter());
+  }
+
+  public EHoldingsRootProxyImpl(RMAPIConfigurationService configurationService,
+                                HeaderValidator headerValidator,
+                                RootProxyConverter converter) {
+    this.configurationService = configurationService;
+    this.headerValidator = headerValidator;
+    this.converter = converter;
+  }
+
+  @Override
+  @HandleValidationErrors
+  public void getEholdingsRootProxy(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    
+    headerValidator.validate(okapiHeaders);
+    CompletableFuture.completedFuture(null)
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(rmapiConfiguration -> {
+        RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
+          rmapiConfiguration.getUrl(), vertxContext.owner());
+        return rmapiService.retrieveRootProxy();
+      })
+      .thenAccept(rootProxy ->
+        asyncResultHandler.handle(Future.succeededFuture(GetEholdingsRootProxyResponse
+          .respond200WithApplicationVndApiJson(converter.convertRootProxy(rootProxy)))))
+      .exceptionally(e -> {
+        if(e.getCause() instanceof RMAPIUnAuthorizedException){
+          RMAPIUnAuthorizedException rmApiException = (RMAPIUnAuthorizedException)e.getCause();
+          asyncResultHandler.handle(Future.succeededFuture(GetEholdingsRootProxyResponse
+            .status(HttpStatus.SC_FORBIDDEN)
+            .header(CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE)
+            .entity(ErrorUtil.createError(rmApiException.getMessage()))
+            .build()));
+        }
+        else {
+          asyncResultHandler.handle(Future.succeededFuture(GetEholdingsRootProxyResponse
+            .status(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+            .header(CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE)
+            .entity(ErrorUtil.createError(e.getCause().getMessage()))
+            .build()));
+        }
+        return null;
+      });
+  }
+
+  @Override
+  public void putEholdingsRootProxy(String contentType, RootProxyPutRequest entity, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.succeededFuture(GetEholdingsRootProxyResponse.status(Response.Status.NOT_IMPLEMENTED).build()));
+  }
+}

--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -20,6 +20,7 @@ import org.folio.rmapi.exception.RMAPIUnAuthorizedException;
 import org.folio.rmapi.model.VendorById;
 import org.folio.rmapi.model.VendorPut;
 import org.folio.rmapi.model.Vendors;
+import org.folio.rmapi.model.RootProxyCustomLabels;
 import org.folio.rmapi.model.Titles;
 
 import java.util.concurrent.CompletableFuture;
@@ -173,7 +174,7 @@ public class RMAPIService {
     return this.getRequest(constructURL("titles?" + path), Titles.class);
   }
 
-    public CompletableFuture<VendorById> retrieveProvider(long id, String include) {
+  public CompletableFuture<VendorById> retrieveProvider(long id, String include) {
 
     final String path = "vendors/" + id;
     // TODO: add support of include parameter when MODKBEKBJ-22 is completed
@@ -189,6 +190,13 @@ public class RMAPIService {
       return this.retrieveProvider(id, "");
     });
 
+  }
+  
+  public CompletableFuture<RootProxyCustomLabels> retrieveRootProxy() {
+
+    final String path = "";
+
+    return this.getRequest(constructURL(path), RootProxyCustomLabels.class);
   }
 
   /**

--- a/src/main/java/org/folio/rmapi/model/CustomLabel.java
+++ b/src/main/java/org/folio/rmapi/model/CustomLabel.java
@@ -1,0 +1,54 @@
+package org.folio.rmapi.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+public class CustomLabel {
+  
+  @JsonProperty("id")
+  private Integer id;
+  @JsonProperty("displayLabel")
+  private String displayLabel;
+  @JsonProperty("displayOnFullTextFinder")
+  private Boolean displayOnFullTextFinder;
+  @JsonProperty("displayOnPublicationFinder")
+  private Boolean displayOnPublicationFinder;
+  
+  @JsonProperty("id")
+  public Integer getId() {
+    return id;
+  }
+
+  @JsonProperty("id")
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  @JsonProperty("displayLabel")
+  public String getDisplayLabel() {
+    return displayLabel;
+  }
+
+  @JsonProperty("displayLabel")
+  public void setDisplayLabel(String displayLabel) {
+    this.displayLabel = displayLabel;
+  }
+
+  @JsonProperty("displayOnFullTextFinder")
+  public Boolean getDisplayOnFullTextFinder() {
+    return displayOnFullTextFinder;
+  }
+
+  @JsonProperty("displayOnFullTextFinder")
+  public void setDisplayOnFullTextFinder(Boolean displayOnFullTextFinder) {
+    this.displayOnFullTextFinder = displayOnFullTextFinder;
+  }
+
+  @JsonProperty("displayOnPublicationFinder")
+  public Boolean getDisplayOnPublicationFinder() {
+    return displayOnPublicationFinder;
+  }
+
+  @JsonProperty("displayOnPublicationFinder")
+  public void setDisplayOnPublicationFinder(Boolean displayOnPublicationFinder) {
+    this.displayOnPublicationFinder = displayOnPublicationFinder;
+  }
+}

--- a/src/main/java/org/folio/rmapi/model/RootProxyCustomLabels.java
+++ b/src/main/java/org/folio/rmapi/model/RootProxyCustomLabels.java
@@ -1,0 +1,32 @@
+package org.folio.rmapi.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RootProxyCustomLabels {
+
+  @JsonProperty("proxy")
+  private Proxy proxy;
+  
+  @JsonProperty("labels")
+  private List<CustomLabel> labelList;
+
+  public Proxy getProxy() {
+    return proxy;
+  }
+
+  public void setProxy(Proxy proxy) {
+    this.proxy = proxy;
+  }
+  
+  public List<CustomLabel> getLabelList() {
+    return labelList;
+  }
+  
+  public void setLabelList(List<CustomLabel> labelList) {
+    this.labelList = labelList;
+  }
+}

--- a/src/test/java/org/folio/rest/impl/EHoldingsRootProxyImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EHoldingsRootProxyImplTest.java
@@ -1,0 +1,136 @@
+package org.folio.rest.impl;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.restassured.specification.RequestSpecification;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.config.cache.RMAPIConfigurationCache;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.rest.util.RestConstants;
+import org.folio.util.TestUtil;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static org.hamcrest.Matchers.equalTo;
+
+@RunWith(VertxUnitRunner.class)
+public class EHoldingsRootProxyImplTest {
+  private final String configurationStubFile = "responses/configuration/get-configuration.json";
+  private static final String STUB_CUSTOMER_ID = "TEST_CUSTOMER_ID";
+  private static final String ROOT_PROXY_ID = "root-proxy";
+  private static final String ROOT_PROXY_TYPE = "rootProxies";
+
+  private static int port;
+  private static String host;
+  
+  @org.junit.Rule
+  public WireMockRule userMockServer = new WireMockRule(
+    WireMockConfiguration.wireMockConfig()
+      .dynamicPort()
+      .notifier(new ConsoleNotifier(true)));
+
+  @BeforeClass
+  public static void setUpClass(final TestContext context) {
+    Vertx vertx = Vertx.vertx();
+    vertx.exceptionHandler(context.exceptionHandler());
+    port = NetworkUtils.nextFreePort();
+    host = "http://localhost";
+
+    DeploymentOptions restVerticleDeploymentOptions = new DeploymentOptions()
+      .setConfig(new JsonObject().put("http.port", port));
+    vertx.deployVerticle(RestVerticle.class.getName(), restVerticleDeploymentOptions, context.asyncAssertSuccess());
+  }
+
+  @Before
+  public void setUp() {
+    RMAPIConfigurationCache.getInstance().invalidate();
+  }
+  
+  @Test
+  public void shouldReturnRootProxyWhenCustIdAndAPIKeyAreValid() throws IOException, URISyntaxException {
+    String stubResponseFile = "responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-success-response.json";
+
+    String expectedRootProxyID = "<n>";
+
+    String wiremockUrl = host + ":" + userMockServer.port();
+    TestUtil.mockConfiguration(configurationStubFile, wiremockUrl);
+    WireMock.stubFor(
+      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
+        .willReturn(new ResponseDefinitionBuilder()
+          .withBody(TestUtil.readFile(stubResponseFile))));
+
+    RequestSpecification requestSpecification = getRequestSpecification();
+
+    RestAssured.given()
+      .spec(requestSpecification)
+      .when()
+      .get("eholdings/root-proxy")
+      .then()
+      .statusCode(200)
+      .body("data.id", equalTo(ROOT_PROXY_ID))
+      .body("data.type", equalTo(ROOT_PROXY_TYPE))
+      .body("data.attributes.id", equalTo(ROOT_PROXY_ID))
+      .body("data.attributes.proxyTypeId", equalTo(expectedRootProxyID));
+  }
+  
+  @Test
+  public void shouldReturnUnauthorizedWhenRMAPIRequestCompletesWith401ErrorStatus() throws IOException, URISyntaxException {
+    String wiremockUrl = host + ":" + userMockServer.port();
+    TestUtil.mockConfiguration(configurationStubFile, wiremockUrl);
+    WireMock.stubFor(
+      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
+        .willReturn(new ResponseDefinitionBuilder().withStatus(401)));
+    
+    RequestSpecification requestSpecification = getRequestSpecification();
+
+    RestAssured.given()
+      .spec(requestSpecification)
+      .when()
+      .get("eholdings/root-proxy")
+      .then()
+      .statusCode(403);
+  }
+  
+  @Test
+  public void shouldReturnUnauthorizedWhenRMAPIRequestCompletesWith403ErrorStatus() throws IOException, URISyntaxException {
+    String wiremockUrl = host + ":" + userMockServer.port();
+    TestUtil.mockConfiguration(configurationStubFile, wiremockUrl);
+    WireMock.stubFor(
+      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
+        .willReturn(new ResponseDefinitionBuilder().withStatus(403)));
+    
+    RequestSpecification requestSpecification = getRequestSpecification();
+
+    RestAssured.given()
+      .spec(requestSpecification)
+      .when()
+      .get("eholdings/root-proxy")
+      .then()
+      .statusCode(403);
+  }
+  
+  private RequestSpecification getRequestSpecification() {
+    return TestUtil.getRequestSpecificationBuilder(host + ":" + port)
+      .addHeader(RestConstants.OKAPI_URL_HEADER,   host + ":" + userMockServer.port())
+    .build();
+  }
+
+}
+

--- a/src/test/resources/responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-success-response.json
+++ b/src/test/resources/responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-success-response.json
@@ -1,0 +1,37 @@
+{
+  "proxy": {
+    "id": "<n>"
+  },
+  "labels": [
+    {
+      "id": 1,
+      "displayLabel": "label 1",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": false
+    },
+    {
+      "id": 2,
+      "displayLabel": "label 2",
+      "displayOnFullTextFinder": true,
+      "displayOnPublicationFinder": true
+    },
+    {
+      "id": 3,
+      "displayLabel": "label 3",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": true
+    },
+    {
+      "id": 4,
+      "displayLabel": "label 4",
+      "displayOnFullTextFinder": true,
+      "displayOnPublicationFinder": false
+    },
+    {
+      "id": 5,
+      "displayLabel": "label 5",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": false
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-93, we are supposed to implement `GET /eholdings/root-proxy` endpoint. This PR addresses that.

## Approach
- Experiment with Ruby code and figure out what request and response look like.
- Put together JSON schemas and RAML for supporting `/eholdings/proxy-types` and `/eholdings/root-proxy`
- Put together root proxy implementation class and associated tests.

## Screenshots
![get_root_proxy](https://user-images.githubusercontent.com/33662516/48516961-e4d56800-e832-11e8-96b9-7c2946ac79cd.gif)
