### PR TITLE
Fix issue with PUT /eholdings/root-proxy

### DIFF
--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -14,6 +14,8 @@ import org.folio.rest.jaxrs.model.RootProxyPutRequest;
 import org.folio.rest.model.PackageId;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.folio.rest.model.Sort;
 import org.folio.rmapi.builder.PackagesFilterableUrlBuilder;
@@ -23,6 +25,7 @@ import org.folio.rmapi.exception.RMAPIResourceNotFoundException;
 import org.folio.rmapi.exception.RMAPIResultsProcessingException;
 import org.folio.rmapi.exception.RMAPIServiceException;
 import org.folio.rmapi.exception.RMAPIUnAuthorizedException;
+import org.folio.rmapi.model.CustomLabel;
 import org.folio.rmapi.model.PackageData;
 import org.folio.rmapi.model.PackageSelectedPayload;
 import org.folio.rmapi.model.Title;
@@ -266,6 +269,13 @@ public class RMAPIService {
     org.folio.rmapi.model.Proxy proxyRMAPI = new org.folio.rmapi.model.Proxy();   
     proxyRMAPI.setId(rootProxyPutRequest.getData().getAttributes().getProxyTypeId());
     rootProxyCustomLabels.setProxy(proxyRMAPI);
+    /* In RM API - custom labels and root proxy are updated using the same PUT endpoint.
+     * We are GETting the object containing both, updating the root proxy with the new one and making a PUT request to RM API.
+     * One gotcha here is that we have to prune custom labels in PUT request to not include any that have displayLabel = '' since RM API
+     * gives a 400 Bad Request if we send them along as part of the update. Hence, the step below.
+     */
+    List<CustomLabel> filteredCustomLabelList = rootProxyCustomLabels.getLabelList().stream().filter(item -> !item.getDisplayLabel().isEmpty()).collect((Collectors.toList()));
+    rootProxyCustomLabels.setLabelList(filteredCustomLabelList);
     return this.putRequest(constructURL(path), rootProxyCustomLabels).thenCompose(updatedRootProxy -> this.retrieveRootProxyCustomLabels());
   }
 

--- a/src/test/resources/requests/rmapi/proxiescustomlabels/put-root-proxy-custom-labels-without-empty-display-labels.json
+++ b/src/test/resources/requests/rmapi/proxiescustomlabels/put-root-proxy-custom-labels-without-empty-display-labels.json
@@ -1,0 +1,14 @@
+{
+  "proxy": {
+    "id": "Test-Proxy-ID-123",
+    "inherited": null
+  },
+  "labels": [
+    {
+      "id": 1,
+      "displayLabel": "label 1",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": false
+    }
+  ]
+}

--- a/src/test/resources/responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-with-empty-labels-success-response.json
+++ b/src/test/resources/responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-with-empty-labels-success-response.json
@@ -1,0 +1,37 @@
+{
+  "proxy": {
+    "id": "Test-Proxy-ID-123"
+  },
+  "labels": [
+    {
+      "id": 1,
+      "displayLabel": "label 1",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": false
+    },
+    {
+      "id": 2,
+      "displayLabel": "",
+      "displayOnFullTextFinder": true,
+      "displayOnPublicationFinder": true
+    },
+    {
+      "id": 3,
+      "displayLabel": "",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": true
+    },
+    {
+      "id": 4,
+      "displayLabel": "",
+      "displayOnFullTextFinder": true,
+      "displayOnPublicationFinder": false
+    },
+    {
+      "id": 5,
+      "displayLabel": "",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": false
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
During manual testing, identified an issue with the existing implementation of PUT /eholdings/root-proxy code.  Modify code accordingly to fix the issue. 

## Approach
- RM API uses the same endpoint for a PUT request to /{custID} for updating both root proxies and custom labels
- We make a GET call to get root proxy and custom labels and update root proxy with the new one submitted by user, and we have to filter custom labels that we get to not contain any custom labels that have empty string for "displayLabel" because RM API gives a 400 Bad Request when we try to update custom labels with empty string.
- Filter out those custom labels that we get with empty display labels before making the PUT request to RM API to avoid the 400 from RM API
- Confirmed that Ruby code does the same.
- Add unit test
