### PR TITLE
MODKBEKBJ-52 - Fix provider token mapping issue

### DIFF
--- a/src/main/java/org/folio/rest/converter/VendorConverter.java
+++ b/src/main/java/org/folio/rest/converter/VendorConverter.java
@@ -31,7 +31,7 @@ public class VendorConverter {
   }
 
   private Providers convertVendor(Vendor vendor) {
-    TokenInfo token = vendor.getVendorToken();
+    String token = vendor.getVendorToken();
     return new Providers()
       .withId(String.valueOf(vendor.getVendorId()))
       .withType(PROVIDERS_TYPE)
@@ -40,12 +40,12 @@ public class VendorConverter {
         .withPackagesTotal(vendor.getPackagesTotal())
         .withPackagesSelected(vendor.getPackagesSelected())
         .withSupportsCustomPackages(vendor.isCustomer())
-        .withProviderToken(token != null ? new Token().withValue((String) token.getValue()) : null))
+        .withProviderToken(token != null ? new Token().withValue(token) : null))
       .withRelationships(EMPTY_PACKAGE_RELATIONSHIP);
   }
 
   public Provider convertToProvider(VendorById vendor) {
-    TokenInfo vendorToken = vendor.getVendorToken();
+    TokenInfo vendorToken = vendor.getVendorByIdToken();
     return new Provider()
       .withData(new ProviderData()
         .withId(String.valueOf(vendor.getVendorId()))

--- a/src/main/java/org/folio/rmapi/model/Vendor.java
+++ b/src/main/java/org/folio/rmapi/model/Vendor.java
@@ -16,7 +16,7 @@ public class Vendor {
   @JsonProperty("isCustomer")
   private boolean isCustomer;
   @JsonProperty("vendorToken")
-  private TokenInfo vendorToken;
+  private String vendorToken;
 
   public int getVendorId() {
     return vendorId;
@@ -58,11 +58,11 @@ public class Vendor {
     isCustomer = customer;
   }
 
-  public TokenInfo getVendorToken() {
+  public String getVendorToken() {
     return vendorToken;
   }
 
-  public void setVendorToken(TokenInfo vendorToken) {
+  public void setVendorToken(String vendorToken) {
     this.vendorToken = vendorToken;
   }
 }

--- a/src/main/java/org/folio/rmapi/model/VendorById.java
+++ b/src/main/java/org/folio/rmapi/model/VendorById.java
@@ -1,5 +1,6 @@
 package org.folio.rmapi.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -9,11 +10,25 @@ public class VendorById extends Vendor {
   @JsonProperty("proxy")
   private Proxy proxy;
 
+  @JsonIgnore
+  private String vendorToken;
+
+  @JsonProperty("vendorToken")
+  private TokenInfo vendorByIdToken;
+
   public Proxy getProxy() {
     return proxy;
   }
 
   public void setProxy(Proxy proxy) {
     this.proxy = proxy;
+  }
+
+  public TokenInfo getVendorByIdToken() {
+    return vendorByIdToken;
+  }
+
+  public void setVendorByIdToken(TokenInfo vendorByIdToken) {
+    this.vendorByIdToken = vendorByIdToken;
   }
 }

--- a/src/main/java/org/folio/rmapi/model/VendorById.java
+++ b/src/main/java/org/folio/rmapi/model/VendorById.java
@@ -1,6 +1,5 @@
 package org.folio.rmapi.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -9,9 +8,6 @@ public class VendorById extends Vendor {
 
   @JsonProperty("proxy")
   private Proxy proxy;
-
-  @JsonIgnore
-  private String vendorToken;
 
   @JsonProperty("vendorToken")
   private TokenInfo vendorByIdToken;

--- a/src/test/resources/responses/rmapi/vendors/get-vendor-by-id-response.json
+++ b/src/test/resources/responses/rmapi/vendors/get-vendor-by-id-response.json
@@ -8,5 +8,10 @@
     "id": "<n>",
     "inherited": true
   },
-  "vendorToken": null
+  "vendorToken": {
+    "factName": null,
+    "prompt": null,
+    "helpText": null,
+    "value":"sampleToken"
+  }
 }

--- a/src/test/resources/responses/rmapi/vendors/get-vendors-response.json
+++ b/src/test/resources/responses/rmapi/vendors/get-vendors-response.json
@@ -7,12 +7,7 @@
       "isCustomer": false,
       "packagesTotal": 1,
       "packagesSelected": 0,
-      "vendorToken": {
-        "factName": null,
-        "prompt": null,
-        "helpText": null,
-        "value":"sampleToken"
-      }
+      "vendorToken": "sampleToken"
     },
     {
       "vendorId": 66221,


### PR DESCRIPTION
## Purpose
Fix issue that occurs while parsing provider token.

## Approach
- Change vendor token in vendor class to string
- Add object instance of vendor token to "VendorById" class

## Learning
It appears that provider token might be an object or a string in some cases.
