### PR TITLE
MODKBEKBJ-21 - Implement GET /eholdings/providers/{provider_id}/packages

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -50,7 +50,8 @@
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/eholdings/providers/{providerId}/packages"
+          "pathPattern": "/eholdings/providers/{providerId}/packages",
+          "permissionRequired": ["kb-ebsco.provider.packages.get"]
         },
         {
           "methods": ["POST"],
@@ -147,6 +148,11 @@
       "description": "Put single provider"
     },
     {
+      "permissionName": "kb-ebsco.provider.packages.get",
+      "displayName": "get packages for a single provider",
+      "description": "get packages for a single provider"
+    },
+    {
       "permissionName": "kb-ebsco.title.get",
       "displayName": "get single title",
       "description": "Get single title"
@@ -197,6 +203,7 @@
         "kb-ebsco.providerCollection.get",
         "kb-ebsco.provider.get",
         "kb-ebsco.provider.put",
+        "kb-ebsco.provider.packages.get",
         "kb-ebsco.titleCollection.get",
         "kb-ebsco.packageCollection.get",
         "kb-ebsco.package.delete",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -51,7 +51,7 @@
         {
           "methods": ["GET"],
           "pathPattern": "/eholdings/providers/{providerId}/packages",
-          "permissionsRequired": ["kb-ebsco.provider.packages.get"]
+          "permissionsRequired": ["kb-ebsco.provider.packageCollection.get"]
         },
         {
           "methods": ["POST"],
@@ -148,7 +148,7 @@
       "description": "Put single provider"
     },
     {
-      "permissionName": "kb-ebsco.provider.packages.get",
+      "permissionName": "kb-ebsco.provider.packageCollection.get",
       "displayName": "get packages for a single provider",
       "description": "get packages for a single provider"
     },
@@ -203,7 +203,7 @@
         "kb-ebsco.providerCollection.get",
         "kb-ebsco.provider.get",
         "kb-ebsco.provider.put",
-        "kb-ebsco.provider.packages.get",
+        "kb-ebsco.provider.packageCollection.get",
         "kb-ebsco.titleCollection.get",
         "kb-ebsco.packageCollection.get",
         "kb-ebsco.package.delete",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -51,7 +51,7 @@
         {
           "methods": ["GET"],
           "pathPattern": "/eholdings/providers/{providerId}/packages",
-          "permissionRequired": ["kb-ebsco.provider.packages.get"]
+          "permissionsRequired": ["kb-ebsco.provider.packages.get"]
         },
         {
           "methods": ["POST"],

--- a/ramls/examples/providers/providers_providerId_packages_get_400_response.json
+++ b/ramls/examples/providers/providers_providerId_packages_get_400_response.json
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "title": "Parameter OrderBy should be by PackageName when parameter Search is empty."
+      "title": "Search parameter cannot be empty"
     }
   ],
   "jsonapi": {

--- a/ramls/examples/providers/providers_providerId_packages_get_400_response.json
+++ b/ramls/examples/providers/providers_providerId_packages_get_400_response.json
@@ -1,0 +1,10 @@
+{
+  "errors": [
+    {
+      "title": "Parameter OrderBy should be by PackageName when parameter Search is empty."
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/examples/providers/providers_providerId_packages_get_404_response.json
+++ b/ramls/examples/providers/providers_providerId_packages_get_404_response.json
@@ -1,0 +1,10 @@
+{
+  "errors": [
+    {
+      "title": "Provider not found"
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/providers.raml
+++ b/ramls/providers.raml
@@ -98,7 +98,7 @@ traits:
               description: OK
               body:
                 application/vnd.api+json:
-                  description: List of providers matching the provider name and the total number of providers found.
+                  description: List of packages associated with a given provider matching search criteria.
                   type: packageCollection
                   example:
                     strict: false

--- a/ramls/providers.raml
+++ b/ramls/providers.raml
@@ -14,6 +14,7 @@ types:
   providerPutRequest: !include types/providers/providerPutRequest.json
   provider: !include types/providers/provider.json
   packageCollection: !include types/packages/packageCollection.json
+  jsonapiError: !include types/jsonapiError.json
 
 traits:
   queriable: !include traits/queriable.raml
@@ -88,20 +89,36 @@ traits:
               example:
                 strict: false
                 value: !include examples/providers/providers_providerId_put_200_response.json
-  /packages:
-      get:
-        description: Search within a list of packages associated with a given provider.
-        is: [queriable, filterable, sortable, pageable]
-        responses:
-          200:
-            description: OK
-            body:
-              application/vnd.api+json:
-                description: List of providers matching the provider name and the total number of providers found.
-                type: packageCollection
-                example:
-                  strict: false
-                  value: !include examples/providers/providers_providerId_packages_get_200_response.json
+    /packages:
+        get:
+          description: Search within a list of packages associated with a given provider.
+          is: [queriable, filterable, sortable, pageable]
+          responses:
+            200:
+              description: OK
+              body:
+                application/vnd.api+json:
+                  description: List of providers matching the provider name and the total number of providers found.
+                  type: packageCollection
+                  example:
+                    strict: false
+                    value: !include examples/providers/providers_providerId_packages_get_200_response.json
+            400:
+              description: Bad Request
+              body:
+                application/vnd.api+json:
+                  type: jsonapiError
+                  example:
+                    strict: false
+                    value: !include examples/providers/providers_providerId_packages_get_400_response.json
+            404:
+              description: Not Found
+              body:
+                application/vnd.api+json:
+                  type: jsonapiError
+                  example:
+                    strict: false
+                    value: !include examples/providers/providers_providerId_packages_get_404_response.json
 
 
 

--- a/src/main/java/org/folio/rest/impl/EholdingsProvidersImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsProvidersImpl.java
@@ -206,6 +206,12 @@ public class EholdingsProvidersImpl implements EholdingsProviders {
 
     headerValidator.validate(okapiHeaders);
     parametersValidator.validate("true", filterSelected, filterType, sort);
+    if(!Sort.contains(sort.toUpperCase())){
+      throw new ValidationException("Invalid sort parameter");
+    }
+    if("".equals(q)){
+      throw new ValidationException("Search parameter cannot be empty");
+    }
 
     Sort nameSort = Sort.valueOf(sort.toUpperCase());
     CompletableFuture.completedFuture(null)

--- a/src/main/java/org/folio/rest/impl/EholdingsProvidersImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsProvidersImpl.java
@@ -42,7 +42,7 @@ public class EholdingsProvidersImpl implements EholdingsProviders {
   private static final String GET_PROVIDER_NOT_FOUND_MESSAGE = "Provider not found";
   private static final String PUT_PROVIDER_ERROR_MESSAGE = "Failed to update provider";
   private static final String GET_PROVIDER_PACKAGES_ERROR_MESSAGE = "Failed to retrieve provider packages";
-
+  private static final String INVALID_PROVIDER_ID_ERROR = "Provider id is invalid - ";
 
   private final Logger logger = LoggerFactory.getLogger(EholdingsConfigurationImpl.class);
 
@@ -126,7 +126,7 @@ public class EholdingsProvidersImpl implements EholdingsProviders {
     try {
       providerIdLong = Long.parseLong(providerId);
     } catch (NumberFormatException e) {
-      throw new ValidationException("Provider id is invalid - " + providerId, e);
+      throw new ValidationException(INVALID_PROVIDER_ID_ERROR + providerId, e);
     }
 
     headerValidator.validate(okapiHeaders);
@@ -162,7 +162,7 @@ public class EholdingsProvidersImpl implements EholdingsProviders {
     try {
       providerIdLong = Long.parseLong(providerId);
     } catch (NumberFormatException e) {
-      throw new ValidationException("Provider id is invalid - " + providerId, e);
+      throw new ValidationException(INVALID_PROVIDER_ID_ERROR + providerId, e);
     }
     headerValidator.validate(okapiHeaders);
     bodyValidator.validate(entity);
@@ -201,7 +201,7 @@ public class EholdingsProvidersImpl implements EholdingsProviders {
     try {
       providerIdLong = Long.parseLong(providerId);
     } catch (NumberFormatException e) {
-      throw new ValidationException("Provider id is invalid - " + providerId, e);
+      throw new ValidationException(INVALID_PROVIDER_ID_ERROR + providerId, e);
     }
 
     headerValidator.validate(okapiHeaders);

--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -200,12 +200,12 @@ public class RMAPIService {
     return this.getRequest(constructURL(TITLES_PATH + "?" + path), Titles.class);
   }
 
-  public CompletableFuture<Packages> retrievePackages(Integer providerId) {
+  public CompletableFuture<Packages> retrievePackages(Long providerId) {
     return retrievePackages(null, null, providerId, null, 1, 25, Sort.NAME);
   }
 
   public CompletableFuture<Packages> retrievePackages(
-    String filterSelected, String filterType, Integer providerId, String q, int page, int count,
+    String filterSelected, String filterType, Long providerId, String q, int page, int count,
     Sort sort) {
     String path = new PackagesFilterableUrlBuilder()
       .filterSelected(filterSelected)
@@ -229,7 +229,7 @@ public class RMAPIService {
     return vendorsList;
   }
 
-  public Integer getFirstProviderElement(Vendors vendors) {
+  public Long getFirstProviderElement(Vendors vendors) {
     List<Vendor> vendorList = vendors.getVendorList();
     return (CollectionUtils.isEmpty(vendorList)) ? null : vendorList.get(0).getVendorId();
   }
@@ -242,7 +242,7 @@ public class RMAPIService {
 
     vendorFuture = this.getRequest(constructURL(path), VendorById.class);
     if (INCLUDE_PACKAGES_VALUE.equalsIgnoreCase(include)) {
-      packagesFuture = retrievePackages((int) id);
+      packagesFuture = retrievePackages(id);
     } else {
       packagesFuture = CompletableFuture.completedFuture(null);
     }

--- a/src/main/java/org/folio/rmapi/model/Vendor.java
+++ b/src/main/java/org/folio/rmapi/model/Vendor.java
@@ -17,7 +17,7 @@ import lombok.ToString;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Vendor {
   @JsonProperty("vendorId")
-  private int vendorId;
+  private long vendorId;
   @JsonProperty("vendorName")
   private String vendorName;
   @JsonProperty("packagesTotal")

--- a/src/test/java/org/folio/rest/impl/EholdingsProvidersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsProvidersImplTest.java
@@ -427,13 +427,6 @@ public class EholdingsProvidersImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn400IfQueryParamInvalid() throws IOException, URISyntaxException {
-    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
-    WireMock.stubFor(
-      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" +
-        STUB_CUSTOMER_ID + "/vendors/" + STUB_VENDOR_ID + "/packages.*"), true))
-        .willReturn(new ResponseDefinitionBuilder()
-          .withStatus(HttpStatus.SC_BAD_REQUEST)));
-
     RequestSpecification requestSpecification = getRequestSpecification();
     RestAssured.given()
       .spec(requestSpecification)

--- a/src/test/java/org/folio/rest/impl/EholdingsProvidersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsProvidersImplTest.java
@@ -9,13 +9,27 @@ import static org.hamcrest.Matchers.notNullValue;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.http.HttpStatus;
+import org.folio.rest.jaxrs.model.Coverage;
 import org.folio.rest.jaxrs.model.JsonapiError;
 import org.folio.rest.jaxrs.model.MetaDataIncluded;
+import org.folio.rest.jaxrs.model.MetaTotalResults;
+import org.folio.rest.jaxrs.model.PackageCollection;
 import org.folio.rest.jaxrs.model.PackageCollectionItem;
+import org.folio.rest.jaxrs.model.PackageDataAttributes;
 import org.folio.rest.jaxrs.model.Packages;
 import org.folio.rest.jaxrs.model.Provider;
 import org.folio.rest.jaxrs.model.ProviderData;
@@ -24,19 +38,10 @@ import org.folio.rest.jaxrs.model.ProviderPutRequest;
 import org.folio.rest.jaxrs.model.Proxy;
 import org.folio.rest.jaxrs.model.Relationships;
 import org.folio.rest.jaxrs.model.Token;
+import org.folio.rest.jaxrs.model.VisibilityData;
 import org.folio.util.TestUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.matching.RegexPattern;
-import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
-
-import io.restassured.RestAssured;
-import io.restassured.specification.RequestSpecification;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 
 @RunWith(VertxUnitRunner.class)
@@ -92,7 +97,7 @@ public class EholdingsProvidersImplTest extends WireMockTestBase {
           .withBody(TestUtil.readFile(stubResponseFile))));
 
     WireMock.stubFor(
-      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" +  STUB_VENDOR_ID +  "/packages.*"), true))
+      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + STUB_VENDOR_ID + "/packages.*"), true))
         .willReturn(new ResponseDefinitionBuilder()
           .withBody(TestUtil.readFile(stubPackagesResponseFile))));
 
@@ -326,6 +331,140 @@ public class EholdingsProvidersImplTest extends WireMockTestBase {
 
   }
 
+  @Test
+  public void shouldReturnProviderPackagesWhenValidId() throws IOException, URISyntaxException {
+    String packageStubResponseFile = "responses/rmapi/packages/get-packages-by-provider-id.json";
+    UrlPathPattern packageUrlPattern = new UrlPathPattern(new RegexPattern("/rm/rmaccounts.*" +
+      STUB_CUSTOMER_ID + "/vendors/" + STUB_VENDOR_ID + "/packages.*"), true);
+
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
+
+    WireMock.stubFor(WireMock.get(packageUrlPattern)
+      .willReturn(new ResponseDefinitionBuilder()
+        .withBody(TestUtil.readFile(packageStubResponseFile))));
+
+    PackageCollection packages = RestAssured.given()
+      .spec(getRequestSpecification())
+      .when()
+      .get("eholdings/providers/" + STUB_VENDOR_ID + "/packages")
+      .then()
+      .statusCode(HttpStatus.SC_OK).extract().as(PackageCollection.class);
+
+    comparePackages(packages, getExpectedPackage());
+
+  }
+
+  @Test
+  public void shouldReturn400IfProviderIdInvalid() {
+    RequestSpecification requestSpecification = getRequestSpecification();
+    RestAssured.given()
+      .spec(requestSpecification)
+      .when()
+      .get("eholdings/providers/invalid/packages")
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST)
+      .body("errors.first.title", notNullValue());
+  }
+
+  @Test
+  public void shouldReturn400IfCountOutOfRange() {
+    RequestSpecification requestSpecification = getRequestSpecification();
+    RestAssured.given()
+      .spec(requestSpecification)
+      .when()
+      .get("eholdings/providers/" + STUB_VENDOR_ID + "/packages?count=120")
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST)
+      .body("errors.first.title", notNullValue());
+  }
+
+  @Test
+  public void shouldReturn400IfFilterTypeInvalid() {
+    RequestSpecification requestSpecification = getRequestSpecification();
+    RestAssured.given()
+      .spec(requestSpecification)
+      .when()
+      .get("eholdings/providers/" + STUB_VENDOR_ID + "/packages?q=Search&filter[selected]=true&filter[type]=unsupported")
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST)
+      .body("errors.first.title", notNullValue());
+  }
+
+  @Test
+  public void shouldReturn400IfFilterSelectedInvalid() {
+    RequestSpecification requestSpecification = getRequestSpecification();
+    RestAssured.given()
+      .spec(requestSpecification)
+      .when()
+      .get("eholdings/providers/" + STUB_VENDOR_ID + "/packages?q=Search&filter[selected]=invalid")
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST)
+      .body("errors.first.title", notNullValue());
+  }
+
+  @Test
+  public void shouldReturn400IfPageOffsetInvalid() {
+    RequestSpecification requestSpecification = getRequestSpecification();
+    RestAssured.given()
+      .spec(requestSpecification)
+      .when()
+      .get("eholdings/providers/" + STUB_VENDOR_ID + "/packages?q=Search&count=5&page=abc")
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void shouldReturn400IfSortInvalid() {
+    RequestSpecification requestSpecification = getRequestSpecification();
+    RestAssured.given()
+      .spec(requestSpecification)
+      .when()
+      .get("eholdings/providers/" + STUB_VENDOR_ID + "/packages?q=Search&sort=invalid")
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST)
+      .body("errors.first.title", notNullValue());
+  }
+
+  @Test
+  public void shouldReturn400IfQueryParamInvalid() throws IOException, URISyntaxException {
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
+    WireMock.stubFor(
+      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" +
+        STUB_CUSTOMER_ID + "/vendors/" + STUB_VENDOR_ID + "/packages.*"), true))
+        .willReturn(new ResponseDefinitionBuilder()
+          .withStatus(HttpStatus.SC_BAD_REQUEST)));
+
+    RequestSpecification requestSpecification = getRequestSpecification();
+    RestAssured.given()
+      .spec(requestSpecification)
+      .when()
+      .get("/eholdings/providers/" + STUB_VENDOR_ID + "/packages?q=")
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST)
+      .body("errors.first.title", notNullValue());
+  }
+
+  @Test
+  public void shouldReturn404WhenNonProviderIdNotFound() throws IOException, URISyntaxException {
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
+    WireMock.stubFor(
+      WireMock.get(new UrlPathPattern(new EqualToPattern("/rm/rmaccounts/" +
+        STUB_CUSTOMER_ID + "/vendors/191919/packages"), false))
+        .willReturn(new ResponseDefinitionBuilder()
+          .withStatus(HttpStatus.SC_NOT_FOUND)));
+
+    RequestSpecification requestSpecification = getRequestSpecification();
+    JsonapiError error = RestAssured.given()
+      .spec(requestSpecification)
+      .when()
+      .get("/eholdings/providers/191919/packages")
+      .then()
+      .statusCode(HttpStatus.SC_NOT_FOUND)
+      .extract().as(JsonapiError.class);
+
+    assertThat(error.getErrors().get(0).getTitle(), is("Provider not found"));
+  }
+
   private void compareProviders(Provider actual, Provider expected) {
     assertThat(actual.getData().getType(), equalTo(expected.getData().getType()));
     assertThat(actual.getData().getId(), equalTo(expected.getData().getId()));
@@ -398,5 +537,70 @@ public class EholdingsProvidersImplTest extends WireMockTestBase {
           .withPackages(new Packages()
             .withMeta(new MetaDataIncluded()
               .withIncluded(false)))));
+  }
+
+  private void comparePackages(PackageCollection actual, PackageCollection expected) {
+    assertThat(actual.getMeta().getTotalResults(), equalTo(expected.getMeta().getTotalResults()));
+    assertThat(actual.getData().get(0).getId(), equalTo(expected.getData().get(0).getId()));
+    assertThat(actual.getData().get(0).getType(), equalTo("packages"));
+    assertThat(actual.getData().get(0).getAttributes().getName(),
+      equalTo(expected.getData().get(0).getAttributes().getName()));
+    assertThat(actual.getData().get(0).getAttributes().getPackageId(),
+      equalTo(expected.getData().get(0).getAttributes().getPackageId()));
+    assertThat(actual.getData().get(0).getAttributes().getIsCustom(),
+      equalTo(expected.getData().get(0).getAttributes().getIsCustom()));
+    assertThat(actual.getData().get(0).getAttributes().getProviderId(),
+      equalTo(expected.getData().get(0).getAttributes().getProviderId()));
+    assertThat(actual.getData().get(0).getAttributes().getProviderName(),
+      equalTo(expected.getData().get(0).getAttributes().getProviderName()));
+    assertThat(actual.getData().get(0).getAttributes().getTitleCount(),
+      equalTo(expected.getData().get(0).getAttributes().getTitleCount()));
+    assertThat(actual.getData().get(0).getAttributes().getIsSelected(),
+      equalTo(expected.getData().get(0).getAttributes().getIsSelected()));
+    assertThat(actual.getData().get(0).getAttributes().getSelectedCount(),
+      equalTo(expected.getData().get(0).getAttributes().getSelectedCount()));
+    assertThat(actual.getData().get(0).getAttributes().getContentType().value(),
+      equalTo(expected.getData().get(0).getAttributes().getContentType().value()));
+    assertThat(actual.getData().get(0).getAttributes().getIsCustom(),
+      equalTo(expected.getData().get(0).getAttributes().getIsCustom()));
+    assertThat(actual.getData().get(0).getAttributes().getPackageType(),
+      equalTo(expected.getData().get(0).getAttributes().getPackageType()));
+    assertThat(actual.getData().get(0).getAttributes().getVisibilityData().getReason(),
+      equalTo(expected.getData().get(0).getAttributes().getVisibilityData().getReason()));
+    assertThat(actual.getData().get(0).getAttributes().getVisibilityData().getIsHidden(),
+      equalTo(expected.getData().get(0).getAttributes().getVisibilityData().getIsHidden()));
+    assertThat(actual.getData().get(0).getAttributes().getCustomCoverage().getBeginCoverage(),
+      equalTo(expected.getData().get(0).getAttributes().getCustomCoverage().getBeginCoverage()));
+    assertThat(actual.getData().get(0).getAttributes().getCustomCoverage().getEndCoverage(),
+      equalTo(expected.getData().get(0).getAttributes().getCustomCoverage().getEndCoverage()));
+
+  }
+
+  private PackageCollection getExpectedPackage() {
+    List<PackageCollectionItem> collectionItems = new ArrayList<>();
+    PackageCollectionItem collectionItem = new PackageCollectionItem()
+      .withId("1111111-2222222")
+      .withAttributes(new PackageDataAttributes()
+        .withName("TEST_PACKAGE_NAME")
+        .withPackageId(2222222)
+        .withIsCustom(true)
+        .withProviderId(1111111)
+        .withProviderName("TEST_VENDOR_NAME")
+        .withTitleCount(5)
+        .withIsSelected(true)
+        .withSelectedCount(5)
+        .withPackageType("Custom")
+        .withContentType(PackageDataAttributes.ContentType.ONLINE_REFERENCE)
+        .withCustomCoverage(new Coverage()
+          .withBeginCoverage("")
+          .withEndCoverage(""))
+        .withVisibilityData(new VisibilityData()
+          .withIsHidden(false)
+          .withReason("")
+        ));
+    collectionItems.add(collectionItem);
+    return new PackageCollection().withData(collectionItems)
+      .withMeta(new MetaTotalResults().withTotalResults(1));
+
   }
 }

--- a/src/test/resources/responses/packages/get-packages-by-provider-id-response.json
+++ b/src/test/resources/responses/packages/get-packages-by-provider-id-response.json
@@ -1,0 +1,44 @@
+{
+  "data" : [ {
+    "id" : "1111111-2222222",
+    "type" : "packages",
+    "attributes" : {
+      "contentType" : "Online Reference",
+      "customCoverage" : {
+        "beginCoverage" : "",
+        "endCoverage" : ""
+      },
+      "isCustom" : true,
+      "isSelected" : true,
+      "name" : "TEST_PACKAGE_NAME",
+      "packageId" : 2222222,
+      "packageType" : "Custom",
+      "providerId" : 1111111,
+      "providerName" : "TEST_VENDOR_NAME",
+      "selectedCount" : 5,
+      "titleCount" : 5,
+      "visibilityData" : {
+        "isHidden" : false,
+        "reason" : ""
+      }
+    },
+    "relationships" : {
+      "resources" : {
+        "meta" : {
+          "included" : false
+        }
+      },
+      "provider" : {
+        "meta" : {
+          "included" : false
+        }
+      }
+    }
+  } ],
+  "meta" : {
+    "totalResults" : 1
+  },
+  "jsonapi" : {
+    "version" : "1.0"
+  }
+}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-21 we want to have the ability to get packages by provider id by supporting  `/eholdings/providers/{provider_id}/packages` endpoint

## Approach

- Implement get provider packages method
- Added permissions to the request
- Mapped packages returned from RM API by provider id to a collection of packages


