### PR TITLE
MODKBEKBJ-114: Change cache implementation to use vertx.sharedData

### DIFF
--- a/src/main/java/org/folio/config/RMAPIConfiguration.java
+++ b/src/main/java/org/folio/config/RMAPIConfiguration.java
@@ -30,10 +30,4 @@ public final class RMAPIConfiguration implements Shareable {
   public Boolean getConfigValid() {
     return configValid;
   }
-
-  @Override
-  public String toString() {
-    return "RMAPIConfiguration [customerId=" + customerId
-      + ", apiKey=" + apiKey + ", url=" + url + ']';
-  }
 }

--- a/src/main/java/org/folio/config/RMAPIConfiguration.java
+++ b/src/main/java/org/folio/config/RMAPIConfiguration.java
@@ -1,13 +1,19 @@
 package org.folio.config;
 
+import io.vertx.core.shareddata.Shareable;
+import lombok.Builder;
+import lombok.Value;
+
 /**
  * Contains the RM API connection details from mod-configuration.
  */
-public final class RMAPIConfiguration {
-  private String customerId;
-  private String apiKey;
-  private String url;
-  private Boolean configValid;
+@Value
+@Builder(toBuilder = true)
+public final class RMAPIConfiguration implements Shareable {
+  private final String customerId;
+  private final String apiKey;
+  private final String url;
+  private final Boolean configValid;
 
   public String getCustomerId() {
     return customerId;
@@ -23,22 +29,6 @@ public final class RMAPIConfiguration {
 
   public Boolean getConfigValid() {
     return configValid;
-  }
-
-  public void setCustomerId(String customerId) {
-    this.customerId = customerId;
-  }
-
-  public void setApiKey(String apiKey) {
-    this.apiKey = apiKey;
-  }
-
-  public void setUrl(String url) {
-    this.url = url;
-  }
-
-  public void setConfigValid(Boolean configValid) {
-    this.configValid = configValid;
   }
 
   @Override

--- a/src/main/java/org/folio/config/RMAPIConfigurationServiceCache.java
+++ b/src/main/java/org/folio/config/RMAPIConfigurationServiceCache.java
@@ -1,14 +1,15 @@
 package org.folio.config;
 
-import io.vertx.core.Context;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+
 import org.folio.config.api.RMAPIConfigurationService;
 import org.folio.config.cache.RMAPIConfigurationCache;
 import org.folio.config.model.ConfigurationError;
 import org.folio.rest.model.OkapiData;
+
+import io.vertx.core.Context;
 
 public class RMAPIConfigurationServiceCache implements RMAPIConfigurationService {
 
@@ -19,40 +20,41 @@ public class RMAPIConfigurationServiceCache implements RMAPIConfigurationService
   }
 
   @Override
-  public CompletableFuture<RMAPIConfiguration> retrieveConfiguration(OkapiData okapiData) {
-    RMAPIConfiguration cachedConfiguration = RMAPIConfigurationCache.getInstance()
+  public CompletableFuture<RMAPIConfiguration> retrieveConfiguration(OkapiData okapiData, Context vertxContext) {
+    RMAPIConfiguration cachedConfiguration = new RMAPIConfigurationCache(vertxContext.owner())
       .getValue(okapiData.getTenant());
     if(cachedConfiguration != null){
       return CompletableFuture.completedFuture(cachedConfiguration);
     }
 
-    return rmapiConfigurationService.retrieveConfiguration(okapiData)
+    return rmapiConfigurationService.retrieveConfiguration(okapiData, vertxContext)
     .thenCompose(rmapiConfiguration -> {
-      RMAPIConfigurationCache.getInstance()
+      new RMAPIConfigurationCache(vertxContext.owner())
         .putValue(okapiData.getTenant(), rmapiConfiguration);
       return CompletableFuture.completedFuture(rmapiConfiguration);
     });
   }
 
   @Override
-  public CompletableFuture<RMAPIConfiguration> updateConfiguration(RMAPIConfiguration rmapiConfiguration, OkapiData okapiData) {
-    return rmapiConfigurationService.updateConfiguration(rmapiConfiguration, okapiData)
+  public CompletableFuture<RMAPIConfiguration> updateConfiguration(RMAPIConfiguration rmapiConfiguration, Context vertxContext, OkapiData okapiData) {
+    return rmapiConfigurationService.updateConfiguration(rmapiConfiguration, vertxContext, okapiData)
     .thenCompose(configuration ->  {
-      RMAPIConfigurationCache.getInstance()
+      new RMAPIConfigurationCache(vertxContext.owner())
         .putValue(okapiData.getTenant(), configuration);
       return CompletableFuture.completedFuture(configuration);
     });
   }
 
   @Override
-  public CompletableFuture<List<ConfigurationError>> verifyCredentials(RMAPIConfiguration rmapiConfiguration, Context vertxContext) {
+  public CompletableFuture<List<ConfigurationError>> verifyCredentials(RMAPIConfiguration rmapiConfiguration, Context vertxContext, String tenant) {
     if(rmapiConfiguration.getConfigValid() != null && rmapiConfiguration.getConfigValid()){
       return CompletableFuture.completedFuture(Collections.emptyList());
     }
-    return rmapiConfigurationService.verifyCredentials(rmapiConfiguration, vertxContext)
+    return rmapiConfigurationService.verifyCredentials(rmapiConfiguration, vertxContext, tenant)
       .thenCompose(errors -> {
         if(errors.isEmpty()){
-          rmapiConfiguration.setConfigValid(true);
+          new RMAPIConfigurationCache(vertxContext.owner()).putValue(tenant,
+            rmapiConfiguration.toBuilder().configValid(true).build());
         }
         return CompletableFuture.completedFuture(errors);
       });

--- a/src/main/java/org/folio/config/api/RMAPIConfigurationService.java
+++ b/src/main/java/org/folio/config/api/RMAPIConfigurationService.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 public interface RMAPIConfigurationService {
-  CompletableFuture<RMAPIConfiguration> retrieveConfiguration(OkapiData okapiData);
-  CompletableFuture<RMAPIConfiguration> updateConfiguration(RMAPIConfiguration rmapiConfiguration, OkapiData okapiData);
-  CompletableFuture<List<ConfigurationError>> verifyCredentials(RMAPIConfiguration rmapiConfiguration, Context vertxContext);
+  CompletableFuture<RMAPIConfiguration> retrieveConfiguration(OkapiData okapiData, Context vertxContext);
+  CompletableFuture<RMAPIConfiguration> updateConfiguration(RMAPIConfiguration rmapiConfiguration, Context vertxContext, OkapiData okapiData);
+  CompletableFuture<List<ConfigurationError>> verifyCredentials(RMAPIConfiguration rmapiConfiguration, Context vertxContext, String tenant);
 }

--- a/src/main/java/org/folio/config/cache/RMAPIConfigurationCache.java
+++ b/src/main/java/org/folio/config/cache/RMAPIConfigurationCache.java
@@ -9,7 +9,6 @@ import org.folio.properties.PropertyConfiguration;
 import io.vertx.core.Vertx;
 import io.vertx.core.shareddata.LocalMap;
 import io.vertx.core.shareddata.Shareable;
-import lombok.Builder;
 import lombok.Value;
 
 public final class RMAPIConfigurationCache {
@@ -50,7 +49,6 @@ public final class RMAPIConfigurationCache {
   }
 
   @Value
-  @Builder(toBuilder = true)
   private static class RMAPIConfigurationWrapper implements Shareable {
     private final LocalDateTime expireTime;
     private final RMAPIConfiguration rmapiConfiguration;

--- a/src/main/java/org/folio/config/cache/RMAPIConfigurationCache.java
+++ b/src/main/java/org/folio/config/cache/RMAPIConfigurationCache.java
@@ -1,36 +1,58 @@
 package org.folio.config.cache;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
 import org.folio.config.RMAPIConfiguration;
 import org.folio.properties.PropertyConfiguration;
 
-import java.util.concurrent.TimeUnit;
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.LocalMap;
+import io.vertx.core.shareddata.Shareable;
+import lombok.Builder;
+import lombok.Value;
 
 public final class RMAPIConfigurationCache {
-  private final Cache<String, RMAPIConfiguration> cache;
+  private Vertx vertx;
+  private long expirationTime;
 
-  private static final RMAPIConfigurationCache INSTANCE = new RMAPIConfigurationCache();
-  private RMAPIConfigurationCache() {
-    Long expirationTime = PropertyConfiguration.getInstance().getConfiguration().getLong("configuration.cache.expire");
-    this.cache =  CacheBuilder.newBuilder()
-      .expireAfterWrite(expirationTime, TimeUnit.SECONDS)
-      .build();
+  public RMAPIConfigurationCache(Vertx vertx) {
+    this.expirationTime = PropertyConfiguration.getInstance().getConfiguration().getLong("configuration.cache.expire");
+    this.vertx = vertx;
   }
 
-  public static RMAPIConfigurationCache getInstance(){
-    return INSTANCE;
-  }
-
-  public RMAPIConfiguration getValue(String tenant){
-    return cache.getIfPresent(tenant);
+  public RMAPIConfiguration getValue(String tenant) {
+    RMAPIConfigurationWrapper configurationWrapper = getLocalMap().computeIfPresent(tenant, (key, configuration) -> {
+      if (LocalDateTime.now().isBefore(configuration.getExpireTime())) {
+        return configuration;
+      } else {
+        return null;
+      }
+    });
+    if (configurationWrapper == null) {
+      return null;
+    } else {
+      return configurationWrapper.getRmapiConfiguration();
+    }
   }
 
   public void putValue(String tenant, RMAPIConfiguration configuration){
-    cache.put(tenant, configuration);
+    LocalDateTime expireTime = LocalDateTime.now().plus(expirationTime, ChronoUnit.SECONDS);
+    getLocalMap().put(tenant, new RMAPIConfigurationWrapper(expireTime, configuration));
   }
 
   public void invalidate(String tenant){
-    cache.invalidate(tenant);
+    getLocalMap().remove(tenant);
+  }
+
+  private LocalMap<String, RMAPIConfigurationWrapper> getLocalMap() {
+    return vertx.sharedData().getLocalMap("configurationMap");
+  }
+
+  @Value
+  @Builder(toBuilder = true)
+  private static class RMAPIConfigurationWrapper implements Shareable {
+    private final LocalDateTime expireTime;
+    private final RMAPIConfiguration rmapiConfiguration;
   }
 }

--- a/src/main/java/org/folio/rest/converter/RMAPIConfigurationConverter.java
+++ b/src/main/java/org/folio/rest/converter/RMAPIConfigurationConverter.java
@@ -36,10 +36,10 @@ public class RMAPIConfigurationConverter {
     String rmapiBaseUrl = configuration.getData().getAttributes().getRmapiBaseUrl();
     rmapiBaseUrl = rmapiBaseUrl != null ? rmapiBaseUrl : DEFAULT_URL;
 
-    RMAPIConfiguration rmapiConfiguration = new RMAPIConfiguration();
-    rmapiConfiguration.setUrl(rmapiBaseUrl);
-    rmapiConfiguration.setApiKey(configuration.getData().getAttributes().getApiKey());
-    rmapiConfiguration.setCustomerId(configuration.getData().getAttributes().getCustomerId());
-    return rmapiConfiguration;
+    RMAPIConfiguration.RMAPIConfigurationBuilder builder = RMAPIConfiguration.builder();
+    builder.url(rmapiBaseUrl);
+    builder.apiKey(configuration.getData().getAttributes().getApiKey());
+    builder.customerId(configuration.getData().getAttributes().getCustomerId());
+    return builder.build();
   }
 }

--- a/src/main/java/org/folio/rest/impl/EHoldingsRootProxyImpl.java
+++ b/src/main/java/org/folio/rest/impl/EHoldingsRootProxyImpl.java
@@ -67,7 +67,7 @@ public class EHoldingsRootProxyImpl implements EholdingsRootProxy {
 
     headerValidator.validate(okapiHeaders);
     CompletableFuture.completedFuture(null)
-      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenCompose(rmapiConfiguration -> {
         RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
           rmapiConfiguration.getUrl(), vertxContext.owner());
@@ -99,7 +99,7 @@ public class EHoldingsRootProxyImpl implements EholdingsRootProxy {
 
     MutableObject<RMAPIService> service = new MutableObject<>();
     CompletableFuture.completedFuture(null)
-      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenAccept(rmapiConfiguration ->
         service.setValue(new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
           rmapiConfiguration.getUrl(), vertxContext.owner())))

--- a/src/main/java/org/folio/rest/impl/EholdingsCacheImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsCacheImpl.java
@@ -28,7 +28,7 @@ public class EholdingsCacheImpl implements EholdingsCache {
   @Override
   public void deleteEholdingsCache(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     headerValidator.validate(okapiHeaders);
-    RMAPIConfigurationCache.getInstance().invalidate(okapiHeaders.get(RestConstants.OKAPI_TENANT_HEADER));
+    new RMAPIConfigurationCache(vertxContext.owner()).invalidate(okapiHeaders.get(RestConstants.OKAPI_TENANT_HEADER));
     asyncResultHandler.handle(Future.succeededFuture(EholdingsCacheImpl.DeleteEholdingsCacheResponse.respond204()));
   }
 }

--- a/src/main/java/org/folio/rest/impl/EholdingsConfigurationImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsConfigurationImpl.java
@@ -54,7 +54,7 @@ public class EholdingsConfigurationImpl implements EholdingsConfiguration {
   public void getEholdingsConfiguration(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     headerValidator.validate(okapiHeaders);
     CompletableFuture.completedFuture(null)
-      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenAccept(rmapiConfiguration -> {
         Configuration configuration = converter.convertToConfiguration(rmapiConfiguration);
         asyncResultHandler.handle(Future.succeededFuture(GetEholdingsConfigurationResponse.respond200WithApplicationVndApiJson(configuration)));
@@ -77,7 +77,7 @@ public class EholdingsConfigurationImpl implements EholdingsConfiguration {
     CompletableFuture.completedFuture(null)
       .thenCompose(o -> {
         okapiData.setValue(new OkapiData(okapiHeaders));
-        return configurationService.verifyCredentials(rmapiConfiguration, vertxContext);
+        return configurationService.verifyCredentials(rmapiConfiguration, vertxContext, okapiData.getValue().getTenant());
       })
       .thenCompose(errors -> {
         if (!errors.isEmpty()) {
@@ -87,7 +87,7 @@ public class EholdingsConfigurationImpl implements EholdingsConfiguration {
         }
         return CompletableFuture.completedFuture(null);
       })
-      .thenCompose(o -> configurationService.updateConfiguration(rmapiConfiguration, okapiData.getValue()))
+      .thenCompose(o -> configurationService.updateConfiguration(rmapiConfiguration, vertxContext, okapiData.getValue()))
       .thenAccept(configuration ->
         asyncResultHandler.handle(Future.succeededFuture(PutEholdingsConfigurationResponse
           .respond200WithApplicationVndApiJson(converter.convertToConfiguration(rmapiConfiguration)))))

--- a/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
@@ -119,7 +119,7 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
     Sort nameSort = Sort.valueOf(sort.toUpperCase());
     MutableObject<RMAPIService> service = new MutableObject<>();
     CompletableFuture.completedFuture(null)
-      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenAccept(rmapiConfiguration ->
         service.setValue(new RMAPIService(rmapiConfiguration.getCustomerId(),
           rmapiConfiguration.getAPIKey(), rmapiConfiguration.getUrl(), vertxContext.owner())))
@@ -154,7 +154,7 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
 
     MutableObject<RMAPIService> service = new MutableObject<>();
     CompletableFuture.completedFuture(null)
-      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenAccept(rmapiConfiguration ->
         service.setValue(new RMAPIService(rmapiConfiguration.getCustomerId(),
           rmapiConfiguration.getAPIKey(), rmapiConfiguration.getUrl(), vertxContext.owner())))
@@ -182,7 +182,7 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
     PackageId parsedPackageId = idParser.parsePackageId(packageId);
     headerValidator.validate(okapiHeaders);
     CompletableFuture.completedFuture(null)
-      .thenCompose(okapiData -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(okapiData -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenCompose(rmapiConfiguration -> {
         RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
           rmapiConfiguration.getUrl(), vertxContext.owner());
@@ -205,7 +205,7 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
     PackageId parsedPackageId = idParser.parsePackageId(packageId);
     MutableObject<RMAPIService> rmapiService = new MutableObject<>();
     CompletableFuture.completedFuture(null)
-      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenCompose(rmapiConfiguration -> {
         rmapiService.setValue(new RMAPIService(rmapiConfiguration.getCustomerId(),
           rmapiConfiguration.getAPIKey(), rmapiConfiguration.getUrl(), vertxContext.owner()));
@@ -247,7 +247,7 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
     PackageId parsedPackageId = idParser.parsePackageId(packageId);
     MutableObject<RMAPIService> rmapiService = new MutableObject<>();
     CompletableFuture.completedFuture(null)
-      .thenCompose(okapiData -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(okapiData -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenCompose(rmapiConfiguration -> {
         rmapiService.setValue(new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
           rmapiConfiguration.getUrl(), vertxContext.owner()));
@@ -286,7 +286,7 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
     Sort nameSort = Sort.valueOf(sort.toUpperCase());
 
     CompletableFuture.completedFuture(null)
-      .thenCompose(okapiData -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(okapiData -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenCompose(rmapiConfiguration -> {
         RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
           rmapiConfiguration.getUrl(), vertxContext.owner());

--- a/src/main/java/org/folio/rest/impl/EholdingsProvidersImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsProvidersImpl.java
@@ -92,7 +92,7 @@ public class EholdingsProvidersImpl implements EholdingsProviders {
     validateQuery(q);
 
     CompletableFuture.completedFuture(null)
-    .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+    .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
     .thenCompose(rmapiConfiguration -> {
       RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
         rmapiConfiguration.getUrl(), vertxContext.owner());
@@ -130,7 +130,7 @@ public class EholdingsProvidersImpl implements EholdingsProviders {
     headerValidator.validate(okapiHeaders);
 
     CompletableFuture.completedFuture(null)
-      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenCompose(rmapiConfiguration -> {
         RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
           rmapiConfiguration.getUrl(), vertxContext.owner());
@@ -165,7 +165,7 @@ public class EholdingsProvidersImpl implements EholdingsProviders {
     VendorPut rmapiVendor = converter.convertToVendor(entity);
 
     CompletableFuture.completedFuture(null)
-        .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+        .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
         .thenCompose(rmapiConfiguration -> {
           RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(),
               rmapiConfiguration.getAPIKey(), rmapiConfiguration.getUrl(), vertxContext.owner());
@@ -198,7 +198,7 @@ public class EholdingsProvidersImpl implements EholdingsProviders {
 
     Sort nameSort = Sort.valueOf(sort.toUpperCase());
     CompletableFuture.completedFuture(null)
-      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenCompose(rmapiConfiguration -> {
         RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
           rmapiConfiguration.getUrl(), vertxContext.owner());

--- a/src/main/java/org/folio/rest/impl/EholdingsProxyTypesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsProxyTypesImpl.java
@@ -38,7 +38,7 @@ public class EholdingsProxyTypesImpl implements EholdingsProxyTypes {
   private ProxyConverter converter;
   private HeaderValidator headerValidator;
 
-  
+
   public EholdingsProxyTypesImpl() {
     this(new RMAPIConfigurationServiceCache(
             new RMAPIConfigurationServiceImpl(new ConfigurationClientProvider())),
@@ -58,7 +58,7 @@ public class EholdingsProxyTypesImpl implements EholdingsProxyTypes {
     headerValidator.validate(okapiHeaders);
 
     CompletableFuture.completedFuture(null)
-      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenCompose(rmapiConfiguration -> {
         RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
           rmapiConfiguration.getUrl(), vertxContext.owner());

--- a/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
@@ -83,7 +83,7 @@ public class EholdingsResourcesImpl implements EholdingsResources{
     boolean includeTitle = includedObjects.contains("title");
 
     CompletableFuture.completedFuture(null)
-      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenCompose(rmapiConfiguration -> {
         RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
           rmapiConfiguration.getUrl(), vertxContext.owner());

--- a/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
@@ -95,7 +95,7 @@ public class EholdingsTitlesImpl implements EholdingsTitles {
     Sort nameSort = Sort.valueOf(sort.toUpperCase());
 
     CompletableFuture.completedFuture(null)
-      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenCompose(rmapiConfiguration -> {
         RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
           rmapiConfiguration.getUrl(), vertxContext.owner());
@@ -126,7 +126,7 @@ public class EholdingsTitlesImpl implements EholdingsTitles {
 
     MutableObject<RMAPIService> service = new MutableObject<>();
     CompletableFuture.completedFuture(null)
-      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenAccept(rmapiConfiguration ->
         service.setValue(new RMAPIService(rmapiConfiguration.getCustomerId(),
           rmapiConfiguration.getAPIKey(), rmapiConfiguration.getUrl(), vertxContext.owner())))
@@ -151,7 +151,7 @@ public class EholdingsTitlesImpl implements EholdingsTitles {
 
     headerValidator.validate(okapiHeaders);
     CompletableFuture.completedFuture(null)
-      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
       .thenCompose(rmapiConfiguration -> {
         RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
           rmapiConfiguration.getUrl(), vertxContext.owner());

--- a/src/test/java/org/folio/rest/impl/WireMockTestBase.java
+++ b/src/test/java/org/folio/rest/impl/WireMockTestBase.java
@@ -42,6 +42,7 @@ public abstract class WireMockTestBase {
   protected static final String CONFIGURATION_STUB_FILE = "responses/configuration/get-configuration.json";
   protected static int port;
   protected static String host;
+  protected static final Vertx vertx = Vertx.vertx();
 
   @Rule
   public TestRule watcher = new TestWatcher() {
@@ -61,7 +62,6 @@ public abstract class WireMockTestBase {
 
   @BeforeClass
   public static void setUpClass(final TestContext context) {
-    Vertx vertx = Vertx.vertx();
     vertx.exceptionHandler(context.exceptionHandler());
     port = NetworkUtils.nextFreePort();
     host = "http://localhost";
@@ -72,7 +72,7 @@ public abstract class WireMockTestBase {
 
   @Before
   public void setUp() throws Exception {
-    RMAPIConfigurationCache.getInstance().invalidate(STUB_TENANT);
+    new RMAPIConfigurationCache(vertx).invalidate(STUB_TENANT);
   }
 
   /**

--- a/src/test/java/org/folio/rmapi/config/RMAPIConfigurationServiceTest.java
+++ b/src/test/java/org/folio/rmapi/config/RMAPIConfigurationServiceTest.java
@@ -44,7 +44,7 @@ public class RMAPIConfigurationServiceTest {
   private RMAPIConfigurationService configurationService = new RMAPIConfigurationServiceImpl(configurationClientProvider);
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     when(configurationClientProvider.createClient(anyString(), anyInt(), anyString(), anyString())).thenReturn(mockConfigurationsClient);
   }
 
@@ -55,7 +55,7 @@ public class RMAPIConfigurationServiceTest {
     when(response.bodyHandler(any())).thenAnswer(new HandleBodyAnswer(new BufferImpl()));
     doAnswer(new HandleResponseAnswer(response, 5))
       .when(mockConfigurationsClient).getEntries(anyString(), anyInt(), anyInt(), any(), any(), any());
-    CompletableFuture<RMAPIConfiguration> future = configurationService.retrieveConfiguration(OKAPI_DATA);
+    CompletableFuture<RMAPIConfiguration> future = configurationService.retrieveConfiguration(OKAPI_DATA, null);
     assertTrue(future.isCompletedExceptionally());
   }
 
@@ -63,7 +63,7 @@ public class RMAPIConfigurationServiceTest {
   public void shouldCompleteExceptionallyWhenHttpClientThrowsException() throws Exception {
     doThrow(new UnsupportedEncodingException()).when(mockConfigurationsClient)
       .getEntries(anyString(), anyInt(), anyInt(), any(), any(), any());
-    CompletableFuture<RMAPIConfiguration> future = configurationService.retrieveConfiguration(OKAPI_DATA);
+    CompletableFuture<RMAPIConfiguration> future = configurationService.retrieveConfiguration(OKAPI_DATA, null);
     assertTrue(future.isCompletedExceptionally());
   }
 
@@ -91,7 +91,7 @@ public class RMAPIConfigurationServiceTest {
     doAnswer(new HandleResponseAnswer(deleteResponse, 2))
       .when(mockConfigurationsClient).deleteEntryId(any(), any(), any());
 
-    CompletableFuture<RMAPIConfiguration> future = configurationService.updateConfiguration(new RMAPIConfiguration(), OKAPI_DATA);
+    CompletableFuture<RMAPIConfiguration> future = configurationService.updateConfiguration(RMAPIConfiguration.builder().build(), null , OKAPI_DATA);
     assertTrue(future.isCompletedExceptionally());
   }
 
@@ -113,7 +113,7 @@ public class RMAPIConfigurationServiceTest {
     }
 
     @Override
-    public Object answer(InvocationOnMock invocation) throws Throwable {
+    public Object answer(InvocationOnMock invocation) {
       ((Handler<Buffer>) invocation.getArgument(0)).handle(body);
       return invocation.getMock();
     }
@@ -129,7 +129,7 @@ public class RMAPIConfigurationServiceTest {
     }
 
     @Override
-    public Object answer(InvocationOnMock invocation) throws Throwable {
+    public Object answer(InvocationOnMock invocation) {
       ((Handler<HttpClientResponse>) invocation.getArgument(handlerArgumentIndex)).handle(response);
       return null;
     }


### PR DESCRIPTION
## Purpose
Use the way to share data between verticles that is provided by Vert.x instead of relying on singleton with static variable
## Approach
Made RMAPIConfiguration immutable and implemented cache by using
vertx SharedData object