### PR TITLE
MODKBEKBJ-62: Change raml schema to have relationship and included attributes

### DIFF
--- a/ramls/types/hasManyRelationship.json
+++ b/ramls/types/hasManyRelationship.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Relationship for an array of objects",
+  "description": "Metadata of relationship that describes array of objects",
+  "javaType": "org.folio.rest.jaxrs.model.HasManyRelationship",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "data": {
+      "type": "array",
+      "description": "relationship Data Information",
+      "items": {
+        "type": "object",
+        "$ref": "relationshipData.json"
+      }
+    },
+    "meta": {
+      "type": "object",
+      "description": "Meta information",
+      "$ref": "included.json"
+    }
+  }
+}

--- a/ramls/types/packages/package.json
+++ b/ramls/types/packages/package.json
@@ -11,6 +11,14 @@
       "description": "The Data Schema",
       "$ref": "packageCollectionItem.json"
     },
+    "included": {
+      "type": "array",
+      "description": "List of included items",
+      "items": {
+        "type": "object",
+        "javaType" : "java.lang.Object"
+      }
+    },
     "jsonapi": {
       "type": "object",
       "description": "version of json api",

--- a/ramls/types/packages/packageRelationships.json
+++ b/ramls/types/packages/packageRelationships.json
@@ -9,12 +9,12 @@
     "resources": {
       "type": "object",
       "description": "Displays Resources Relationship if any",
-      "$ref": "../metaIncluded.json"
+      "$ref": "../hasManyRelationship.json"
     },
     "provider": {
       "type": "object",
       "description": "Displays Provider Relationship if any",
-      "$ref": "../metaIncluded.json"
+      "$ref": "../hasOneRelationship.json"
     }
   }
 }

--- a/src/main/java/org/folio/rest/converter/PackagesConverter.java
+++ b/src/main/java/org/folio/rest/converter/PackagesConverter.java
@@ -7,10 +7,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 import org.folio.rest.jaxrs.model.ContentType;
 import org.folio.rest.jaxrs.model.Coverage;
+import org.folio.rest.jaxrs.model.HasManyRelationship;
+import org.folio.rest.jaxrs.model.HasOneRelationship;
 import org.folio.rest.jaxrs.model.MetaDataIncluded;
-import org.folio.rest.jaxrs.model.MetaIncluded;
 import org.folio.rest.jaxrs.model.MetaTotalResults;
 import org.folio.rest.jaxrs.model.Package;
 import org.folio.rest.jaxrs.model.PackageCollection;
@@ -34,9 +36,9 @@ public class PackagesConverter {
 
   private static final Map<String, ContentType> contentTypes = new HashMap<>();
   private static final PackageRelationship EMPTY_PACKAGES_RELATIONSHIP = new PackageRelationship()
-    .withProvider(new MetaIncluded()
+    .withProvider(new HasOneRelationship()
       .withMeta(new MetaDataIncluded().withIncluded(false)))
-    .withResources(new MetaIncluded()
+    .withResources(new HasManyRelationship()
       .withMeta(new MetaDataIncluded()
         .withIncluded(false)));
   private static final Map<ContentType, Integer> contentTypeToRMAPICode = new EnumMap<>(ContentType.class);


### PR DESCRIPTION
## Purpose
Change raml schema for implementation of MODKBEKBJ-62 and MODKBEKBJ-63

## Approach
Added included attribute with type Object, so that it can include both
title and provider objects
Added hasManyRelationship.json and changed packageRelationships.json to
use it. Old metaIncluded.json schema doesn't have fields for id and type
of related objects.