### PR TITLE
Update Provider Error Messages from RM API (vendor vs provider)

### DIFF
--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -46,6 +46,11 @@ public class RMAPIService {
   private static final String PACKAGES_PATH = "packages";
   private static final String TITLES_PATH = "titles";
 
+  private static final String VENDOR_LOWER_STRING = "vendor";
+  private static final String PROVIDER_LOWER_STRING = "provider";
+  private static final String VENDOR_UPPER_STRING = "Vendor";
+  private static final String PROVIDER_UPPER_STRING = "Provider";
+  
   private String customerId;
   private String apiKey;
   private String baseURI;
@@ -64,20 +69,26 @@ public class RMAPIService {
 
     LOG.error(String.format("%s status code = [%s] status message = [%s] query = [%s] body = [%s]",
       INVALID_RMAPI_RESPONSE, response.statusCode(), response.statusMessage(), query, body.toString()));
-
+    
+    String msgBody = mapVendorToProvider(body.toString());
+  
     if (response.statusCode() == 404) {
       future.completeExceptionally(new RMAPIResourceNotFoundException(
-        String.format("Requested resource %s not found", query), response.statusCode(), response.statusMessage(), body.toString(), query));
+        String.format("Requested resource %s not found", query), response.statusCode(), response.statusMessage(), msgBody, query));
     } else if ((response.statusCode() == 401) || (response.statusCode() == 403)) {
       future.completeExceptionally(new RMAPIUnAuthorizedException(
-        String.format("Unauthorized Access to %s", query), response.statusCode(), response.statusMessage(), body.toString(), query));
+        String.format("Unauthorized Access to %s", query), response.statusCode(), response.statusMessage(), msgBody, query));
     } else {
 
       future.completeExceptionally(new RMAPIServiceException(
         String.format("%s Code = %s Message = %s Body = %s", INVALID_RMAPI_RESPONSE, response.statusCode(),
-          response.statusMessage(), body.toString()),
-        response.statusCode(), response.statusMessage(), body.toString(), query));
+            response.statusMessage(), body.toString()),
+        response.statusCode(), response.statusMessage(), msgBody, query));
     }
+  }
+  
+  private String mapVendorToProvider(String msgBody) {
+    return msgBody.replaceAll(VENDOR_LOWER_STRING, PROVIDER_LOWER_STRING).replaceAll(VENDOR_UPPER_STRING, PROVIDER_UPPER_STRING);
   }
 
   private <T> CompletableFuture<T> getRequest(String query, Class<T> clazz) {

--- a/src/test/java/org/folio/rest/impl/EholdingsProvidersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsProvidersImplTest.java
@@ -256,7 +256,7 @@ public class EholdingsProvidersImplTest extends WireMockTestBase {
       .statusCode(HttpStatus.SC_BAD_REQUEST)
       .extract().as(JsonapiError.class);
 
-    assertThat(error.getErrors().get(0).getTitle(), equalTo("Vendor does not allow token"));
+    assertThat(error.getErrors().get(0).getTitle(), equalTo("Provider does not allow token"));
 
   }
 


### PR DESCRIPTION
## Purpose

Error messages from RM API return messages containing `vendor` instead of `provider`. 
Mod-kb-ebsco currently updates message body and replaces Vendor, vendor with Provider, provider respectively in the following code:
https://github.com/folio-org/mod-kb-ebsco/blob/9b68934c587983e28cb7a3d9c73e7a562b31ac90/app/controllers/application_controller.rb#L99 

## Approach
Update java module to do the same replacement
Update unit test to reflect vendor instead of provider

## Screen Shots

Before
<img width="1645" alt="screen shot 2018-11-16 at 12 31 59 pm" src="https://user-images.githubusercontent.com/19415226/48638195-e96a5f80-e99d-11e8-8eae-25b32925edd8.png">

After

<img width="1659" alt="screen shot 2018-11-16 at 12 35 48 pm" src="https://user-images.githubusercontent.com/19415226/48638214-f424f480-e99d-11e8-930d-14dcf75de788.png">




