### PR TITLE
MODKBEKBJ-113 replace logging implementation with log4j2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
     <raml-module-builder.version>23.2.0</raml-module-builder.version>
     <vertx.version>3.5.4</vertx.version>
     <aspectj.version>1.9.1</aspectj.version>
-    <slf4j.version>1.7.25</slf4j.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mod-configuration-client.version>4.0.3</mod-configuration-client.version>
@@ -104,19 +103,14 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4.9</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>2.9.1</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>
@@ -154,11 +148,6 @@
       <artifactId>jsonassert</artifactId>
       <version>1.5.0</version>
       <scope>test</scope>
-  </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <version>4.4.9</version>
     </dependency>
   </dependencies>
 
@@ -382,8 +371,8 @@
             <configuration>
               <properties>
                 <property>
-                  <name>log4j.configuration</name>
-                  <value>${project.baseUri}src/main/resources/log4j.properties</value>
+                  <name>log4j.configurationFile</name>
+                  <value>${project.baseUri}src/main/resources/log4j2.xml</value>
                 </property>
               </properties>
             </configuration>
@@ -439,6 +428,11 @@
                https://issues.apache.org/jira/browse/SUREFIRE-1588
           -->
           <useSystemClassLoader>false</useSystemClassLoader>
+          <systemPropertyVariables>
+            <vertx.logger-delegate-factory-class-name>
+              io.vertx.core.logging.Log4j2LogDelegateFactory
+            </vertx.logger-delegate-factory-class-name>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
 

--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -7,6 +7,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.json.Json;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.mutable.MutableObject;
 import org.folio.rest.jaxrs.model.RootProxyPutRequest;
@@ -42,15 +50,6 @@ import org.folio.rmapi.model.VendorPut;
 import org.folio.rmapi.model.Vendors;
 import org.folio.rmapi.result.ResourceResult;
 import org.folio.rmapi.result.VendorResult;
-
-import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.json.Json;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 
 public class RMAPIService {
 
@@ -96,8 +95,8 @@ public class RMAPIService {
   private <T> void handleRMAPIError(HttpClientResponse response, String query, Buffer body,
       CompletableFuture<T> future) {
 
-    LOG.error(String.format("%s status code = [%s] status message = [%s] query = [%s] body = [%s]",
-      INVALID_RMAPI_RESPONSE, response.statusCode(), response.statusMessage(), query, body.toString()));
+    LOG.error("{} status code = [{}] status message = [{}] query = [{}] body = [{}]",
+      INVALID_RMAPI_RESPONSE, response.statusCode(), response.statusMessage(), query, body.toString());
 
     String msgBody = mapVendorToProvider(body.toString());
 
@@ -130,7 +129,7 @@ public class RMAPIService {
 
     addRequestHeaders(request);
 
-    LOG.info("RMAPI Service GET absolute URL is:" + request.absoluteURI());
+    LOG.info("RMAPI Service GET absolute URL is: {}", request.absoluteURI());
 
     executeRequest(query, clazz, future, httpClient, request);
 
@@ -150,7 +149,7 @@ public class RMAPIService {
 
     addRequestHeaders(request);
 
-    LOG.info("RMAPI Service PUT absolute URL is:" + request.absoluteURI());
+    LOG.info("RMAPI Service PUT absolute URL is: {}", request.absoluteURI());
 
     request.handler(response -> response.bodyHandler(body -> {
       httpClient.close();
@@ -163,7 +162,7 @@ public class RMAPIService {
     })).exceptionHandler(future::completeExceptionally);
 
     String encodedBody = Json.encodePrettily(putData);
-    LOG.info("RMAPI Service PUT body is:" + encodedBody);
+    LOG.info("RMAPI Service PUT body is: {}", encodedBody);
     request.end(encodedBody);
 
     return future;
@@ -180,15 +179,15 @@ public class RMAPIService {
 
     addRequestHeaders(request);
 
-    LOG.info("RMAPI Service POST absolute URL is:" + request.absoluteURI());
+    LOG.info("RMAPI Service POST absolute URL is: {}", request.absoluteURI());
 
     executeRequest(query, clazz, future, httpClient, request);
 
     String encodedBody = Json.encodePrettily(postData);
-    LOG.info("RMAPI Service POST body is:" + encodedBody);
+    LOG.info("RMAPI Service POST body is: {}", encodedBody);
     request.end(encodedBody);
 
-      return future;
+    return future;
   }
 
   private <T> void executeRequest(String query, Class<T> clazz, CompletableFuture<T> future,
@@ -200,9 +199,8 @@ public class RMAPIService {
           T results = Json.decodeValue(body.toString(), clazz);
           future.complete(results);
         } catch (Exception e) {
-          LOG.error(
-              String.format("%s - Response = [%s] Target Type = [%s] Cause: [%s]",
-                JSON_RESPONSE_ERROR, body.toString(), clazz, e.getMessage()));
+          LOG.error("{} - Response = [{}] Target Type = [{}] Cause: [{}]",
+                JSON_RESPONSE_ERROR, body.toString(), clazz, e.getMessage());
             future.completeExceptionally(
               new RMAPIResultsProcessingException(String.format("%s for query = %s", JSON_RESPONSE_ERROR, query), e));
           }

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,8 +1,0 @@
-# variables are substituted from filters-[production|development].properties
-log4j.rootLogger=INFO, CONSOLE
-#log4j.rootLogger=DEBUG, CONSOLE
-
-# CONSOLE is set to be a ConsoleAppender using a PatternLayout.
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{HH:mm:ss} %-5p %-20.20C{1} %m%n

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="CONSOLE" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5p %-20.20C{1} [%reqId] %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="CONSOLE"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/src/test/java/org/folio/rest/impl/WireMockTestBase.java
+++ b/src/test/java/org/folio/rest/impl/WireMockTestBase.java
@@ -13,6 +13,8 @@ import io.restassured.specification.RequestSpecification;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.TestContext;
 import org.folio.config.cache.RMAPIConfigurationCache;
 import org.folio.http.HttpConsts;
@@ -26,8 +28,6 @@ import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Base test class for tests that use wiremock and vertx http servers,

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,8 +1,0 @@
-# variables are substituted from filters-[production|development].properties
-log4j.rootLogger=INFO, CONSOLE
-#log4j.rootLogger=DEBUG, CONSOLE
-
-# CONSOLE is set to be a ConsoleAppender using a PatternLayout.
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%-5p %m%n

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="CONSOLE" target="SYSTEM_OUT">
+      <PatternLayout pattern="%-5p %-20.20C{1} %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="CONSOLE"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
## Purpose
Make log4j2 a logging implementation for the module

## Approach
- add log4j2 configuration for tests (`log4j2-test.xml`) and primary code (`log4j2.xml`). the last one will be used only if `domain-models-runtime` doesn't provide the configuration
- remove explicit usage of slf4j logger from the tests; add log4j-slf4j bridge to be used by wiremock
- use log placeholders wherever an object has to be added into the log message 
- set log4j2 delegate factory for tests in `maven-surefire-plugin`

## Learning
* `RestLancher` initialize vertx logging delegate factory in static block and it's log4j2 one
![image](https://user-images.githubusercontent.com/42244720/49799297-482cba00-fd4d-11e8-9026-27d4a4f15469.png)
It'd be better to define the property in deployment descriptor or other configuration but that's we have for the moment.  
* `domain-models-runtime` jar contains log4j2.properties. it can be overridden only by setting `log4j.configurationFile` system property (see also https://logging.apache.org/log4j/2.0/manual/configuration.html)
