### PR TITLE
MODKBEKBJ-105 enable test coverage by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,14 +50,13 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <jacoco.skip>true</jacoco.skip>
+        <test.coverage.skip>false</test.coverage.skip>
       </properties>
     </profile>
     <profile>
-      <id>test-coverage</id>
+      <id>no-coverage</id>
       <properties>
-        <jacoco.skip>false</jacoco.skip>
-        <maven.test.skip>false</maven.test.skip>
+        <test.coverage.skip>true</test.coverage.skip>
       </properties>
     </profile>
   </profiles>
@@ -448,6 +447,9 @@
             <goals>
               <goal>prepare-agent</goal>
             </goals>
+            <configuration>
+              <skip>${test.coverage.skip}</skip>
+            </configuration>
           </execution>
           <execution>
             <id>jacoco-coverage-report</id>
@@ -455,6 +457,9 @@
             <goals>
               <goal>report</goal>
             </goals>
+            <configuration>
+              <skip>${test.coverage.skip}</skip>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Purpose
Current Jenkins build calls JaCoCo plugin directly, from command line:
`mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install`
It comes in contradiction with introduced profiles where the coverage disable by default
So in order to not break Jenkins build, code coverage is enabled in pom file

## Approach
set a property which disables code coverage to false by defult
