### PR TITLE
MODKBEKBJ-95: Implement PUT root proxy endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -86,11 +86,13 @@
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/eholdings/root-proxy"
+          "pathPattern": "/eholdings/root-proxy",
+          "permissionsRequired": ["kb-ebsco.root-proxy.get"]
         },
         {
           "methods": ["PUT"],
-          "pathPattern": "/eholdings/root-proxy"
+          "pathPattern": "/eholdings/root-proxy",
+          "permissionsRequired": ["kb-ebsco.root-proxy.put"]
         },
         {
           "methods": ["GET"],
@@ -157,6 +159,16 @@
       "description": "Delete custom package"
     },
     {
+      "permissionName": "kb-ebsco.root-proxy.get",
+      "displayName": "get root proxy",
+      "description": "Get root proxy"
+    },
+    {
+      "permissionName": "kb-ebsco.root-proxy.put",
+      "displayName": "put root proxy",
+      "description": "Put root proxy"
+    },
+    {
       "permissionName": "kb-ebsco.all",
       "displayName": "EBSCO KB Broker - all permissions",
       "description": "All permissions for EBSCO KB module",
@@ -170,7 +182,9 @@
         "kb-ebsco.titleCollection.get",
         "kb-ebsco.package.delete",
         "kb-ebsco.title.get",
-        "kb-ebsco.titleCollection.get"
+        "kb-ebsco.titleCollection.get",
+        "kb-ebsco.root-proxy.get",
+        "kb-ebsco.root-proxy.put"
       ]
     }
   ],

--- a/src/main/java/org/folio/rest/converter/RootProxyConverter.java
+++ b/src/main/java/org/folio/rest/converter/RootProxyConverter.java
@@ -5,7 +5,6 @@ import org.folio.rest.jaxrs.model.RootProxyDataAttributes;
 import org.folio.rest.util.RestConstants;
 import org.folio.rmapi.model.RootProxyCustomLabels;
 
-
 public class RootProxyConverter {
   private static final String ROOT_PROXY_ID = "root-proxy";
   private static final String ROOT_PROXY_TYPE = "rootProxies";

--- a/src/main/java/org/folio/rest/impl/EHoldingsRootProxyImpl.java
+++ b/src/main/java/org/folio/rest/impl/EHoldingsRootProxyImpl.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.ws.rs.core.Response;
 
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.http.HttpStatus;
 import org.folio.config.RMAPIConfigurationServiceCache;
 import org.folio.config.RMAPIConfigurationServiceImpl;
@@ -17,37 +18,48 @@ import org.folio.rest.jaxrs.resource.EholdingsRootProxy;
 import org.folio.rest.model.OkapiData;
 import org.folio.rest.util.ErrorUtil;
 import org.folio.rest.validator.HeaderValidator;
+import org.folio.rest.validator.RootProxyPutBodyValidator;
 import org.folio.rmapi.RMAPIService;
+import org.folio.rmapi.exception.RMAPIServiceException;
 import org.folio.rmapi.exception.RMAPIUnAuthorizedException;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 public class EHoldingsRootProxyImpl implements EholdingsRootProxy {
   
   private RMAPIConfigurationService configurationService;
   private HeaderValidator headerValidator;
   private RootProxyConverter converter;
+  private RootProxyPutBodyValidator bodyValidator;
   
   private static final String CONTENT_TYPE_HEADER = "Content-Type";
   private static final String CONTENT_TYPE_VALUE = "application/vnd.api+json";
+  private static final String PUT_ROOT_PROXY_ERROR_MESSAGE = "Failed to update root proxy";
+  
+  private final Logger logger = LoggerFactory.getLogger(EHoldingsRootProxyImpl.class);
   
   public EHoldingsRootProxyImpl() {
     this(
       new RMAPIConfigurationServiceCache(
         new RMAPIConfigurationServiceImpl(new ConfigurationClientProvider())),
       new HeaderValidator(),
-      new RootProxyConverter());
+      new RootProxyConverter(),
+      new RootProxyPutBodyValidator());
   }
 
   public EHoldingsRootProxyImpl(RMAPIConfigurationService configurationService,
                                 HeaderValidator headerValidator,
-                                RootProxyConverter converter) {
+                                RootProxyConverter converter,
+                                RootProxyPutBodyValidator bodyValidator) {
     this.configurationService = configurationService;
     this.headerValidator = headerValidator;
     this.converter = converter;
+    this.bodyValidator = bodyValidator;
   }
 
   @Override
@@ -60,11 +72,11 @@ public class EHoldingsRootProxyImpl implements EholdingsRootProxy {
       .thenCompose(rmapiConfiguration -> {
         RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
           rmapiConfiguration.getUrl(), vertxContext.owner());
-        return rmapiService.retrieveRootProxy();
+        return rmapiService.retrieveRootProxyCustomLabels();
       })
-      .thenAccept(rootProxy ->
+      .thenAccept(rootProxyCustomLabels ->
         asyncResultHandler.handle(Future.succeededFuture(GetEholdingsRootProxyResponse
-          .respond200WithApplicationVndApiJson(converter.convertRootProxy(rootProxy)))))
+          .respond200WithApplicationVndApiJson(converter.convertRootProxy(rootProxyCustomLabels)))))
       .exceptionally(e -> {
         if(e.getCause() instanceof RMAPIUnAuthorizedException){
           RMAPIUnAuthorizedException rmApiException = (RMAPIUnAuthorizedException)e.getCause();
@@ -86,8 +98,47 @@ public class EHoldingsRootProxyImpl implements EholdingsRootProxy {
   }
 
   @Override
+  @HandleValidationErrors
   public void putEholdingsRootProxy(String contentType, RootProxyPutRequest entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    asyncResultHandler.handle(Future.succeededFuture(GetEholdingsRootProxyResponse.status(Response.Status.NOT_IMPLEMENTED).build()));
+    headerValidator.validate(okapiHeaders);
+    bodyValidator.validate(entity);
+    
+    MutableObject<RMAPIService> service = new MutableObject<>();
+    CompletableFuture.completedFuture(null)
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenAccept(rmapiConfiguration -> 
+        service.setValue(new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
+          rmapiConfiguration.getUrl(), vertxContext.owner())))
+      .thenCompose(o -> service.getValue().retrieveRootProxyCustomLabels())
+      .thenCompose(rootProxyCustomLabels -> service.getValue().updateRootProxyCustomLabels(entity, rootProxyCustomLabels))
+      .thenAccept(rootProxy ->
+        asyncResultHandler.handle(Future.succeededFuture(PutEholdingsRootProxyResponse
+          .respond200WithApplicationVndApiJson(converter.convertRootProxy(rootProxy)))))
+      .exceptionally(e -> {
+        logger.error(PUT_ROOT_PROXY_ERROR_MESSAGE, e);
+        if(e.getCause() instanceof RMAPIUnAuthorizedException){
+          RMAPIUnAuthorizedException rmApiException = (RMAPIUnAuthorizedException)e.getCause();
+          asyncResultHandler.handle(Future.succeededFuture(PutEholdingsRootProxyResponse
+            .status(HttpStatus.SC_FORBIDDEN)
+            .header(CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE)
+            .entity(ErrorUtil.createError(rmApiException.getMessage()))
+            .build()));
+        } else if (e.getCause() instanceof RMAPIServiceException) {
+          RMAPIServiceException rmApiException = (RMAPIServiceException)e.getCause();
+          asyncResultHandler.handle(Future.succeededFuture(PutEholdingsRootProxyResponse
+            .status(rmApiException.getRMAPICode())
+            .header(CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE)
+            .entity(ErrorUtil.createErrorFromRMAPIResponse(rmApiException))
+            .build()));
+        } else {
+          asyncResultHandler.handle(Future.succeededFuture(GetEholdingsRootProxyResponse
+            .status(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+            .header(CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE)
+            .entity(ErrorUtil.createError(e.getCause().getMessage()))
+            .build()));
+        }
+        return null;
+      });
   }
 }

--- a/src/main/java/org/folio/rest/validator/RootProxyPutBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/RootProxyPutBodyValidator.java
@@ -1,0 +1,26 @@
+package org.folio.rest.validator;
+
+import org.folio.rest.exception.InputValidationException;
+import org.folio.rest.jaxrs.model.RootProxyPutRequest;
+
+public class RootProxyPutBodyValidator {
+    private static final String INVALID_PROXY_ID = "Invalid proxy id";
+    private static final String PROXY_NOT_NULL = "proxyTypeId cannot be null";
+
+    /**
+     * @throws InputValidationException
+     *           if PUT validation fails
+     *           
+     *           We are checking only for null case because RM API handles every other case
+     *           if the proxy is invalid and gives a 400 except for null in case of which it gives
+     *           a 500.
+     */
+    public void validate(RootProxyPutRequest putRequest) {
+      if (putRequest != null 
+          && putRequest.getData() != null
+          && putRequest.getData().getAttributes() != null 
+          && putRequest.getData().getAttributes().getProxyTypeId() == null) {
+        throw new InputValidationException(INVALID_PROXY_ID, PROXY_NOT_NULL);
+      }
+    }
+  }

--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -10,6 +10,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
+import org.folio.rest.jaxrs.model.RootProxyPutRequest;
 import org.folio.rest.model.PackageId;
 import org.folio.rest.model.Sort;
 import org.folio.rmapi.builder.QueriableUrlBuilder;
@@ -208,11 +209,19 @@ public class RMAPIService {
     return this.putRequest(constructURL(path),new PackageSelectedPayload(false));
   }
 
-  public CompletableFuture<RootProxyCustomLabels> retrieveRootProxy() {
-
+  public CompletableFuture<RootProxyCustomLabels> retrieveRootProxyCustomLabels() {
     final String path = "";
 
     return this.getRequest(constructURL(path), RootProxyCustomLabels.class);
+  }
+  
+  public CompletableFuture<RootProxyCustomLabels> updateRootProxyCustomLabels(RootProxyPutRequest rootProxyPutRequest, RootProxyCustomLabels rootProxyCustomLabels) {
+    final String path = "";
+    
+    org.folio.rmapi.model.Proxy proxyRMAPI = new org.folio.rmapi.model.Proxy();   
+    proxyRMAPI.setId(rootProxyPutRequest.getData().getAttributes().getProxyTypeId());
+    rootProxyCustomLabels.setProxy(proxyRMAPI);
+    return this.putRequest(constructURL(path), rootProxyCustomLabels).thenCompose(updatedRootProxy -> this.retrieveRootProxyCustomLabels());
   }
 
   public CompletableFuture<Title> retrieveTitle(long id) {

--- a/src/test/java/org/folio/rest/impl/EHoldingsRootProxyImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EHoldingsRootProxyImplTest.java
@@ -1,67 +1,37 @@
 package org.folio.rest.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 import io.restassured.RestAssured;
-import io.restassured.http.Header;
 import io.restassured.specification.RequestSpecification;
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.folio.config.cache.RMAPIConfigurationCache;
-import org.folio.rest.RestVerticle;
-import org.folio.rest.tools.utils.NetworkUtils;
+
+import org.apache.http.HttpStatus;
+import org.folio.rest.jaxrs.model.JsonapiError;
+import org.folio.rest.jaxrs.model.RootProxy;
+import org.folio.rest.jaxrs.model.RootProxyData;
+import org.folio.rest.jaxrs.model.RootProxyDataAttributes;
+import org.folio.rest.jaxrs.model.RootProxyPutRequest;
 import org.folio.rest.util.RestConstants;
 import org.folio.util.TestUtil;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 @RunWith(VertxUnitRunner.class)
-public class EHoldingsRootProxyImplTest {
-  private final String configurationStubFile = "responses/configuration/get-configuration.json";
-  private static final String STUB_CUSTOMER_ID = "TEST_CUSTOMER_ID";
+public class EHoldingsRootProxyImplTest extends WireMockTestBase {
   private static final String ROOT_PROXY_ID = "root-proxy";
   private static final String ROOT_PROXY_TYPE = "rootProxies";
-
-  private static int port;
-  private static String host;
-  
-  @org.junit.Rule
-  public WireMockRule userMockServer = new WireMockRule(
-    WireMockConfiguration.wireMockConfig()
-      .dynamicPort()
-      .notifier(new ConsoleNotifier(true)));
-
-  @BeforeClass
-  public static void setUpClass(final TestContext context) {
-    Vertx vertx = Vertx.vertx();
-    vertx.exceptionHandler(context.exceptionHandler());
-    port = NetworkUtils.nextFreePort();
-    host = "http://localhost";
-
-    DeploymentOptions restVerticleDeploymentOptions = new DeploymentOptions()
-      .setConfig(new JsonObject().put("http.port", port));
-    vertx.deployVerticle(RestVerticle.class.getName(), restVerticleDeploymentOptions, context.asyncAssertSuccess());
-  }
-
-  @Before
-  public void setUp() {
-    RMAPIConfigurationCache.getInstance().invalidate();
-  }
   
   @Test
   public void shouldReturnRootProxyWhenCustIdAndAPIKeyAreValid() throws IOException, URISyntaxException {
@@ -69,8 +39,8 @@ public class EHoldingsRootProxyImplTest {
 
     String expectedRootProxyID = "<n>";
 
-    String wiremockUrl = host + ":" + userMockServer.port();
-    TestUtil.mockConfiguration(configurationStubFile, wiremockUrl);
+    String wiremockUrl = getWiremockUrl();
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
     WireMock.stubFor(
       WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
         .willReturn(new ResponseDefinitionBuilder()
@@ -92,8 +62,8 @@ public class EHoldingsRootProxyImplTest {
   
   @Test
   public void shouldReturnUnauthorizedWhenRMAPIRequestCompletesWith401ErrorStatus() throws IOException, URISyntaxException {
-    String wiremockUrl = host + ":" + userMockServer.port();
-    TestUtil.mockConfiguration(configurationStubFile, wiremockUrl);
+    String wiremockUrl = getWiremockUrl();
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
     WireMock.stubFor(
       WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
         .willReturn(new ResponseDefinitionBuilder().withStatus(401)));
@@ -110,8 +80,8 @@ public class EHoldingsRootProxyImplTest {
   
   @Test
   public void shouldReturnUnauthorizedWhenRMAPIRequestCompletesWith403ErrorStatus() throws IOException, URISyntaxException {
-    String wiremockUrl = host + ":" + userMockServer.port();
-    TestUtil.mockConfiguration(configurationStubFile, wiremockUrl);
+    String wiremockUrl = getWiremockUrl();
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
     WireMock.stubFor(
       WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
         .willReturn(new ResponseDefinitionBuilder().withStatus(403)));
@@ -126,11 +96,97 @@ public class EHoldingsRootProxyImplTest {
       .statusCode(403);
   }
   
-  private RequestSpecification getRequestSpecification() {
-    return TestUtil.getRequestSpecificationBuilder(host + ":" + port)
-      .addHeader(RestConstants.OKAPI_URL_HEADER,   host + ":" + userMockServer.port())
-    .build();
-  }
+  @Test
+  public void shouldReturnUpdatedProxyOnSuccessfulPut() throws IOException, URISyntaxException {
+    String stubResponseFile = "responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-updated-response.json";
 
+    String wiremockUrl = getWiremockUrl();
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
+
+    WireMock.stubFor(
+      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
+        .willReturn(new ResponseDefinitionBuilder().withBody(TestUtil.readFile(stubResponseFile))));
+
+    WireMock.stubFor(
+      WireMock.put(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
+        .willReturn(new ResponseDefinitionBuilder().withStatus(204)));
+
+    ObjectMapper mapper = new ObjectMapper();
+    RootProxyPutRequest rootProxyToBeUpdated = mapper.readValue(TestUtil.getFile("requests/kb-ebsco/put-root-proxy.json"),
+        RootProxyPutRequest.class);
+
+    RootProxy expected = getUpdatedRootProxy();
+    RequestSpecification requestSpecification = getRequestSpecification();
+
+    String updateRootProxyEndpoint = "eholdings/root-proxy";
+
+    RootProxy rootProxy = RestAssured
+      .given()
+      .spec(requestSpecification)
+      .header(CONTENT_TYPE_HEADER)
+      .body(mapper.writeValueAsString(rootProxyToBeUpdated))
+      .when()
+      .put(updateRootProxyEndpoint)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .extract().as(RootProxy.class);
+    
+    assertThat(rootProxy.getData().getId(), equalTo(expected.getData().getId()));
+    assertThat(rootProxy.getData().getType(), equalTo(expected.getData().getType()));
+    assertThat(rootProxy.getData().getAttributes().getId(), equalTo(expected.getData().getAttributes().getId()));
+    assertThat(rootProxy.getData().getAttributes().getProxyTypeId(), equalTo(expected.getData().getAttributes().getProxyTypeId()));
+
+    WireMock.verify(1, putRequestedFor(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
+      .withRequestBody(equalToJson(TestUtil.readFile("requests/rmapi/proxiescustomlabels/put-root-proxy-custom-labels.json"))));
+  }
+  
+  @Test
+  public void shouldReturn400WhenInvalidProxyIDAndRMAPIErrorOnPut() throws IOException, URISyntaxException {
+    String stubGetResponseFile = "responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-updated-response.json";
+    String stubPutResponseFile = "responses/rmapi/proxiescustomlabels/put-root-proxy-custom-labels-400-error-response.json";
+
+    String wiremockUrl = getWiremockUrl();
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
+    
+    WireMock.stubFor(
+        WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
+          .willReturn(new ResponseDefinitionBuilder().withBody(TestUtil.readFile(stubGetResponseFile))));
+
+    WireMock.stubFor(
+      WireMock.put(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
+        .willReturn(new ResponseDefinitionBuilder().withBody(TestUtil.readFile(stubPutResponseFile)).withStatus(400)));
+
+    ObjectMapper mapper = new ObjectMapper();
+    RootProxyPutRequest proxyToBeUpdated = mapper.readValue(TestUtil.getFile("requests/kb-ebsco/put-root-proxy.json"),
+        RootProxyPutRequest.class);
+
+    RequestSpecification requestSpecification = getRequestSpecification();
+
+    String rootProxyEndpoint = "eholdings/root-proxy";
+
+    JsonapiError error = RestAssured
+      .given()
+      .spec(requestSpecification)
+      .header(CONTENT_TYPE_HEADER)
+      .body(mapper.writeValueAsString(proxyToBeUpdated))
+      .when()
+      .put(rootProxyEndpoint)
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST)
+      .extract().as(JsonapiError.class);
+
+    assertThat(error.getErrors().get(0).getTitle(), equalTo("Invalid Proxy ID"));
+  }
+  
+  private RootProxy getUpdatedRootProxy() {
+    return new RootProxy()
+      .withData(new RootProxyData()
+          .withId(ROOT_PROXY_ID)
+          .withType(ROOT_PROXY_TYPE)
+          .withAttributes(new RootProxyDataAttributes()
+              .withId(ROOT_PROXY_ID)
+              .withProxyTypeId("Test-Proxy-ID-123")))
+      .withJsonapi(RestConstants.JSONAPI);
+  }
 }
 

--- a/src/test/java/org/folio/rest/impl/EHoldingsRootProxyImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EHoldingsRootProxyImplTest.java
@@ -1,6 +1,5 @@
 package org.folio.rest.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
@@ -14,7 +13,6 @@ import org.folio.rest.jaxrs.model.JsonapiError;
 import org.folio.rest.jaxrs.model.RootProxy;
 import org.folio.rest.jaxrs.model.RootProxyData;
 import org.folio.rest.jaxrs.model.RootProxyDataAttributes;
-import org.folio.rest.jaxrs.model.RootProxyPutRequest;
 import org.folio.rest.util.RestConstants;
 import org.folio.util.TestUtil;
 import org.junit.Test;
@@ -111,10 +109,6 @@ public class EHoldingsRootProxyImplTest extends WireMockTestBase {
       WireMock.put(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
         .willReturn(new ResponseDefinitionBuilder().withStatus(204)));
 
-    ObjectMapper mapper = new ObjectMapper();
-    RootProxyPutRequest rootProxyToBeUpdated = mapper.readValue(TestUtil.getFile("requests/kb-ebsco/put-root-proxy.json"),
-        RootProxyPutRequest.class);
-
     RootProxy expected = getUpdatedRootProxy();
     RequestSpecification requestSpecification = getRequestSpecification();
 
@@ -124,7 +118,7 @@ public class EHoldingsRootProxyImplTest extends WireMockTestBase {
       .given()
       .spec(requestSpecification)
       .header(CONTENT_TYPE_HEADER)
-      .body(mapper.writeValueAsString(rootProxyToBeUpdated))
+      .body(TestUtil.readFile("requests/kb-ebsco/put-root-proxy.json"))
       .when()
       .put(updateRootProxyEndpoint)
       .then()
@@ -156,10 +150,6 @@ public class EHoldingsRootProxyImplTest extends WireMockTestBase {
       WireMock.put(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
         .willReturn(new ResponseDefinitionBuilder().withBody(TestUtil.readFile(stubPutResponseFile)).withStatus(400)));
 
-    ObjectMapper mapper = new ObjectMapper();
-    RootProxyPutRequest proxyToBeUpdated = mapper.readValue(TestUtil.getFile("requests/kb-ebsco/put-root-proxy.json"),
-        RootProxyPutRequest.class);
-
     RequestSpecification requestSpecification = getRequestSpecification();
 
     String rootProxyEndpoint = "eholdings/root-proxy";
@@ -168,7 +158,7 @@ public class EHoldingsRootProxyImplTest extends WireMockTestBase {
       .given()
       .spec(requestSpecification)
       .header(CONTENT_TYPE_HEADER)
-      .body(mapper.writeValueAsString(proxyToBeUpdated))
+      .body(TestUtil.readFile("requests/kb-ebsco/put-root-proxy.json"))
       .when()
       .put(rootProxyEndpoint)
       .then()

--- a/src/test/java/org/folio/rest/validator/RootProxyPutBodyValidatorTest.java
+++ b/src/test/java/org/folio/rest/validator/RootProxyPutBodyValidatorTest.java
@@ -1,0 +1,34 @@
+package org.folio.rest.validator;
+
+import org.folio.rest.exception.InputValidationException;
+import org.folio.rest.jaxrs.model.RootProxyDataAttributes;
+import org.folio.rest.jaxrs.model.RootProxyPutData;
+import org.folio.rest.jaxrs.model.RootProxyPutRequest;
+import org.junit.Test;
+
+public class RootProxyPutBodyValidatorTest {
+  private final RootProxyPutBodyValidator validator = new RootProxyPutBodyValidator();
+  
+  @Test(expected = InputValidationException.class)
+  public void shouldThrowExceptionWhenProxyTypeIdIsNull() {
+    
+    RootProxyPutRequest request = new RootProxyPutRequest()
+        .withData(new RootProxyPutData().withAttributes(new RootProxyDataAttributes().withProxyTypeId(null)));
+    validator.validate(request);
+  }
+
+  @Test
+  public void shouldNotThrowExceptionWhenProxyTypeIdIsSomeNonNullValue() {
+    RootProxyPutRequest request = new RootProxyPutRequest()
+        .withData(new RootProxyPutData().withAttributes(new RootProxyDataAttributes().withProxyTypeId("hello")));
+    validator.validate(request);
+  }
+
+  @Test
+  public void shouldNotThrowExceptionWhenProxyTypeIdIsEmptyString() {
+    RootProxyPutRequest request = new RootProxyPutRequest()
+        .withData(new RootProxyPutData().withAttributes(new RootProxyDataAttributes().withProxyTypeId("")));
+    validator.validate(request);
+  }
+}
+

--- a/src/test/resources/requests/kb-ebsco/put-root-proxy.json
+++ b/src/test/resources/requests/kb-ebsco/put-root-proxy.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "id": "root-proxy",
+    "type": "rootProxies",
+    "attributes": {
+      "id": "root-proxy",
+      "proxyTypeId": "Test-Proxy-ID-123"
+    }
+  }
+}

--- a/src/test/resources/requests/rmapi/proxiescustomlabels/put-root-proxy-custom-labels.json
+++ b/src/test/resources/requests/rmapi/proxiescustomlabels/put-root-proxy-custom-labels.json
@@ -1,0 +1,38 @@
+{
+  "proxy": {
+    "id": "Test-Proxy-ID-123",
+    "inherited": null
+  },
+  "labels": [
+    {
+      "id": 1,
+      "displayLabel": "label 1",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": false
+    },
+    {
+      "id": 2,
+      "displayLabel": "label 2",
+      "displayOnFullTextFinder": true,
+      "displayOnPublicationFinder": true
+    },
+    {
+      "id": 3,
+      "displayLabel": "label 3",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": true
+    },
+    {
+      "id": 4,
+      "displayLabel": "label 4",
+      "displayOnFullTextFinder": true,
+      "displayOnPublicationFinder": false
+    },
+    {
+      "id": 5,
+      "displayLabel": "label 5",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": false
+    }
+  ]
+}

--- a/src/test/resources/responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-updated-response.json
+++ b/src/test/resources/responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-updated-response.json
@@ -1,0 +1,37 @@
+{
+  "proxy": {
+    "id": "Test-Proxy-ID-123"
+  },
+  "labels": [
+    {
+      "id": 1,
+      "displayLabel": "label 1",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": false
+    },
+    {
+      "id": 2,
+      "displayLabel": "label 2",
+      "displayOnFullTextFinder": true,
+      "displayOnPublicationFinder": true
+    },
+    {
+      "id": 3,
+      "displayLabel": "label 3",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": true
+    },
+    {
+      "id": 4,
+      "displayLabel": "label 4",
+      "displayOnFullTextFinder": true,
+      "displayOnPublicationFinder": false
+    },
+    {
+      "id": 5,
+      "displayLabel": "label 5",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": false
+    }
+  ]
+}

--- a/src/test/resources/responses/rmapi/proxiescustomlabels/put-root-proxy-custom-labels-400-error-response.json
+++ b/src/test/resources/responses/rmapi/proxiescustomlabels/put-root-proxy-custom-labels-400-error-response.json
@@ -1,0 +1,9 @@
+{
+  "errors": [
+    {
+      "code": 1006,
+      "subCode": 0,
+      "message": "Invalid Proxy ID"
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-95, we are supposed to implement `PUT /eholdings/root-proxy`. This PR addresses that.

## Approach
- Add support for updating root proxy by implementing PUT /eholdings/root-proxy
- Add associated unit tests
- Add associated permissions in module descriptor

## Screenshots
![put_proxy_id](https://user-images.githubusercontent.com/33662516/48644001-4884a000-e9af-11e8-85ba-f94fc9254614.gif)
