### PR TITLE
MODKBEKBJ-103: Add an endpoint for invalidating configuration cache

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -113,6 +113,11 @@
           "methods": ["GET"],
           "pathPattern": "/eholdings/status",
           "permissionsRequired" :["kb-ebsco.status.get"]
+        },
+        {
+          "methods": ["DELETE"],
+          "pathPattern": "/eholdings/cache",
+          "permissionsRequired" :["kb-ebsco.cache.delete"]
         }
       ]
     }
@@ -132,6 +137,11 @@
       "permissionName": "kb-ebsco.status.get",
       "displayName": "get RM API configuration status",
       "description": "Get RM API configuration status"
+    },
+    {
+      "permissionName": "kb-ebsco.cache.delete",
+      "displayName": "delete RM API configuration cache",
+      "description": "Delete RM API configuration cache"
     },
     {
       "permissionName": "kb-ebsco.providerCollection.get",
@@ -206,6 +216,7 @@
         "kb-ebsco.configuration.get",
         "kb-ebsco.configuration.put",
         "kb-ebsco.status.get",
+        "kb-ebsco.cache.delete",
         "kb-ebsco.providerCollection.get",
         "kb-ebsco.provider.get",
         "kb-ebsco.provider.put",

--- a/ramls/eholdings.raml
+++ b/ramls/eholdings.raml
@@ -86,3 +86,11 @@ types:
         body:
           text/plain:
             example: "Internal server error, contact administrator"
+/eholdings/cache:
+  displayName: Cache
+  delete:
+    description: |
+      Invalidate configuration cache for tenant
+    responses:
+      204:
+        description: No Content

--- a/src/main/java/org/folio/config/cache/RMAPIConfigurationCache.java
+++ b/src/main/java/org/folio/config/cache/RMAPIConfigurationCache.java
@@ -30,7 +30,7 @@ public final class RMAPIConfigurationCache {
     cache.put(tenant, configuration);
   }
 
-  public void invalidate(){
-    cache.invalidateAll();
+  public void invalidate(String tenant){
+    cache.invalidate(tenant);
   }
 }

--- a/src/main/java/org/folio/rest/impl/EholdingsCacheImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsCacheImpl.java
@@ -1,0 +1,34 @@
+package org.folio.rest.impl;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.config.cache.RMAPIConfigurationCache;
+import org.folio.rest.jaxrs.resource.EholdingsCache;
+import org.folio.rest.util.RestConstants;
+import org.folio.rest.validator.HeaderValidator;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+public class EholdingsCacheImpl implements EholdingsCache {
+  private HeaderValidator headerValidator;
+
+  public EholdingsCacheImpl() {
+    this(new HeaderValidator());
+  }
+
+  public EholdingsCacheImpl(HeaderValidator headerValidator) {
+    this.headerValidator = headerValidator;
+  }
+
+  @Override
+  public void deleteEholdingsCache(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    headerValidator.validate(okapiHeaders);
+    RMAPIConfigurationCache.getInstance().invalidate(okapiHeaders.get(RestConstants.OKAPI_TENANT_HEADER));
+    asyncResultHandler.handle(Future.succeededFuture(EholdingsCacheImpl.DeleteEholdingsCacheResponse.respond204()));
+  }
+}

--- a/src/test/java/org/folio/rest/impl/EholdingsCacheImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsCacheImplTest.java
@@ -1,0 +1,53 @@
+package org.folio.rest.impl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.apache.http.HttpStatus;
+import org.folio.util.TestUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.restassured.RestAssured;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class EholdingsCacheImplTest extends WireMockTestBase {
+
+  @Test
+  public void shouldHaveCacheMissWhenDeleteCacheRequestIsSent() throws IOException, URISyntaxException {
+    int cacheMissCount = 0;
+    TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
+
+    sendGetConfigurationRequest();
+    sendGetConfigurationRequest();
+
+    //Verify that second request didn't cause a cache miss, because configuration was cached
+    WireMock.verify(++cacheMissCount, getRequestedFor(urlMatching("/configurations/entries.*")));
+
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .when()
+      .delete("eholdings/cache")
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT);
+
+    sendGetConfigurationRequest();
+
+    WireMock.verify(++cacheMissCount, getRequestedFor(urlMatching("/configurations/entries.*")));
+  }
+
+  private void sendGetConfigurationRequest() {
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .when()
+      .get("eholdings/configuration")
+      .then()
+      .statusCode(200);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/WireMockTestBase.java
+++ b/src/test/java/org/folio/rest/impl/WireMockTestBase.java
@@ -1,5 +1,7 @@
 package org.folio.rest.impl;
 
+import static org.folio.util.TestUtil.STUB_TENANT;
+
 import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -67,7 +69,7 @@ public abstract class WireMockTestBase {
 
   @Before
   public void setUp() throws Exception {
-    RMAPIConfigurationCache.getInstance().invalidate();
+    RMAPIConfigurationCache.getInstance().invalidate(STUB_TENANT);
   }
 
   /**

--- a/src/test/java/org/folio/util/TestUtil.java
+++ b/src/test/java/org/folio/util/TestUtil.java
@@ -21,6 +21,9 @@ import org.folio.rest.util.RestConstants;
 
 public final class TestUtil {
 
+  public static final String STUB_TENANT = "fs";
+  public static final String STUB_TOKEN = "TEST_OKAPI_TOKEN";
+
   private TestUtil() {
   }
 
@@ -65,8 +68,8 @@ public final class TestUtil {
    */
   public static RequestSpecBuilder getRequestSpecificationBuilder(String uri) {
     return new RequestSpecBuilder()
-      .addHeader(RestConstants.OKAPI_TENANT_HEADER, "fs")
-      .addHeader(RestConstants.OKAPI_TOKEN_HEADER, "TEST_OKAPI_TOKEN")
+      .addHeader(RestConstants.OKAPI_TENANT_HEADER, STUB_TENANT)
+      .addHeader(RestConstants.OKAPI_TOKEN_HEADER, STUB_TOKEN)
       .setBaseUri(uri)
       .log(LogDetail.ALL);
   }


### PR DESCRIPTION
## Purpose
Implement endpoint to invalidate configuration cache

## Approach
Added /eholdings/cache endpoint to eholdings.raml and to ModuleDescriptor-template.json
Implemented endpoint to only invalidate cache for current tenant