### PR TITLE
MODKBEKBJ-31: GET resource by resourceId

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -58,7 +58,8 @@
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/eholdings/resources/{resourceId}"
+          "pathPattern": "/eholdings/resources/{resourceId}",
+          "permissionsRequired": ["kb-ebsco.resource.get"]
         },
         {
           "methods": ["PUT"],
@@ -156,6 +157,11 @@
       "description": "Get titles"
     },
     {
+      "permissionName": "kb-ebsco.resource.get",
+      "displayName": "get single resource",
+      "description": "Get single resource"
+    },
+    {
       "permissionName": "kb-ebsco.packageCollection.get",
       "displayName": "get packages",
       "description": "Get packages"
@@ -197,6 +203,7 @@
         "kb-ebsco.title.get",
         "kb-ebsco.titleCollection.get",
         "kb-ebsco.package.get",
+        "kb-ebsco.resource.get",
         "kb-ebsco.root-proxy.get",
         "kb-ebsco.root-proxy.put"
       ]

--- a/ramls/types/publicationType.json
+++ b/ramls/types/publicationType.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Publication Type schema",
   "description": "Publication Type schema",
-  "javaType": "org.folio.rest.jaxrs.model.TitlePublicationType",
+  "javaType": "org.folio.rest.jaxrs.model.PublicationType",
   "type": "string",
   "additionalProperties": false,
       "enum": [

--- a/ramls/types/resources/resourceDataAttributes.json
+++ b/ramls/types/resources/resourceDataAttributes.json
@@ -63,23 +63,7 @@
     "publicationType": {
       "type": "string",
       "description": "Publication type. Note that this attribute can be updated ONLY FOR A CUSTOM RESOURCE.",
-      "enum": [
-        "Audiobook",
-        "Book",
-        "Book Series",
-        "Database",
-        "Journal",
-        "Newsletter",
-        "Newspaper",
-        "Proceedings",
-        "Report",
-        "Streaming Audio",
-        "Streaming Video",
-        "Thesis & Dissertation",
-        "Website",
-        "Unspecified"
-      ],
-      "example": "Journal"
+      "$ref": "../publicationType.json"
     },
     "subjects": {
       "type": "array",

--- a/src/main/java/org/folio/rest/converter/CommonAttributesConverter.java
+++ b/src/main/java/org/folio/rest/converter/CommonAttributesConverter.java
@@ -1,12 +1,58 @@
 package org.folio.rest.converter;
 
+import java.util.Objects;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.folio.rest.jaxrs.model.TitleContributors;
+import org.folio.rest.jaxrs.model.TitleIdentifier;
+import org.folio.rest.jaxrs.model.TitleSubject;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.rest.jaxrs.model.Coverage;
+import org.folio.rest.jaxrs.model.PublicationType;
 import org.folio.rest.jaxrs.model.Token;
+import org.folio.rmapi.model.CoverageDates;
+import org.folio.rmapi.model.EmbargoPeriod;
+import org.folio.rmapi.model.Identifier;
+import org.folio.rmapi.model.Subject;
+import org.folio.rmapi.model.VisibilityInfo;
 import org.folio.rmapi.model.TokenInfo;
 
-import java.util.Objects;
-
 public class CommonAttributesConverter {
+  
+  private static final Map<Integer, String> IDENTIFIER_TYPES = new HashMap<>();
+  static {
+    IDENTIFIER_TYPES.put(0,"ISSN");
+    IDENTIFIER_TYPES.put(1,"ISBN");
+  }
 
+  private static final Map<Integer, String> IDENTIFIER_SUBTYPES = new HashMap<>();
+  static {
+    IDENTIFIER_SUBTYPES.put(1,"Print");
+    IDENTIFIER_SUBTYPES.put(2,"Online");
+  }
+  
+  static final Map<String, PublicationType> publicationTypes = new HashMap<>();
+  static {
+    publicationTypes.put("audiobook", PublicationType.AUDIOBOOK);
+    publicationTypes.put("book", PublicationType.BOOK);
+    publicationTypes.put("bookseries", PublicationType.BOOK_SERIES);
+    publicationTypes.put("database", PublicationType.DATABASE);
+    publicationTypes.put("journal", PublicationType.JOURNAL);
+    publicationTypes.put("newsletter", PublicationType.NEWSLETTER);
+    publicationTypes.put("newspaper", PublicationType.NEWSPAPER);
+    publicationTypes.put("proceedings", PublicationType.PROCEEDINGS);
+    publicationTypes.put("report", PublicationType.REPORT);
+    publicationTypes.put("streamingaudio", PublicationType.STREAMING_AUDIO);
+    publicationTypes.put("streamingvideo", PublicationType.STREAMING_VIDEO);
+    publicationTypes.put("thesisdissertation", PublicationType.THESIS_DISSERTATION);
+    publicationTypes.put("website", PublicationType.WEBSITE);
+    publicationTypes.put("unspecified", PublicationType.UNSPECIFIED);
+  }
+  
   public Token convertToken(TokenInfo tokenInfo) {
     if(Objects.isNull(tokenInfo)){
       return null;
@@ -16,5 +62,64 @@ public class CommonAttributesConverter {
       .withHelpText(tokenInfo.getHelpText())
       .withPrompt(tokenInfo.getPrompt())
       .withValue(tokenInfo.getValue() == null ? null : (String) tokenInfo.getValue());
+  }
+  
+  public List<TitleContributors> convertContributors(List<org.folio.rmapi.model.Contributor> contributorList) {
+    return contributorList.stream().map(contributor ->
+      new TitleContributors()
+      .withContributor(contributor.getTitleContributor())
+      .withType(StringUtils.capitalize(contributor.getType()))
+      )
+      .collect(Collectors.toList());
+  }
+  
+  public List<TitleIdentifier> convertIdentifiers(List<Identifier> identifiersList) {
+    return identifiersList.stream()
+      .filter(identifier -> IDENTIFIER_TYPES.keySet().contains(identifier.getType()) && IDENTIFIER_SUBTYPES.keySet().contains(identifier.getSubtype()))
+      .sorted(Comparator.comparing(Identifier::getType).thenComparing(Identifier::getSubtype))
+      .map(identifier -> new TitleIdentifier()
+                          .withId(identifier.getId())
+                          .withType(IDENTIFIER_TYPES.getOrDefault(identifier.getType(), ""))
+                          .withSubtype(IDENTIFIER_SUBTYPES.getOrDefault(identifier.getSubtype(), "")))
+      .collect(Collectors.toList());
+  }
+  
+  public List<TitleSubject> convertSubjects(List<Subject> subjectsList) {
+    return subjectsList.stream().map(subject ->
+      new TitleSubject()
+      .withSubject(subject.getSubject())
+      .withType(subject.getType())
+      )
+      .collect(Collectors.toList());
+  }
+
+  public org.folio.rest.jaxrs.model.EmbargoPeriod convertEmbargo(EmbargoPeriod customEmbargoPeriod) {
+    org.folio.rest.jaxrs.model.EmbargoPeriod customEmbargo = new org.folio.rest.jaxrs.model.EmbargoPeriod();
+    customEmbargo.setEmbargoUnit(customEmbargoPeriod.getEmbargoUnit());
+    customEmbargo.setEmbargoValue(customEmbargoPeriod.getEmbargoValue());
+    return customEmbargo;
+  }
+
+  public org.folio.rest.jaxrs.model.VisibilityData convertVisibilityData(VisibilityInfo visibilityData) {
+    org.folio.rest.jaxrs.model.VisibilityData visibility = new org.folio.rest.jaxrs.model.VisibilityData();
+    visibility.setIsHidden(visibilityData.getHidden());
+    visibility.setReason(visibilityData.getReason().equals("Hidden by EP") ? "Set by system" : "");
+    return visibility;
+  }
+
+  public List<Coverage> convertCoverages(List<CoverageDates> coverageList) {
+    return coverageList.stream().map(coverageItem ->
+    new Coverage()
+      .withBeginCoverage(coverageItem.getBeginCoverage())
+      .withEndCoverage(coverageItem.getEndCoverage())
+    )
+    .collect(Collectors.toList());
+  }
+
+  public org.folio.rest.jaxrs.model.Proxy convertProxy(org.folio.rmapi.model.Proxy proxy) {
+    org.folio.rest.jaxrs.model.Proxy p = new org.folio.rest.jaxrs.model.Proxy();
+    p.setId(proxy.getId());
+    p.setInherited(proxy.getInherited());
+    return p;
   }
 }

--- a/src/main/java/org/folio/rest/converter/ResourcesConverter.java
+++ b/src/main/java/org/folio/rest/converter/ResourcesConverter.java
@@ -1,0 +1,75 @@
+package org.folio.rest.converter;
+
+import org.folio.rest.jaxrs.model.MetaDataIncluded;
+import org.folio.rest.jaxrs.model.MetaIncluded;
+import org.folio.rest.jaxrs.model.Resource;
+import org.folio.rest.jaxrs.model.ResourceCollectionItem;
+import org.folio.rest.jaxrs.model.ResourceDataAttributes;
+import org.folio.rest.jaxrs.model.ResourceRelationships;
+import org.folio.rest.util.RestConstants;
+import org.folio.rmapi.model.CustomerResources;
+import org.folio.rmapi.model.Title;
+
+public class ResourcesConverter {
+  
+  private static final ResourceRelationships EMPTY_RELATIONSHIPS = new ResourceRelationships()
+      .withProvider(new MetaIncluded().withMeta(
+        new MetaDataIncluded()
+          .withIncluded(false)))
+      .withPackage(new MetaIncluded().withMeta(
+          new MetaDataIncluded()
+            .withIncluded(false)))
+      .withTitle(new MetaIncluded().withMeta(
+          new MetaDataIncluded()
+            .withIncluded(false)));    
+
+  private CommonAttributesConverter commonConverter;
+  
+  public ResourcesConverter() {
+    this(new CommonAttributesConverter());
+  }
+  
+  public ResourcesConverter(CommonAttributesConverter commonConverter) {
+    this.commonConverter = commonConverter;
+  }
+
+  public Resource convertFromRMAPIResource(Title title) {
+    CustomerResources resource = title.getCustomerResourcesList().get(0);
+    return new org.folio.rest.jaxrs.model.Resource()
+        .withData(new ResourceCollectionItem()
+          .withId(String.valueOf(resource.getVendorId() + "-" + resource.getPackageId() + "-" + resource.getTitleId()))
+          .withType(ResourceCollectionItem.Type.RESOURCES)
+          .withAttributes(new ResourceDataAttributes()
+            .withDescription(title.getDescription())
+            .withEdition(title.getEdition())
+            .withIsPeerReviewed(title.getPeerReviewed())
+            .withIsTitleCustom(title.getTitleCustom())
+            .withPublisherName(title.getPublisherName())
+            .withTitleId(title.getTitleId())
+            .withContributors(commonConverter.convertContributors(title.getContributorsList()))
+            .withIdentifiers(commonConverter.convertIdentifiers(title.getIdentifiersList()))
+            .withName(title.getTitleName())
+            .withPublicationType(CommonAttributesConverter.publicationTypes.get(title.getPubType().toLowerCase()))
+            .withSubjects(commonConverter.convertSubjects(title.getSubjectsList()))
+            .withCoverageStatement(resource.getCoverageStatement())
+            .withCustomEmbargoPeriod(commonConverter.convertEmbargo(resource.getCustomEmbargoPeriod()))
+            .withIsPackageCustom(resource.getPackageCustom())
+            .withIsSelected(resource.getSelected())
+            .withIsTokenNeeded(resource.getTokenNeeded())
+            .withLocationId(resource.getLocationId())
+            .withManagedEmbargoPeriod(commonConverter.convertEmbargo(resource.getManagedEmbargoPeriod()))
+            .withPackageId(String.valueOf(resource.getVendorId() + "-" + resource.getPackageId()))
+            .withPackageName(resource.getPackageName())
+            .withUrl(resource.getUrl())
+            .withProviderId(resource.getVendorId())
+            .withProviderName(resource.getVendorName())
+            .withVisibilityData(commonConverter.convertVisibilityData(resource.getVisibilityData()))
+            .withManagedCoverages(commonConverter.convertCoverages(resource.getManagedCoverageList()))
+            .withCustomCoverages(commonConverter.convertCoverages(resource.getCustomCoverageList()))
+            .withProxy(commonConverter.convertProxy(resource.getProxy())))
+          .withRelationships(EMPTY_RELATIONSHIPS)
+          )
+        .withIncluded(null)
+        .withJsonapi(RestConstants.JSONAPI);
+  }
+}

--- a/src/main/java/org/folio/rest/converter/TitleConverter.java
+++ b/src/main/java/org/folio/rest/converter/TitleConverter.java
@@ -1,9 +1,6 @@
 package org.folio.rest.converter;
 
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.folio.rest.jaxrs.model.Data;
@@ -12,53 +9,27 @@ import org.folio.rest.jaxrs.model.MetaIncluded;
 import org.folio.rest.jaxrs.model.MetaTotalResults;
 import org.folio.rest.jaxrs.model.TitleAttributes;
 import org.folio.rest.jaxrs.model.TitleCollection;
-import org.folio.rest.jaxrs.model.TitleContributors;
-import org.folio.rest.jaxrs.model.TitleIdentifier;
 import org.folio.rest.jaxrs.model.TitleListDataAttributes;
-import org.folio.rest.jaxrs.model.TitlePublicationType;
 import org.folio.rest.jaxrs.model.TitleRelationship;
-import org.folio.rest.jaxrs.model.TitleSubject;
 import org.folio.rest.util.RestConstants;
-import org.folio.rmapi.model.Identifier;
-import org.folio.rmapi.model.Subject;
 import org.folio.rmapi.model.Title;
 import org.folio.rmapi.model.Titles;
 
 public class TitleConverter {
+  
+  private CommonAttributesConverter commonConverter;
 
   private static final TitleRelationship EMPTY_RESOURCES_RELATIONSHIP = new TitleRelationship()
     .withResources(new MetaIncluded().withMeta(
       new MetaDataIncluded()
         .withIncluded(false)));
 
-  private static final Map<String, TitlePublicationType> publicationTypes = new HashMap<>();
-  static {
-    publicationTypes.put("audiobook", TitlePublicationType.AUDIOBOOK);
-    publicationTypes.put("book", TitlePublicationType.BOOK);
-    publicationTypes.put("bookseries", TitlePublicationType.BOOK_SERIES);
-    publicationTypes.put("database", TitlePublicationType.DATABASE);
-    publicationTypes.put("journal", TitlePublicationType.JOURNAL);
-    publicationTypes.put("newsletter", TitlePublicationType.NEWSLETTER);
-    publicationTypes.put("newspaper", TitlePublicationType.NEWSPAPER);
-    publicationTypes.put("proceedings", TitlePublicationType.PROCEEDINGS);
-    publicationTypes.put("report", TitlePublicationType.REPORT);
-    publicationTypes.put("streamingaudio", TitlePublicationType.STREAMING_AUDIO);
-    publicationTypes.put("streamingvideo", TitlePublicationType.STREAMING_VIDEO);
-    publicationTypes.put("thesisdissertation", TitlePublicationType.THESIS_DISSERTATION);
-    publicationTypes.put("website", TitlePublicationType.WEBSITE);
-    publicationTypes.put("unspecified", TitlePublicationType.UNSPECIFIED);
+  public TitleConverter() {
+    this(new CommonAttributesConverter());
   }
-
-  private static final Map<Integer, String> IDENTIFIER_TYPES = new HashMap<>();
-  static {
-    IDENTIFIER_TYPES.put(0,"ISSN");
-    IDENTIFIER_TYPES.put(1,"ISBN");
-  }
-
-  private static final Map<Integer, String> IDENTIFIER_SUBTYPES = new HashMap<>();
-  static {
-    IDENTIFIER_SUBTYPES.put(1,"Print");
-    IDENTIFIER_SUBTYPES.put(2,"Online");
+  
+  public TitleConverter(CommonAttributesConverter commonConverter) {
+    this.commonConverter = commonConverter;
   }
 
   public TitleCollection convert(Titles titles) {
@@ -80,11 +51,11 @@ public class TitleConverter {
                 .withName(rmapiTitle.getTitleName())
                 .withPublisherName(rmapiTitle.getPublisherName())
                 .withIsTitleCustom(rmapiTitle.getTitleCustom())
-                .withPublicationType(publicationTypes.get(rmapiTitle.getPubType().toLowerCase()))
-                .withSubjects(convertSubjects(rmapiTitle.getSubjectsList()))
-                .withIdentifiers(convertIdentifiers(rmapiTitle.getIdentifiersList()))
+                .withPublicationType(CommonAttributesConverter.publicationTypes.get(rmapiTitle.getPubType().toLowerCase()))
+                .withSubjects(commonConverter.convertSubjects(rmapiTitle.getSubjectsList()))
+                .withIdentifiers(commonConverter.convertIdentifiers(rmapiTitle.getIdentifiersList()))
                 .withEdition(rmapiTitle.getEdition())
-                .withContributors(convertContributors(rmapiTitle.getContributorsList()))
+                .withContributors(commonConverter.convertContributors(rmapiTitle.getContributorsList()))
                 .withDescription(rmapiTitle.getDescription())
                 .withIsPeerReviewed(rmapiTitle.getPeerReviewed())
                 )
@@ -103,38 +74,8 @@ public class TitleConverter {
         .withName(title.getTitleName())
         .withPublisherName(title.getPublisherName())
         .withIsTitleCustom(title.getTitleCustom())
-        .withPublicationType(publicationTypes.get(title.getPubType().toLowerCase()))
-        .withSubjects(convertSubjects(title.getSubjectsList()))
-        .withIdentifiers(convertIdentifiers(title.getIdentifiersList())));
+        .withPublicationType(CommonAttributesConverter.publicationTypes.get(title.getPubType().toLowerCase()))
+        .withSubjects(commonConverter.convertSubjects(title.getSubjectsList()))
+        .withIdentifiers(commonConverter.convertIdentifiers(title.getIdentifiersList())));
   }
-
-  private List<TitleSubject> convertSubjects(List<Subject> subjectsList) {
-    return subjectsList.stream().map(subject ->
-      new TitleSubject()
-      .withSubject(subject.getSubject())
-      .withType(subject.getType())
-      )
-      .collect(Collectors.toList());
-  }
-
-  private List<TitleIdentifier> convertIdentifiers(List<Identifier> identifiersList) {
-    return identifiersList.stream()
-      .filter(identifier -> IDENTIFIER_TYPES.keySet().contains(identifier.getType()) && IDENTIFIER_SUBTYPES.keySet().contains(identifier.getSubtype()))
-      .sorted(Comparator.comparing(Identifier::getType).thenComparing(Identifier::getSubtype))
-      .map(identifier -> new TitleIdentifier()
-                          .withId(identifier.getId())
-                          .withType(IDENTIFIER_TYPES.getOrDefault(identifier.getType(), ""))
-                          .withSubtype(IDENTIFIER_SUBTYPES.getOrDefault(identifier.getSubtype(), "")))
-      .collect(Collectors.toList());
-  }
-
-  private List<TitleContributors> convertContributors(List<org.folio.rmapi.model.Contributor> contributorList) {
-    return contributorList.stream().map(contributor ->
-      new TitleContributors()
-      .withContributor(contributor.getTitleContributor())
-      .withType(contributor.getType())
-      )
-      .collect(Collectors.toList());
-  }
-
 }

--- a/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
@@ -10,18 +10,15 @@ import java.util.regex.Pattern;
 import javax.validation.ValidationException;
 import javax.ws.rs.core.Response;
 
-import org.apache.http.HttpStatus;
 import org.folio.config.RMAPIConfigurationServiceCache;
 import org.folio.config.RMAPIConfigurationServiceImpl;
 import org.folio.config.api.RMAPIConfigurationService;
 import org.folio.http.ConfigurationClientProvider;
 import org.folio.rest.aspect.HandleValidationErrors;
 import org.folio.rest.converter.ResourcesConverter;
-import org.folio.rest.exception.InputValidationException;
 import org.folio.rest.jaxrs.model.ResourcePostRequest;
 import org.folio.rest.jaxrs.model.ResourcePutRequest;
 import org.folio.rest.jaxrs.resource.EholdingsResources;
-import org.folio.rest.jaxrs.resource.EholdingsProviders.GetEholdingsProvidersByProviderIdResponse;
 import org.folio.rest.model.OkapiData;
 import org.folio.rest.model.ResourceId;
 import org.folio.rest.util.ErrorHandler;
@@ -29,7 +26,6 @@ import org.folio.rest.util.ErrorUtil;
 import org.folio.rest.validator.HeaderValidator;
 import org.folio.rmapi.RMAPIService;
 import org.folio.rmapi.exception.RMAPIResourceNotFoundException;
-import org.folio.rmapi.exception.RMAPIServiceException;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -45,8 +41,6 @@ public class EholdingsResourcesImpl implements EholdingsResources{
   private static final Pattern RESOURCE_ID_PATTERN = Pattern.compile(RESOURCE_ID_REGEX);
   private static final String RESOURCE_ID_INVALID_ERROR = "Resource id is invalid";
   private static final String RESOURCE_NOT_FOUND_MESSAGE = "Resource not found";
-  private static final String CONTENT_TYPE_HEADER = "Content-Type";
-  private static final String CONTENT_TYPE_VALUE = "application/vnd.api+json";
   
   private final Logger logger = LoggerFactory.getLogger(EholdingsResourcesImpl.class);
   

--- a/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
@@ -1,0 +1,154 @@
+package org.folio.rest.impl;
+
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.validation.ValidationException;
+import javax.ws.rs.core.Response;
+
+import org.apache.http.HttpStatus;
+import org.folio.config.RMAPIConfigurationServiceCache;
+import org.folio.config.RMAPIConfigurationServiceImpl;
+import org.folio.config.api.RMAPIConfigurationService;
+import org.folio.http.ConfigurationClientProvider;
+import org.folio.rest.aspect.HandleValidationErrors;
+import org.folio.rest.converter.ResourcesConverter;
+import org.folio.rest.exception.InputValidationException;
+import org.folio.rest.jaxrs.model.ResourcePostRequest;
+import org.folio.rest.jaxrs.model.ResourcePutRequest;
+import org.folio.rest.jaxrs.resource.EholdingsResources;
+import org.folio.rest.model.OkapiData;
+import org.folio.rest.model.ResourceId;
+import org.folio.rest.util.ErrorUtil;
+import org.folio.rest.validator.HeaderValidator;
+import org.folio.rmapi.RMAPIService;
+import org.folio.rmapi.exception.RMAPIResourceNotFoundException;
+import org.folio.rmapi.exception.RMAPIServiceException;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+
+public class EholdingsResourcesImpl implements EholdingsResources{
+  
+  private static final String RESOURCE_ID_REGEX = "([^-]+)-([^-]+)-([^-]+)";
+  private static final Pattern RESOURCE_ID_PATTERN = Pattern.compile(RESOURCE_ID_REGEX);
+  private static final String RESOURCE_ID_INVALID_ERROR = "Resource id is invalid";
+  private static final String RESOURCE_NOT_FOUND_MESSAGE = "Resource not found";
+  private static final String CONTENT_TYPE_HEADER = "Content-Type";
+  private static final String CONTENT_TYPE_VALUE = "application/vnd.api+json";
+  
+  private final Logger logger = LoggerFactory.getLogger(EholdingsResourcesImpl.class);
+  
+  private RMAPIConfigurationService configurationService;
+  private HeaderValidator headerValidator;
+  private ResourcesConverter converter;
+  
+  public EholdingsResourcesImpl() {
+    this(
+      new RMAPIConfigurationServiceCache(
+        new RMAPIConfigurationServiceImpl(new ConfigurationClientProvider())),
+      new HeaderValidator(),
+      new ResourcesConverter());
+  }
+  
+  public EholdingsResourcesImpl(RMAPIConfigurationService configurationService,
+      HeaderValidator headerValidator,
+      ResourcesConverter converter) {
+    this.configurationService = configurationService;
+    this.headerValidator = headerValidator;
+    this.converter = converter;
+}
+
+  @Override
+  public void postEholdingsResources(String contentType, ResourcePostRequest entity, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.succeededFuture(PostEholdingsResourcesResponse.status(Response.Status.NOT_IMPLEMENTED).build()));
+    
+  }
+
+  @Override
+  @HandleValidationErrors
+  public void getEholdingsResourcesByResourceId(String resourceId, String include, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    ResourceId parsedResourceId = parseResourceId(resourceId);
+    headerValidator.validate(okapiHeaders);
+    
+    CompletableFuture.completedFuture(null)
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(rmapiConfiguration -> {
+        RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
+          rmapiConfiguration.getUrl(), vertxContext.owner());
+        return rmapiService.retrieveResource(parsedResourceId);
+    })
+    .thenAccept(title ->
+      asyncResultHandler.handle(Future.succeededFuture(GetEholdingsResourcesByResourceIdResponse
+        .respond200WithApplicationVndApiJson(converter.convertFromRMAPIResource(title)))))
+    .exceptionally(e -> {
+      logger.error(INTERNAL_SERVER_ERROR, e);
+      if (e.getCause() instanceof RMAPIResourceNotFoundException) {
+        asyncResultHandler.handle(Future.succeededFuture(GetEholdingsResourcesByResourceIdResponse
+          .respond404WithApplicationVndApiJson(ErrorUtil.createError(RESOURCE_NOT_FOUND_MESSAGE))));
+      } else if (e.getCause() instanceof RMAPIServiceException) {
+          RMAPIServiceException rmApiException = (RMAPIServiceException) e.getCause();
+          asyncResultHandler.handle(Future.succeededFuture(
+              Response.status(rmApiException.getRMAPICode()).header(CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE)
+                  .entity(ErrorUtil.createErrorFromRMAPIResponse(rmApiException)).build()));
+      } else if (e.getCause() instanceof InputValidationException) {
+        InputValidationException inputValidationException = (InputValidationException) e.getCause();
+        asyncResultHandler.handle(Future.succeededFuture(
+            GetEholdingsResourcesByResourceIdResponse.respond400WithApplicationVndApiJson(
+            ErrorUtil.createError(inputValidationException.getMessage(), inputValidationException.getMessageDetail()))));
+      } else {
+        asyncResultHandler.handle(Future.succeededFuture(GetEholdingsResourcesByResourceIdResponse
+          .status(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+          .header(CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE)
+          .entity(ErrorUtil.createError(e.getCause().getMessage()))
+          .build()));
+      }
+      return null;
+    });
+  }
+
+  private ResourceId parseResourceId(String resourceIdString) {
+    try {
+      long providerId;
+      long packageId;
+      long titleId;
+      
+      Matcher matcher = RESOURCE_ID_PATTERN.matcher(resourceIdString);
+      
+      if(matcher.find() && matcher.hitEnd()) {
+        providerId = Long.parseLong(matcher.group(1));
+        packageId = Long.parseLong(matcher.group(2));
+        titleId = Long.parseLong(matcher.group(3));
+      } else {
+        throw new ValidationException(RESOURCE_ID_INVALID_ERROR );
+      }
+      
+      return new ResourceId(providerId, packageId, titleId);
+    } catch (NumberFormatException e) {
+      throw new ValidationException(RESOURCE_ID_INVALID_ERROR);
+    }
+  }
+
+  @Override
+  public void putEholdingsResourcesByResourceId(String resourceId, String contentType, ResourcePutRequest entity,
+      Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.succeededFuture(PutEholdingsResourcesByResourceIdResponse.status(Response.Status.NOT_IMPLEMENTED).build()));
+  }
+
+  @Override
+  public void deleteEholdingsResourcesByResourceId(String resourceId, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.succeededFuture(DeleteEholdingsResourcesByResourceIdResponse.status(Response.Status.NOT_IMPLEMENTED).build())); 
+  }
+}

--- a/src/main/java/org/folio/rest/model/ResourceId.java
+++ b/src/main/java/org/folio/rest/model/ResourceId.java
@@ -1,0 +1,15 @@
+package org.folio.rest.model;
+
+public class ResourceId extends PackageId{
+
+  private long titleIdPart;
+
+  public ResourceId(long providerIdPart, long packageIdPart, long titleIdPart) {
+    super(providerIdPart, packageIdPart);
+    this.titleIdPart = titleIdPart;
+  }
+  
+  public long getTitleIdPart() {
+    return titleIdPart;
+  }
+}

--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -1,5 +1,15 @@
 package org.folio.rmapi;
 
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -26,16 +36,7 @@ import org.folio.rmapi.model.Vendor;
 import org.folio.rmapi.model.VendorById;
 import org.folio.rmapi.model.VendorPut;
 import org.folio.rmapi.model.Vendors;
-
-import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.json.Json;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.folio.rest.model.ResourceId;
 
 public class RMAPIService {
 
@@ -298,6 +299,11 @@ public class RMAPIService {
     final String path = TITLES_PATH + '/' + id;
     return this.getRequest(constructURL(path), Title.class);
   }
+  
+  public CompletableFuture<Title> retrieveResource(ResourceId resourceId) {
+    final String path = VENDORS_PATH + '/' + resourceId.getProviderIdPart() + '/' + PACKAGES_PATH + '/' + resourceId.getPackageIdPart() + '/' + TITLES_PATH + '/' + resourceId.getTitleIdPart();
+    return this.getRequest(constructURL(path), Title.class);
+  }
 
   /**
    * Constructs full rmapi path
@@ -329,5 +335,4 @@ public class RMAPIService {
       return packages;
     }
   }
-
 }

--- a/src/main/java/org/folio/rmapi/model/CustomerResources.java
+++ b/src/main/java/org/folio/rmapi/model/CustomerResources.java
@@ -41,6 +41,9 @@ public class CustomerResources {
   @JsonProperty("visibilityData")
   private VisibilityInfo visibilityData;
 
+  @JsonProperty("proxy")
+  private Proxy proxy;
+  
   @JsonProperty("managedCoverageList")
   private List<CoverageDates> managedCoverageList;
 
@@ -108,6 +111,10 @@ public class CustomerResources {
 
   public VisibilityInfo getVisibilityData() {
     return visibilityData;
+  }
+  
+  public Proxy getProxy() {
+    return proxy;
   }
 
   public List<CoverageDates> getManagedCoverageList() {

--- a/src/test/java/org/folio/rest/impl/EholdingsResourcesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsResourcesImplTest.java
@@ -1,0 +1,157 @@
+package org.folio.rest.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.folio.rest.jaxrs.model.JsonapiError;
+import org.folio.util.TestUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+
+import io.restassured.RestAssured;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class EholdingsResourcesImplTest extends WireMockTestBase {
+  
+  private static final String STUB_RESOURCE_ID = "583-4345-762169";
+  private static final int vendorId = 583;
+  private static final int packageId = 4345;
+
+  @Test
+  public void shouldReturnResourceWhenValidId() throws IOException, URISyntaxException {
+    String stubResponseFile = "responses/rmapi/resources/get-resource-by-id-success-response.json";
+
+    String wiremockUrl = getWiremockUrl();
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
+    WireMock.stubFor(
+        WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + vendorId + "/packages/" + packageId + "/titles.*"), true))
+        .willReturn(new ResponseDefinitionBuilder()
+            .withBody(TestUtil.readFile(stubResponseFile))));
+
+    String resourceByIdEndpoint = "eholdings/resources/" + STUB_RESOURCE_ID;
+
+    RestAssured.given()
+    .spec(getRequestSpecification())
+    .when()
+    .get(resourceByIdEndpoint)
+    .then()
+    .statusCode(200)
+    .body("data.type",equalTo("resources"))
+    .body("data.id", equalTo("583-4345-762169"))
+    .body("data.attributes.isPeerReviewed", equalTo(false))
+    .body("data.attributes.isTitleCustom", equalTo(false))
+    .body("data.attributes.publisherName", equalTo("Praeger"))
+    .body("data.attributes.titleId", equalTo(762169))
+    .body("data.attributes.contributors[0].type", equalTo("Author"))
+    .body("data.attributes.contributors[0].contributor", equalTo("Beeman, William O."))
+    /*
+     * List of identifiers returned below from RM API get filtered and sorted to
+     * only support types ISSN/ISBN and subtypes Print/Online
+     */
+    .body("data.attributes.identifiers[0].id", equalTo("978-0-275-98214-0"))
+    .body("data.attributes.identifiers[1].id",equalTo("978-0-313-06800-3"))
+    .body("data.attributes.identifiers[2].id", equalTo("978-1-282-40979-8"))
+    .body("data.attributes.identifiers[0].type", equalTo("ISBN"))
+    .body("data.attributes.identifiers[1].type",equalTo("ISBN"))
+    .body("data.attributes.identifiers[2].type", equalTo("ISBN"))
+    .body("data.attributes.identifiers[0].subtype", equalTo("Print"))
+    .body("data.attributes.identifiers[1].subtype",equalTo("Online"))
+    .body("data.attributes.identifiers[2].subtype",equalTo("Online"))
+    .body("data.attributes.name", equalTo("\"Great Satan\" Vs. the \"Mad Mullahs\": How the United States and Iran Demonize Each Other"))
+    .body("data.attributes.publicationType", equalTo("Book"))
+    .body("data.attributes.subjects[0].type", equalTo("BISAC"))
+    .body("data.attributes.subjects[0].subject", equalTo("SOCIAL SCIENCE / Ethnic Studies / General"))
+    .body("data.attributes.customEmbargoPeriod.embargoValue", equalTo(0))
+    .body("data.attributes.isPackageCustom", equalTo(false))
+    .body("data.attributes.isSelected", equalTo(true))
+    .body("data.attributes.isTokenNeeded", equalTo(false))
+    .body("data.attributes.locationId", equalTo(2863717))
+    .body("data.attributes.managedEmbargoPeriod.embargoValue", equalTo(0))
+    .body("data.attributes.packageId", equalTo("583-4345"))
+    .body("data.attributes.packageName", equalTo("ABC-CLIO eBook Collection"))
+    .body("data.attributes.url", equalTo("https://publisher.abc-clio.com/9780313068003/"))
+    .body("data.attributes.providerId", equalTo(583))
+    .body("data.attributes.providerName", equalTo("ABC-CLIO"))
+    .body("data.attributes.visibilityData.isHidden", equalTo(true))
+    .body("data.attributes.visibilityData.reason", equalTo(""))
+    .body("data.attributes.managedCoverages[0].beginCoverage", equalTo("2005-01-01"))
+    .body("data.attributes.managedCoverages[0].endCoverage", equalTo("2005-12-31"))
+    .body("data.attributes.proxy.id", equalTo("<n>"))
+    .body("data.attributes.proxy.inherited", equalTo(true))
+    .body("data.relationships.provider.meta.included", equalTo(false))
+    .body("data.relationships.title.meta.included", equalTo(false))
+    .body("data.relationships.package.meta.included", equalTo(false));
+  }
+
+  @Test
+  public void shouldReturn404WhenRMAPINotFoundOnResourceGet() throws IOException, URISyntaxException {
+    String stubResponseFile = "responses/rmapi/resources/get-resource-by-id-not-found-response.json";
+
+    String wiremockUrl = getWiremockUrl();
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
+    WireMock.stubFor(
+        WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + vendorId + "/packages/" + packageId + "/titles.*"), true))
+        .willReturn(new ResponseDefinitionBuilder()
+            .withBody(TestUtil.readFile(stubResponseFile))
+            .withStatus(404)));
+
+    String resourceByIdEndpoint = "eholdings/resources/" + STUB_RESOURCE_ID;
+
+    JsonapiError error = RestAssured.given()
+    .spec(getRequestSpecification())
+    .when()
+    .get(resourceByIdEndpoint)
+    .then()
+    .statusCode(404)
+    .extract().as(JsonapiError.class);
+
+    assertThat(error.getErrors().get(0).getTitle(), equalTo("Resource not found"));
+  }
+
+  @Test
+  public void shouldReturn400WhenValidationErrorOnResourceGet() throws IOException, URISyntaxException {
+    String wiremockUrl = getWiremockUrl();
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
+
+    String resourceByIdEndpoint = "eholdings/resources/583-abc-762169";
+
+    JsonapiError error = RestAssured.given()
+    .spec(getRequestSpecification())
+    .when()
+    .get(resourceByIdEndpoint)
+    .then()
+    .statusCode(400)
+    .extract().as(JsonapiError.class);
+
+    assertThat(error.getErrors().get(0).getTitle(), equalTo("Resource id is invalid"));
+  }
+
+  @Test
+  public void shouldReturn500WhenRMApiReturns500ErrorOnResourceGet() throws IOException, URISyntaxException {
+    String wiremockUrl = getWiremockUrl();
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
+    WireMock.stubFor(
+      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + vendorId + "/packages/" + packageId + "/titles.*"), true))
+        .willReturn(new ResponseDefinitionBuilder()
+          .withStatus(500)));
+
+    String resourceByIdEndpoint = "eholdings/resources/" + STUB_RESOURCE_ID;
+
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .when()
+      .when()
+      .get(resourceByIdEndpoint)
+      .then()
+      .statusCode(500);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/EholdingsTitlesTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsTitlesTest.java
@@ -134,7 +134,7 @@ public class EholdingsTitlesTest extends WireMockTestBase {
     .body("data.attributes.edition", isEmptyOrNullString())
     .body("data.attributes.description", isEmptyOrNullString())
     .body("data.attributes.isPeerReviewed", equalTo(false))
-    .body("data.attributes.contributors[0].type", equalTo("author"))
+    .body("data.attributes.contributors[0].type", equalTo("Author"))
     .body("data.attributes.contributors[0].contributor", equalTo("Bloom, Harold"))
     .body("data.relationships.resources.meta.included", equalTo(false));
 

--- a/src/test/resources/responses/rmapi/resources/get-resource-by-id-not-found-response.json
+++ b/src/test/resources/responses/rmapi/resources/get-resource-by-id-not-found-response.json
@@ -1,0 +1,9 @@
+{
+  "Errors": [
+    {
+      "Code": 1001,
+      "Message": "Title not found",
+      "SubCode": 0
+    }
+  ]
+}

--- a/src/test/resources/responses/rmapi/resources/get-resource-by-id-success-response.json
+++ b/src/test/resources/responses/rmapi/resources/get-resource-by-id-success-response.json
@@ -1,0 +1,98 @@
+{
+  "titleId": 762169,
+  "titleName": "\"Great Satan\" Vs. the \"Mad Mullahs\": How the United States and Iran Demonize Each Other",
+  "publisherName": "Praeger",
+  "identifiersList": [
+    {
+      "id": "300079",
+      "source": "ResourceIdentifier",
+      "subtype": 0,
+      "type": 7
+    },
+    {
+      "id": "762169",
+      "source": "AtoZ",
+      "subtype": 0,
+      "type": 9
+    },
+    {
+      "id": "978-0-275-98214-0",
+      "source": "ResourceIdentifier",
+      "subtype": 1,
+      "type": 1
+    },
+    {
+      "id": "978-0-313-06800-3",
+      "source": "ResourceIdentifier",
+      "subtype": 2,
+      "type": 1
+    },
+    {
+      "id": "978-1-282-40979-8",
+      "source": "ResourceIdentifier",
+      "subtype": 2,
+      "type": 1
+    }
+  ],
+  "subjectsList": [
+    {
+      "type": "BISAC",
+      "subject": "SOCIAL SCIENCE / Ethnic Studies / General"
+    }
+  ],
+  "isTitleCustom": false,
+  "pubType": "Book",
+  "customerResourcesList": [
+    {
+      "titleId": 762169,
+      "packageId": 4345,
+      "packageName": "ABC-CLIO eBook Collection",
+      "packageType": "Variable",
+      "proxy": {
+        "id": "<n>",
+        "inherited": true
+      },
+      "isPackageCustom": false,
+      "vendorId": 583,
+      "vendorName": "ABC-CLIO",
+      "locationId": 2863717,
+      "isSelected": true,
+      "isTokenNeeded": false,
+      "visibilityData": {
+        "isHidden": true,
+        "reason": "Hidden by Customer"
+      },
+      "managedCoverageList": [
+        {
+          "beginCoverage": "2005-01-01",
+          "endCoverage": "2005-12-31"
+        }
+      ],
+      "customCoverageList": [],
+      "coverageStatement": null,
+      "managedEmbargoPeriod": {
+        "embargoUnit": null,
+        "embargoValue": 0
+      },
+      "customEmbargoPeriod": {
+        "embargoUnit": null,
+        "embargoValue": 0
+      },
+      "url": "https://publisher.abc-clio.com/9780313068003/",
+      "userDefinedField1": null,
+      "userDefinedField2": null,
+      "userDefinedField3": null,
+      "userDefinedField4": null,
+      "userDefinedField5": null
+    }
+  ],
+  "description": null,
+  "edition": null,
+  "isPeerReviewed": false,
+  "contributorsList": [
+    {
+      "type": "author",
+      "contributor": "Beeman, William O."
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-31, we are supposed to implement `GET /eholdings/resources/{resourceId}`. This PR addresses that.

## Approach
- Implement `GET /eholdings/resources/{resourceId}`
- Add unit tests

## Screenshots
![get_resource_by_resourceid](https://user-images.githubusercontent.com/33662516/48793706-d02b2100-ecc5-11e8-9237-fc7feebdf946.gif)