### PR TITLE
MODKBEKBJ-37 - Implement Title Get By Id Endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -43,7 +43,8 @@
         },
         {
           "methods": ["PUT"],
-          "pathPattern": "/eholdings/providers/{providerId}"
+          "pathPattern": "/eholdings/providers/{providerId}",
+          "permissionsRequired" :["kb-ebsco.provider.put"]
         },
         {
           "methods": ["GET"],
@@ -76,7 +77,8 @@
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/eholdings/titles/{titleId}"
+          "pathPattern": "/eholdings/titles/{titleId}",
+          "permissionsRequired" :["kb-ebsco.title.get"]
         },
         {
           "methods": ["GET"],
@@ -134,6 +136,16 @@
       "displayName": "get single provider",
       "description": "Get single provider"
     },
+     {
+      "permissionName": "kb-ebsco.provider.put",
+      "displayName": "put single provider",
+      "description": "Put single provider"
+    },
+    {
+      "permissionName": "kb-ebsco.title.get",
+      "displayName": "get single title",
+      "description": "Get single title"
+    },
     {
       "permissionName": "kb-ebsco.titleCollection.get",
       "displayName": "get titles",
@@ -154,8 +166,11 @@
         "kb-ebsco.status.get",
         "kb-ebsco.providerCollection.get",
         "kb-ebsco.provider.get",
+        "kb-ebsco.provider.put",
         "kb-ebsco.titleCollection.get",
-        "kb-ebsco.package.delete"
+        "kb-ebsco.package.delete",
+        "kb-ebsco.title.get",
+        "kb-ebsco.titleCollection.get"
       ]
     }
   ],

--- a/ramls/types/publicationType.json
+++ b/ramls/types/publicationType.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Publication Type schema",
+  "description": "Publication Type schema",
+  "javaType": "org.folio.rest.jaxrs.model.TitlePublicationType",
+  "type": "string",
+  "additionalProperties": false,
+      "enum": [
+        "All",
+        "Audiobook",
+        "Book",
+        "Book Series",
+        "Database",
+        "Journal",
+        "Newsletter",
+        "Newspaper",
+        "Proceedings",
+        "Report",
+        "Streaming Audio",
+        "Streaming Video",
+        "Thesis & Dissertation",
+        "Website",
+        "Unspecified"
+      ],
+      "example": "Journal"
+}

--- a/ramls/types/titles/title.json
+++ b/ramls/types/titles/title.json
@@ -20,16 +20,15 @@
           "description": "The Id Schema",
           "example": "100130"
         },
-        "relationships": {
+       "relationships": {
           "type": "object",
-          "description": "Title Relationships Schema",
-          "$ref": "../relationships.json"
+          "description": "Displays title relationships",
+          "$ref": "titleRelationship.json"
         },
         "type": {
           "type": "string",
           "description": "Title Type",
           "example": "titles"
-
         }
       }
     },

--- a/ramls/types/titles/titleData.json
+++ b/ramls/types/titles/titleData.json
@@ -52,24 +52,7 @@
     "publicationType": {
       "type": "string",
       "description": "Type of publication",
-      "enum": [
-        "All",
-        "Audiobook",
-        "Book",
-        "Book Series",
-        "Database",
-        "Journal",
-        "Newsletter",
-        "Newspaper",
-        "Proceedings",
-        "Report",
-        "Streaming Audio",
-        "Streaming Video",
-        "Thesis & Dissertation",
-        "Website",
-        "Unspecified"
-      ],
-      "example": "Journal"
+      "$ref": "../publicationType.json"
     },
     "publisherName": {
       "type": "string",

--- a/ramls/types/titles/titleListDataAttributes.json
+++ b/ramls/types/titles/titleListDataAttributes.json
@@ -28,24 +28,7 @@
     "publicationType": {
       "type": "string",
       "description": "Type of publication",
-      "enum": [
-        "All",
-        "Audiobook",
-        "Book",
-        "Book Series",
-        "Database",
-        "Journal",
-        "Newsletter",
-        "Newspaper",
-        "Proceedings",
-        "Report",
-        "Streaming Audio",
-        "Streaming Video",
-        "Thesis & Dissertation",
-        "Website",
-        "Unspecified"
-      ],
-      "example": "Journal"
+      "$ref": "../publicationType.json"
     },
     "publisherName": {
       "type": "string",

--- a/src/main/java/org/folio/rest/converter/TitleConverter.java
+++ b/src/main/java/org/folio/rest/converter/TitleConverter.java
@@ -10,7 +10,6 @@ import org.folio.rest.jaxrs.model.Data;
 import org.folio.rest.jaxrs.model.MetaDataIncluded;
 import org.folio.rest.jaxrs.model.MetaIncluded;
 import org.folio.rest.jaxrs.model.MetaTotalResults;
-import org.folio.rest.jaxrs.model.Relationships;
 import org.folio.rest.jaxrs.model.TitleAttributes;
 import org.folio.rest.jaxrs.model.TitleCollection;
 import org.folio.rest.jaxrs.model.TitleContributors;

--- a/src/main/java/org/folio/rest/converter/TitleConverter.java
+++ b/src/main/java/org/folio/rest/converter/TitleConverter.java
@@ -10,6 +10,7 @@ import org.folio.rest.jaxrs.model.Data;
 import org.folio.rest.jaxrs.model.MetaDataIncluded;
 import org.folio.rest.jaxrs.model.MetaIncluded;
 import org.folio.rest.jaxrs.model.MetaTotalResults;
+import org.folio.rest.jaxrs.model.Relationships;
 import org.folio.rest.jaxrs.model.TitleAttributes;
 import org.folio.rest.jaxrs.model.TitleCollection;
 import org.folio.rest.jaxrs.model.TitleContributors;
@@ -30,7 +31,7 @@ public class TitleConverter {
     .withResources(new MetaIncluded().withMeta(
       new MetaDataIncluded()
         .withIncluded(false)));
-
+  
   private static final Map<String, TitlePublicationType> publicationTypes = new HashMap<>();
   static {
     publicationTypes.put("audiobook", TitlePublicationType.AUDIOBOOK);
@@ -88,6 +89,7 @@ public class TitleConverter {
                 .withDescription(rmapiTitle.getDescription())
                 .withIsPeerReviewed(rmapiTitle.getPeerReviewed())
                 )
+            .withRelationships(EMPTY_RESOURCES_RELATIONSHIP)
             )
         .withIncluded(null)
         .withJsonapi(RestConstants.JSONAPI);

--- a/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
@@ -145,8 +145,7 @@ public class EholdingsTitlesImpl implements EholdingsTitles {
                 Response.status(rmApiException.getRMAPICode()).header(CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE)
                     .entity(ErrorUtil.createErrorFromRMAPIResponse(rmApiException)).build()));
         } else {
-
-          asyncResultHandler.handle(Future.succeededFuture(GetEholdingsProvidersByProviderIdResponse
+          asyncResultHandler.handle(Future.succeededFuture(GetEholdingsTitlesByTitleIdResponse
             .status(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             .header(CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE)
             .entity(ErrorUtil.createError(e.getCause().getMessage()))

--- a/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
@@ -139,6 +139,11 @@ public class EholdingsTitlesImpl implements EholdingsTitles {
         if (e.getCause() instanceof RMAPIResourceNotFoundException) {
           asyncResultHandler.handle(Future.succeededFuture(GetEholdingsTitlesByTitleIdResponse
             .respond404WithApplicationVndApiJson(ErrorUtil.createError(GET_TITLE_NOT_FOUND_MESSAGE))));
+        } else if (e.getCause() instanceof RMAPIServiceException) {
+            RMAPIServiceException rmApiException = (RMAPIServiceException) e.getCause();
+            asyncResultHandler.handle(Future.succeededFuture(
+                Response.status(rmApiException.getRMAPICode()).header(CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE)
+                    .entity(ErrorUtil.createErrorFromRMAPIResponse(rmApiException)).build()));
         } else {
 
           asyncResultHandler.handle(Future.succeededFuture(GetEholdingsProvidersByProviderIdResponse

--- a/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
@@ -17,8 +17,6 @@ import org.folio.rest.aspect.HandleValidationErrors;
 import org.folio.rest.converter.TitleConverter;
 import org.folio.rest.jaxrs.model.TitlePostRequest;
 import org.folio.rest.jaxrs.resource.EholdingsTitles;
-import org.folio.rest.jaxrs.resource.EholdingsProviders.GetEholdingsProvidersByProviderIdResponse;
-import org.folio.rest.jaxrs.resource.EholdingsTitles.GetEholdingsTitlesByTitleIdResponse;
 import org.folio.rest.model.OkapiData;
 import org.folio.rest.model.Sort;
 import org.folio.rest.util.ErrorUtil;
@@ -35,7 +33,6 @@ import java.util.concurrent.CompletableFuture;
 
 public class EholdingsTitlesImpl implements EholdingsTitles {
 
-  private static final String INTERNAL_SERVER_ERROR = "Internal server error";
   private static final String GET_TITLES_ERROR_MESSAGE = "Failed to retrieve titles";
   private static final String GET_TITLE_NOT_FOUND_MESSAGE = "Title not found";
   

--- a/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
@@ -93,14 +93,14 @@ public class EholdingsTitlesImpl implements EholdingsTitles {
           RMAPIServiceException rmApiException = (RMAPIServiceException)e.getCause();
           asyncResultHandler.handle(Future.succeededFuture(Response
             .status(rmApiException.getRMAPICode())
-            .header("Content-Type", "application/vnd.api+json")
+            .header(CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE)
             .entity(ErrorUtil.createErrorFromRMAPIResponse(rmApiException))
             .build()));
         }
         else {
           asyncResultHandler.handle(Future.succeededFuture(Response
             .status(500)
-            .header("Content-Type", "application/vnd.api+json")
+            .header(CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE)
             .entity(ErrorUtil.createError(e.getCause().getMessage()))
             .build()));
         }

--- a/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
@@ -127,7 +127,7 @@ public class EholdingsTitlesImpl implements EholdingsTitles {
       .thenCompose(rmapiConfiguration -> {
         RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
           rmapiConfiguration.getUrl(), vertxContext.owner());
-        return rmapiService.retrieveTitle(titleIdLong, include);
+        return rmapiService.retrieveTitle(titleIdLong);
       })
       .thenAccept(title ->
         asyncResultHandler.handle(Future.succeededFuture(GetEholdingsTitlesByTitleIdResponse

--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -213,6 +213,14 @@ public class RMAPIService {
     return this.getRequest(constructURL(path), RootProxyCustomLabels.class);
   }
 
+  public CompletableFuture<Title> retrieveTitle(long id, String include) {
+
+    final String path = "titles/" + id;
+    // TODO: add support of include parameter when MODKBEKBJ-83 is completed
+
+    return this.getRequest(constructURL(path), Title.class);
+  }
+
   /**
    * Constructs full rmapi path
    *

--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -217,9 +217,7 @@ public class RMAPIService {
 
   public CompletableFuture<Title> retrieveTitle(long id, String include) {
 
-    final String path = "titles/" + id;
-    // TODO: add support of include parameter when MODKBEKBJ-83 is completed
-
+    final String path = TITLES_PATH + '/' + id;
     return this.getRequest(constructURL(path), Title.class);
   }
 

--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -215,7 +215,7 @@ public class RMAPIService {
     return this.getRequest(constructURL(path), RootProxyCustomLabels.class);
   }
 
-  public CompletableFuture<Title> retrieveTitle(long id, String include) {
+  public CompletableFuture<Title> retrieveTitle(long id) {
 
     final String path = TITLES_PATH + '/' + id;
     return this.getRequest(constructURL(path), Title.class);

--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -9,6 +9,7 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+
 import org.folio.rest.model.PackageId;
 import org.folio.rest.model.Sort;
 import org.folio.rmapi.builder.QueriableUrlBuilder;
@@ -19,6 +20,7 @@ import org.folio.rmapi.exception.RMAPIServiceException;
 import org.folio.rmapi.exception.RMAPIUnAuthorizedException;
 import org.folio.rmapi.model.PackageData;
 import org.folio.rmapi.model.PackageSelectedPayload;
+import org.folio.rmapi.model.Title;
 import org.folio.rmapi.model.Titles;
 import org.folio.rmapi.model.VendorById;
 import org.folio.rmapi.model.VendorPut;

--- a/src/test/java/org/folio/rest/impl/EholdingsTitlesTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsTitlesTest.java
@@ -141,7 +141,9 @@ public class EholdingsTitlesTest extends WireMockTestBase {
     .body("data.attributes.description", isEmptyOrNullString())
     .body("data.attributes.isPeerReviewed", equalTo(false))
     .body("data.attributes.contributors[0].type", equalTo("author"))
-    .body("data.attributes.contributors[0].contributor", equalTo("Bloom, Harold"));
+    .body("data.attributes.contributors[0].contributor", equalTo("Bloom, Harold"))
+    .body("data.relationships.resources.meta.included", equalTo(false));
+
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/EholdingsTitlesTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsTitlesTest.java
@@ -7,6 +7,8 @@ import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 import io.restassured.RestAssured;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+import org.folio.rest.jaxrs.model.JsonapiError;
 import org.folio.util.TestUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,7 +26,7 @@ import static org.hamcrest.Matchers.contains;
 
 @RunWith(VertxUnitRunner.class)
 public class EholdingsTitlesTest extends WireMockTestBase {
-
+  private static final String STUB_TITLE_ID = "985846";
   @Test
   public void shouldReturnTitlesOnGet() throws IOException, URISyntaxException {
     String stubResponseFile = "responses/rmapi/titles/searchTitles.json";
@@ -100,8 +102,8 @@ public class EholdingsTitlesTest extends WireMockTestBase {
   public void shouldReturnTitleWhenValidId() throws IOException, URISyntaxException {
     String stubResponseFile = "responses/rmapi/titles/get-title-by-id-response.json";
 
-    String wiremockUrl = host + ":" + userMockServer.port();
-    TestUtil.mockConfiguration("responses/configuration/get-configuration.json", wiremockUrl);
+    String wiremockUrl = getWiremockUrl();
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
     WireMock.stubFor(
         WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/titles.*"), true))
         .willReturn(new ResponseDefinitionBuilder()
@@ -110,11 +112,7 @@ public class EholdingsTitlesTest extends WireMockTestBase {
     String titleByIdEndpoint = "eholdings/titles/" + STUB_TITLE_ID;
 
     RestAssured.given()
-    .spec(spec)
-    .port(port)
-    .header(new Header(RestConstants.OKAPI_URL_HEADER, wiremockUrl))
-    .header(TENANT_HEADER)
-    .header(TOKEN_HEADER)
+    .spec(getRequestSpecification())
     .when()
     .get(titleByIdEndpoint)
     .then()
@@ -150,8 +148,8 @@ public class EholdingsTitlesTest extends WireMockTestBase {
   public void shouldReturn404WhenRMAPINotFoundOnTitleGet() throws IOException, URISyntaxException {
     String stubResponseFile = "responses/rmapi/titles/get-title-by-id-not-found-response.json";
 
-    String wiremockUrl = host + ":" + userMockServer.port();
-    TestUtil.mockConfiguration("responses/configuration/get-configuration.json", wiremockUrl);
+    String wiremockUrl = getWiremockUrl();
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
     WireMock.stubFor(
         WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/titles.*"), true))
         .willReturn(new ResponseDefinitionBuilder()
@@ -161,11 +159,7 @@ public class EholdingsTitlesTest extends WireMockTestBase {
     String titleByIdEndpoint = "eholdings/titles/" + STUB_TITLE_ID;
 
     JsonapiError error = RestAssured.given()
-    .spec(spec)
-    .port(port)
-    .header(new Header(RestConstants.OKAPI_URL_HEADER, wiremockUrl))
-    .header(TENANT_HEADER)
-    .header(TOKEN_HEADER)
+    .spec(getRequestSpecification())
     .when()
     .get(titleByIdEndpoint)
     .then()
@@ -177,15 +171,13 @@ public class EholdingsTitlesTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn400WhenValidationErrorOnTitleGet() throws IOException, URISyntaxException {
-    String wiremockUrl = host + ":" + userMockServer.port();
+    String wiremockUrl = getWiremockUrl();
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
+
     String titleByIdEndpoint = "eholdings/titles/12345aaa";
 
     JsonapiError error = RestAssured.given()
-    .spec(spec)
-    .port(port)
-    .header(new Header(RestConstants.OKAPI_URL_HEADER, wiremockUrl))
-    .header(TENANT_HEADER)
-    .header(TOKEN_HEADER)
+    .spec(getRequestSpecification())
     .when()
     .get(titleByIdEndpoint)
     .then()
@@ -197,8 +189,8 @@ public class EholdingsTitlesTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn500WhenRMApiReturns500ErrorOnTitleGet() throws IOException, URISyntaxException {
-    String wiremockUrl = host + ":" + userMockServer.port();
-    TestUtil.mockConfiguration("responses/configuration/get-configuration.json", wiremockUrl);
+    String wiremockUrl = getWiremockUrl();
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
     WireMock.stubFor(
       WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/titles.*"), true))
         .willReturn(new ResponseDefinitionBuilder()
@@ -206,12 +198,9 @@ public class EholdingsTitlesTest extends WireMockTestBase {
 
     String titleByIdEndpoint = "eholdings/titles/" + STUB_TITLE_ID;
 
-
     RestAssured.given()
-      .spec(spec).port(port)
-      .header(new Header(RestConstants.OKAPI_URL_HEADER, wiremockUrl))
-      .header(TENANT_HEADER)
-      .header(TOKEN_HEADER)
+      .spec(getRequestSpecification())
+      .when()
       .when()
       .get(titleByIdEndpoint)
       .then()

--- a/src/test/java/org/folio/rest/impl/EholdingsTitlesTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsTitlesTest.java
@@ -1,28 +1,24 @@
 package org.folio.rest.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.matching.RegexPattern;
-import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
-import io.restassured.RestAssured;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
 
 import org.folio.rest.jaxrs.model.JsonapiError;
 import org.folio.util.TestUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.List;
-import java.util.stream.Collectors;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
+import io.restassured.RestAssured;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
 public class EholdingsTitlesTest extends WireMockTestBase {

--- a/src/test/resources/responses/rmapi/titles/get-title-by-id-not-found-response.json
+++ b/src/test/resources/responses/rmapi/titles/get-title-by-id-not-found-response.json
@@ -1,0 +1,9 @@
+{
+  "Errors": [
+    {
+      "Code": 1001,
+      "Message": "Title not found",
+      "SubCode": 0
+    }
+  ]
+}

--- a/src/test/resources/responses/rmapi/titles/get-title-by-id-response.json
+++ b/src/test/resources/responses/rmapi/titles/get-title-by-id-response.json
@@ -1,0 +1,100 @@
+{
+  "titleId": 985846,
+  "titleName": "F. Scott Fitzgerald's The Great Gatsby (Great Gatsby)",
+  "publisherName": "Chelsea House Publishers",
+  "identifiersList": [
+    {
+      "id": "38624",
+      "source": "ResourceIdentifier",
+      "subtype": 0,
+      "type": 7
+    },
+    {
+      "id": "978-0-585-24731-1",
+      "source": "ResourceIdentifier",
+      "subtype": 2,
+      "type": 1
+    },
+    {
+      "id": "978-0-7910-3651-8",
+      "source": "ResourceIdentifier",
+      "subtype": 1,
+      "type": 1
+    },
+    {
+      "id": "985846",
+      "source": "AtoZ",
+      "subtype": 0,
+      "type": 9
+    },
+    {
+      "id": "U7Q",
+      "source": "MFS",
+      "subtype": 0,
+      "type": 8
+    }
+  ],
+  "subjectsList": [
+    {
+      "type": "BISAC",
+      "subject": "LITERARY CRITICISM \/ American \/ General"
+    }
+  ],
+  "isTitleCustom": false,
+  "pubType": "Book",
+  "customerResourcesList": [
+    {
+      "titleId": 985846,
+      "packageId": 5207,
+      "packageName": "EBSCO eBooks",
+      "packageType": "Selectable",
+      "proxy": {
+        "id": "EZProxy",
+        "inherited": true
+      },
+      "isPackageCustom": false,
+      "vendorId": 19,
+      "vendorName": "EBSCO",
+      "locationId": 3464602,
+      "isSelected": true,
+      "isTokenNeeded": false,
+      "visibilityData": {
+        "isHidden": false,
+        "reason": ""
+      },
+      "managedCoverageList": [
+        {
+          "beginCoverage": "1996-01-01",
+          "endCoverage": "1996-12-31"
+        }
+      ],
+      "customCoverageList": [
+        
+      ],
+      "coverageStatement": null,
+      "managedEmbargoPeriod": {
+        "embargoUnit": null,
+        "embargoValue": 0
+      },
+      "customEmbargoPeriod": {
+        "embargoUnit": null,
+        "embargoValue": 0
+      },
+      "url": "http:\/\/search.ebscohost.com\/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=38624",
+      "userDefinedField1": null,
+      "userDefinedField2": null,
+      "userDefinedField3": null,
+      "userDefinedField4": null,
+      "userDefinedField5": null
+    }
+  ],
+  "description": null,
+  "edition": null,
+  "isPeerReviewed": false,
+  "contributorsList": [
+    {
+      "type": "author",
+      "contributor": "Bloom, Harold"
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-37 implement titles get by id endpoint

## Approach
- Added module descriptor permission, plus missing permission for provider put
- RAML Updates (moved publication types enum to common class to be shared by list and title details, udated title.json relationship to reflect resources only
- Added conversion of title detail record from RM API format to JSON API format
- Added unit tests with updated refactoring to use WireMockTestBase

#### TODOS and Open Questions
- [ ] Separate PR and Jira issue to handle `?include=resources`
https://issues.folio.org/browse/MODKBEKBJ-83 

#### Screen Shots
![2018-11-15 13 19 27](https://user-images.githubusercontent.com/19415226/48573146-5f58c300-e8d9-11e8-8110-f599d574a1ea.gif)

