### PR TITLE
MODKBEKBJ-32: Implement PUT for custom and managed resources

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -68,7 +68,8 @@
         },
         {
           "methods": ["PUT"],
-          "pathPattern": "/eholdings/resources/{resourceId}"
+          "pathPattern": "/eholdings/resources/{resourceId}",
+          "permissionsRequired": ["kb-ebsco.resource.put"]
         },
         {
           "methods": ["DELETE"],
@@ -194,6 +195,11 @@
       "description": "Post resource"
     },
     {
+      "permissionName": "kb-ebsco.resource.put",
+      "displayName": "put single resource",
+      "description": "Put single resource"
+    },
+    {
       "permissionName": "kb-ebsco.packageCollection.get",
       "displayName": "get packages",
       "description": "Get packages"
@@ -262,6 +268,7 @@
         "kb-ebsco.package.put",
         "kb-ebsco.resource.get",
         "kb-ebsco.resource.post",
+        "kb-ebsco.resource.put",
         "kb-ebsco.proxyTypes.get",
         "kb-ebsco.root-proxy.get",
         "kb-ebsco.root-proxy.put"

--- a/ramls/types/identifier.json
+++ b/ramls/types/identifier.json
@@ -14,13 +14,13 @@
     "subtype": {
       "type": "string",
       "description": "Subtype for the identifier. Valid values are  Print, Online.",
-      "enum": [ "Print", "Online"],
+      "enum": [ "Empty", "Print", "Online", "Preceding", "Succeeding", "Regional", "Linking", "Invalid"],
       "example": "Print"
     },
     "type": {
       "type": "string",
       "description": "Type of identifier. Valid values are ISSN, ISBN.",
-      "enum": [ "ISSN", "ISBN"],
+      "enum": [ "ISSN", "ISBN", "TSDID", "SPID", "EjsJournalID", "NewsbankID", "ZDBID", "EPBookID", "Mid", "BHM"],
       "example": "ISSN"
     }
   }

--- a/ramls/types/resources/resourcePutData.json
+++ b/ramls/types/resources/resourcePutData.json
@@ -6,6 +6,12 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "id": {
+      "type": "string",
+      "readonly": true,
+      "description": "Unique resource id",
+      "example": "123356-3157038-394579"
+    },
     "type": {
       "description": "Data type",
       "type": "string",

--- a/src/main/java/org/folio/rest/converter/CommonAttributesConverter.java
+++ b/src/main/java/org/folio/rest/converter/CommonAttributesConverter.java
@@ -38,7 +38,7 @@ public class CommonAttributesConverter {
     IDENTIFIER_SUBTYPES.put(2, Subtype.ONLINE);
   }
 
-  private static final Map<String, org.folio.rest.jaxrs.model.EmbargoPeriod.EmbargoUnit> EMBARGO_UNITS = new HashMap<>();
+  protected static final Map<String, org.folio.rest.jaxrs.model.EmbargoPeriod.EmbargoUnit> EMBARGO_UNITS = new HashMap<>();
   static {
     EMBARGO_UNITS.put("Days", EmbargoUnit.DAYS);
     EMBARGO_UNITS.put("Weeks", EmbargoUnit.WEEKS);

--- a/src/main/java/org/folio/rest/converter/ResourcesConverter.java
+++ b/src/main/java/org/folio/rest/converter/ResourcesConverter.java
@@ -1,17 +1,34 @@
 package org.folio.rest.converter;
 
 import org.folio.rest.jaxrs.model.*;
+import static java.util.stream.Collectors.toList;
+import static org.folio.rest.util.RestConstants.PACKAGES_TYPE;
+import static org.folio.rest.util.RestConstants.PROVIDERS_TYPE;
+import static org.folio.rest.util.RestConstants.TITLES_TYPE;
+
+import java.util.ArrayList;
+
+import org.folio.rest.jaxrs.model.Coverage;
+import org.folio.rest.jaxrs.model.EmbargoPeriod.EmbargoUnit;
+import org.folio.rest.jaxrs.model.HasOneRelationship;
+import org.folio.rest.jaxrs.model.MetaDataIncluded;
+import org.folio.rest.jaxrs.model.RelationshipData;
+import org.folio.rest.jaxrs.model.Resource;
+import org.folio.rest.jaxrs.model.ResourceCollectionItem;
+import org.folio.rest.jaxrs.model.ResourceDataAttributes;
+import org.folio.rest.jaxrs.model.ResourcePutRequest;
+import org.folio.rest.jaxrs.model.ResourceRelationships;
 import org.folio.rest.util.RestConstants;
 import org.folio.rmapi.model.*;
+import org.folio.rmapi.model.CoverageDates;
+import org.folio.rmapi.model.EmbargoPeriod;
+import org.folio.rmapi.model.PackageByIdData;
+import org.folio.rmapi.model.ResourcePut;
 import org.folio.rmapi.model.Title;
 import org.folio.rmapi.model.Titles;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.toList;
-import static org.folio.rest.util.RestConstants.*;
 
 public class ResourcesConverter {
   private CommonAttributesConverter commonConverter;
@@ -141,5 +158,85 @@ public class ResourcesConverter {
       .withManagedCoverages(commonConverter.convertCoverages(resource.getManagedCoverageList()))
       .withCustomCoverages(commonConverter.convertCoverages(resource.getCustomCoverageList()))
       .withProxy(commonConverter.convertProxy(resource.getProxy()));
+  }
+
+  public org.folio.rmapi.model.ResourcePut convertToRMAPIResourcePutRequest(ResourcePutRequest entity) {
+    ResourceDataAttributes attributes = entity.getData().getAttributes();
+    //Map common attributes for custom/managed resources to RM API fields
+    ResourcePut.ResourcePutBuilder builder = convertCommonAttributesToResourcePutRequest(attributes);
+    return builder.build();
+  }
+
+  public ResourcePut convertToRMAPICustomResourcePutRequest(ResourcePutRequest entity) {
+    ResourceDataAttributes attributes = entity.getData().getAttributes();
+    //Map common attributes for custom/managed resources to RM API fields
+    ResourcePut.ResourcePutBuilder builder = convertCommonAttributesToResourcePutRequest(attributes);
+    //Map attributes specific to custom resources to RM API fields
+    builder.titleName(attributes.getName());
+    builder.publisherName(attributes.getPublisherName());
+    builder.edition(attributes.getEdition());
+    builder.description(attributes.getDescription());
+    builder.url(attributes.getUrl());
+    if (attributes.getIdentifiers() != null && !attributes.getIdentifiers().isEmpty()) {
+      builder.identifiersList(commonConverter.convertToIdentifiers(attributes.getIdentifiers()));
+    }
+    if (attributes.getContributors() != null && !attributes.getContributors().isEmpty()) {
+      builder.contributorsList(commonConverter.convertToContributors(attributes.getContributors()));
+    }
+    return builder.build();
+  }
+
+  private ResourcePut.ResourcePutBuilder convertCommonAttributesToResourcePutRequest(ResourceDataAttributes attributes) {
+    ResourcePut.ResourcePutBuilder builder = ResourcePut.builder();
+
+    builder.isSelected(attributes.getIsSelected());
+
+    if (attributes.getProxy() != null) {
+      //RM API gives an error when we pass inherited as true along with updated proxy value
+      //Hard code it to false; it should not affect the state of inherited that RM API maintains
+      org.folio.rmapi.model.Proxy proxy = org.folio.rmapi.model.Proxy.builder()
+        .id(attributes.getProxy().getId())
+        .inherited(false)
+        .build();
+      builder.proxy(proxy);
+    }
+
+    if (attributes.getVisibilityData() != null) {
+      builder.isHidden(attributes.getVisibilityData().getIsHidden());
+    }
+    
+    if (attributes.getCoverageStatement() != null) {
+      builder.coverageStatement(attributes.getCoverageStatement());
+    }
+    
+    if (attributes.getCustomEmbargoPeriod() != null) {
+      EmbargoUnit embargoUnit = attributes.getCustomEmbargoPeriod().getEmbargoUnit();
+      EmbargoPeriod customEmbargo = EmbargoPeriod.builder()
+          .embargoUnit(embargoUnit != null ? embargoUnit.value() : null)
+          .embargoValue(attributes.getCustomEmbargoPeriod().getEmbargoValue())
+          .build();
+      builder.customEmbargoPeriod(customEmbargo);
+    }
+
+    if (attributes.getCustomCoverages() != null && !attributes.getCustomCoverages().isEmpty()) {
+      builder.customCoverageList(convertToRMAPICustomCoverageList(attributes.getCustomCoverages()));
+    }
+    
+    // For now, we do not have any attributes specific to managed resources to be mapped to RM API fields
+    // but below, we set the same values as we conduct a GET for pubType and isPeerReviewed because otherwise RM API gives
+    // a bad request error if those values are set to null. All of the other fields are retained as is by RM API because they 
+    // cannot be updated.
+    builder.pubType(attributes.getPublicationType() != null ? attributes.getPublicationType().value() : null);
+    builder.isPeerReviewed(attributes.getIsPeerReviewed());
+
+    return builder;
+  }
+
+  private List<CoverageDates> convertToRMAPICustomCoverageList(List<Coverage> customCoverages) {
+    return customCoverages.stream().map(coverage -> CoverageDates.builder()
+        .beginCoverage(coverage.getBeginCoverage())
+        .endCoverage(coverage.getEndCoverage())
+        .build())
+        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
@@ -39,7 +39,8 @@ import org.folio.rmapi.model.PackageByIdData;
 import org.folio.rmapi.model.ResourceSelectedPayload;
 import org.folio.rmapi.model.Title;
 import org.folio.rmapi.result.ObjectsForPostResourceResult;
-
+import org.folio.rest.validator.ResourcePutBodyValidator;
+import org.folio.rmapi.model.ResourcePut;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -51,6 +52,7 @@ import io.vertx.core.logging.LoggerFactory;
 public class EholdingsResourcesImpl implements EholdingsResources{
   private static final String RESOURCE_NOT_FOUND_MESSAGE = "Resource not found";
   private static final int MAX_TITLE_COUNT = 100;
+  private static final String PUT_RESOURCE_ERROR_MESSAGE = "Failed to update package";
 
   private final Logger logger = LoggerFactory.getLogger(EholdingsResourcesImpl.class);
 
@@ -59,7 +61,8 @@ public class EholdingsResourcesImpl implements EholdingsResources{
   private ResourcesConverter converter;
   private IdParser idParser;
   private ResourcePostValidator postValidator;
-
+  private ResourcePutBodyValidator resourcePutBodyValidator;
+  
   public EholdingsResourcesImpl() {
     this(
       new RMAPIConfigurationServiceCache(
@@ -67,19 +70,22 @@ public class EholdingsResourcesImpl implements EholdingsResources{
       new HeaderValidator(),
       new ResourcePostValidator(),
       new ResourcesConverter(),
-      new IdParser());
+      new IdParser(),
+      new ResourcePutBodyValidator());
   }
 
   public EholdingsResourcesImpl(RMAPIConfigurationService configurationService,
       HeaderValidator headerValidator,
       ResourcePostValidator postValidator,
       ResourcesConverter converter,
-      IdParser idParser) {
+      IdParser idParser,
+      ResourcePutBodyValidator resourcePutBodyValidator) {
     this.configurationService = configurationService;
     this.headerValidator = headerValidator;
     this.postValidator = postValidator;
     this.converter = converter;
     this.idParser = idParser;
+    this.resourcePutBodyValidator = resourcePutBodyValidator;
 }
 
   @Override
@@ -164,7 +170,45 @@ public class EholdingsResourcesImpl implements EholdingsResources{
   @Override
   public void putEholdingsResourcesByResourceId(String resourceId, String contentType, ResourcePutRequest entity,
       Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    asyncResultHandler.handle(Future.succeededFuture(PutEholdingsResourcesByResourceIdResponse.status(Response.Status.NOT_IMPLEMENTED).build()));
+    ResourceId parsedResourceId = idParser.parseResourceId(resourceId);
+    headerValidator.validate(okapiHeaders);
+    MutableObject<RMAPIService> rmapiService = new MutableObject<>();
+    CompletableFuture.completedFuture(null)
+      .thenCompose(o -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders), vertxContext))
+      .thenCompose(rmapiConfiguration -> {
+        rmapiService.setValue(new RMAPIService(rmapiConfiguration.getCustomerId(),
+          rmapiConfiguration.getAPIKey(), rmapiConfiguration.getUrl(), vertxContext.owner()));
+        return rmapiService.getValue().retrieveResource(parsedResourceId, null);
+      })
+      .thenCompose(resourceData -> {
+        ResourcePut resourcePutBody;
+        boolean isTitleCustom = resourceData.getTitle().getIsTitleCustom().booleanValue();
+        resourcePutBodyValidator.validate(entity, isTitleCustom);
+        if (isTitleCustom) {
+          resourcePutBody = converter.convertToRMAPICustomResourcePutRequest(entity);
+        } else {
+          resourcePutBody = converter.convertToRMAPIResourcePutRequest(entity);
+        }
+        return rmapiService.getValue().updateResource(parsedResourceId, resourcePutBody);
+      })
+      .thenCompose(o -> rmapiService.getValue().retrieveResource(parsedResourceId, null))
+      .thenAccept(resourceData ->
+        asyncResultHandler.handle(Future.succeededFuture(EholdingsResources.PutEholdingsResourcesByResourceIdResponse
+          .respond200WithApplicationVndApiJson(converter.convertFromRMAPIResource(resourceData.getTitle(), null, null, false).get(0)))))
+      .exceptionally(e -> {
+        logger.error(PUT_RESOURCE_ERROR_MESSAGE, e);
+        new ErrorHandler()
+          .add(InputValidationException.class, exception ->
+            EholdingsResources.PutEholdingsResourcesByResourceIdResponse.respond422WithApplicationVndApiJson(
+              ErrorUtil.createError(exception.getMessage(), exception.getMessageDetail())))
+          .add(RMAPIResourceNotFoundException.class, exception ->
+            EholdingsResources.PutEholdingsResourcesByResourceIdResponse.respond404WithApplicationVndApiJson(
+              ErrorUtil.createError(RESOURCE_NOT_FOUND_MESSAGE)))
+          .addRmApiMapper()
+          .addDefaultMapper()
+          .handle(asyncResultHandler, e);
+        return null;
+      });
   }
 
   @Override

--- a/src/main/java/org/folio/rest/util/RestConstants.java
+++ b/src/main/java/org/folio/rest/util/RestConstants.java
@@ -10,6 +10,7 @@ public final class RestConstants {
   public static final String PACKAGES_TYPE = "packages";
   public static final String PROVIDERS_TYPE = "providers";
   public static final String TITLES_TYPE = "titles";
+  public static final String RESOURCES_TYPE = "resources";
 
   private RestConstants(){ }
 }

--- a/src/main/java/org/folio/rest/validator/ResourcePutBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/ResourcePutBodyValidator.java
@@ -1,0 +1,91 @@
+package org.folio.rest.validator;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+import org.folio.rest.exception.InputValidationException;
+import org.folio.rest.jaxrs.model.Coverage;
+import org.folio.rest.jaxrs.model.EmbargoPeriod.EmbargoUnit;
+import org.folio.rest.jaxrs.model.ResourceDataAttributes;
+import org.folio.rest.jaxrs.model.ResourcePutRequest;
+
+public class ResourcePutBodyValidator {
+  
+  private static final String INVALID_REQUEST_BODY_TITLE = "Invalid request body";
+  private static final String INVALID_REQUEST_BODY_DETAILS = "Json body must contain data.attributes";
+  private static final String INVALID_IS_SELECTED_TITLE = "Resource cannot be updated unless added to holdings";
+  private static final String INVALID_IS_SELECTED_DETAILS = "Resource must be added to holdings to be able to update";
+  
+  public void validate(ResourcePutRequest request, boolean isTitleCustom) {
+    if (request == null ||
+      request.getData() == null ||
+      request.getData().getAttributes() == null) {
+      throw new InputValidationException(INVALID_REQUEST_BODY_TITLE, INVALID_REQUEST_BODY_DETAILS);
+    }
+    
+    ResourceDataAttributes attributes = request.getData().getAttributes();
+    boolean isSelected = attributes.getIsSelected().booleanValue();
+    String cvgStmt = attributes.getCoverageStatement();
+
+    /**
+     * Updates cannot be made to a resource unless it is selected
+     */
+    if(isSelected) {
+      /**
+       * Following fields can be updated only for a custom resource although UI sends complete payload
+       * for both managed and custom resources
+       */
+      if(isTitleCustom) {
+        String name = attributes.getName();
+        String pubType = attributes.getPublicationType() != null ? attributes.getPublicationType().value() : null;
+        String pubName = attributes.getPublisherName();
+        String edition = attributes.getEdition();
+        String description = attributes.getDescription();
+        String url = attributes.getUrl();
+        
+        ValidatorUtil.checkIsBlank("name", name);
+        ValidatorUtil.checkMaxLength("name", name, 400);
+        ValidatorUtil.checkIsBlank("publicationType", pubType);
+        if(!StringUtils.isBlank(pubName)) {
+          ValidatorUtil.checkMaxLength("publisherName", pubName, 250);
+        }
+        if(!StringUtils.isBlank(edition)) {
+          ValidatorUtil.checkMaxLength("edition", edition, 250);
+        }
+        if(!StringUtils.isBlank(description)) {
+          ValidatorUtil.checkMaxLength("description", description, 1500);
+        }
+        if(!StringUtils.isBlank(url)) {
+          ValidatorUtil.checkMaxLength("url", url, 600);
+          ValidatorUtil.checkUrlFormat("url", url);
+        }
+        if(Objects.nonNull(attributes.getIdentifiers())) {
+          attributes.getIdentifiers().forEach(identifier -> ValidatorUtil.checkIdentifierValid("identifier", identifier));
+        }
+      }
+
+      /**
+       * Following fields can be updated only for a managed resource although UI sends complete payload
+       * for both managed and custom resources
+       */
+      if(!StringUtils.isBlank(cvgStmt)) {
+        ValidatorUtil.checkMaxLength("coverageStatement", cvgStmt, 250);
+      }
+      if(Objects.nonNull(attributes.getCustomCoverages())) {
+        attributes.getCustomCoverages().forEach(customCoverage -> {
+          ValidatorUtil.checkDateValid("beginCoverage", customCoverage.getBeginCoverage());
+          ValidatorUtil.checkDateValid("endCoverage", customCoverage.getEndCoverage());
+        });  
+      }
+    } else {
+      Boolean isHidden = attributes.getVisibilityData() != null ? attributes.getVisibilityData().getIsHidden() : null;
+      EmbargoUnit embargoUnit = attributes.getCustomEmbargoPeriod() != null ? attributes.getCustomEmbargoPeriod().getEmbargoUnit() : null;
+      List<Coverage> customCoverages = attributes.getCustomCoverages();
+      if (!isTitleCustom && (!Objects.isNull(cvgStmt) || !Objects.isNull(embargoUnit) || isHidden || (!Objects.isNull(customCoverages) && !customCoverages.isEmpty()))) {
+        throw new InputValidationException(INVALID_IS_SELECTED_TITLE, INVALID_IS_SELECTED_DETAILS);
+      }
+    }
+  }
+}
+

--- a/src/main/java/org/folio/rest/validator/ValidatorUtil.java
+++ b/src/main/java/org/folio/rest/validator/ValidatorUtil.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.exception.InputValidationException;
+import org.folio.rest.jaxrs.model.Identifier;
 
 public class ValidatorUtil {
 
@@ -16,11 +17,12 @@ public class ValidatorUtil {
   private static final String MUST_BE_FALSE_FORMAT = "%s must be false";
   private static final String MUST_BE_NULL_FORMAT = "%s must be null or not specified";
   private static final String MUST_NOT_BE_NULL_FORMAT = "%s must not be null";
-  private static final String MUST_NOT_BE_EMPTY_FORMAT = "%s must be empty";
   private static final String MUST_BE_EMPTY_FORMAT = "%s must be empty";
+  private static final String MUST_NOT_BE_EMPTY_FORMAT = "%s must not be empty";
   private static final String MUST_BE_SHORTER_THAN_N_CHARACTERS = "%s is too long (maximum is %s characters)";
   private static final String MUST_BE_VALID_DATE = "%s has invalid format. Should be YYYY-MM-DD";
   private static final DateTimeFormatter DATE_PATTERN = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+  private static final String MUST_BE_VALID_URL = "%s has invalid format. Should start with https:// or http://";
   private static final String INVALID_DATES_ORDER = "Begin Coverage should be smaller than End Coverage";
 
   private ValidatorUtil() {}
@@ -35,6 +37,22 @@ public class ValidatorUtil {
 
   public static void checkIsEmpty(String paramName, String value) {
     if (!StringUtils.isEmpty(value)) {
+      throw new InputValidationException(
+        String.format(INVALID_FIELD_FORMAT, paramName),
+        String.format(MUST_BE_EMPTY_FORMAT, paramName));
+    }
+  }
+  
+  public static void checkIsBlank(String paramName, String value) {
+    if (StringUtils.isBlank(value)) {
+      throw new InputValidationException(
+        String.format(INVALID_FIELD_FORMAT, paramName),
+        String.format(MUST_NOT_BE_EMPTY_FORMAT, paramName));
+    }
+  }
+  
+  public static void checkIsNotBlank(String paramName, String value) {
+    if (!StringUtils.isBlank(value)) {
       throw new InputValidationException(
         String.format(INVALID_FIELD_FORMAT, paramName),
         String.format(MUST_BE_EMPTY_FORMAT, paramName));
@@ -109,6 +127,20 @@ public class ValidatorUtil {
       return true;
     } catch (MalformedURLException e) {
       return false;
+    }
+  }
+
+  public static void checkUrlFormat(String paramName, String value) {
+    if(!StringUtils.startsWith(value, "http://") && !StringUtils.startsWith(value, "https://")) {
+      throw new InputValidationException(
+          String.format(INVALID_FIELD_FORMAT, paramName),
+          String.format(MUST_BE_VALID_URL, paramName));
+    }
+  }
+
+  public static void checkIdentifierValid(String paramName, Identifier identifier) {
+    if(Objects.isNull(identifier.getId()) || identifier.getId().length() > 20 ){
+      throw new InputValidationException("INVALID_FIELD_FORMAT", paramName);
     }
   }
 }

--- a/src/main/java/org/folio/rmapi/model/ResourceData.java
+++ b/src/main/java/org/folio/rmapi/model/ResourceData.java
@@ -1,0 +1,75 @@
+package org.folio.rmapi.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+@EqualsAndHashCode
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ResourceData {
+  @JsonProperty("titleId")
+  private Integer titleId;
+  @JsonProperty("isTitleCustom")
+  private Boolean isTitleCustom;
+  @JsonProperty("isSelected")
+  private Boolean isSelected;
+  @JsonProperty("visibilityData")
+  private VisibilityInfo visibilityData;
+  @JsonProperty("coverageStatement")
+  private String coverageStatement;
+  @JsonProperty("customEmbargoPeriod")
+  private EmbargoPeriod customEmbargoPeriod;
+  @JsonProperty("managedEmbargoPeriod")
+  private EmbargoPeriod managedEmbargoPeriod;
+  @JsonProperty("titleName")
+  private String titleName;
+  @JsonProperty("pubType")
+  private String pubType;
+  @JsonProperty("publisherName")
+  private String publisherName;
+  @JsonProperty("isPeerReviewed")
+  private Boolean isPeerReviewed;
+  @JsonProperty("description")
+  private String description;
+  @JsonProperty("edition")
+  private String edition;
+  @JsonProperty("proxy")
+  private Proxy proxy;
+  @JsonProperty("url")
+  private String url;
+  @JsonProperty("contributorsList")
+  private List<Contributor> contributorsList;
+  @JsonProperty("identifiersList")
+  private List<Identifier> identifiersList;
+  @JsonProperty("customCoverageList")
+  private List<CoverageDates> customCoverageList;
+  @JsonProperty("managedCoverageList")
+  private List<CoverageDates> managedCoverageList;
+  @JsonProperty("subjectsList")
+  private List<Subject> subjectsList;
+  @JsonProperty("isPackageCustom")
+  private Boolean isPackageCustom;
+  @JsonProperty("isTokenNeeded")
+  private Boolean isTokenNeeded;
+  @JsonProperty("locationId")
+  private Integer locationId;
+  @JsonProperty("packageId")
+  private Integer packageId;
+  @JsonProperty("packageName")
+  private String packageName;
+  @JsonProperty("vendorId")
+  private Integer vendorId;
+  @JsonProperty("vendorName")
+  private String vendorName;
+}

--- a/src/main/java/org/folio/rmapi/model/ResourcePut.java
+++ b/src/main/java/org/folio/rmapi/model/ResourcePut.java
@@ -1,0 +1,45 @@
+package org.folio.rmapi.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ResourcePut {
+  @JsonProperty("isSelected")
+  private Boolean isSelected;
+  @JsonProperty("isHidden")
+  private Boolean isHidden;
+  @JsonProperty("coverageStatement")
+  private String coverageStatement;
+  @JsonProperty("customEmbargoPeriod")
+  private EmbargoPeriod customEmbargoPeriod;
+  @JsonProperty("titleName")
+  private String titleName;
+  @JsonProperty("pubType")
+  private String pubType;
+  @JsonProperty("publisherName")
+  private String publisherName;
+  @JsonProperty("isPeerReviewed")
+  private Boolean isPeerReviewed;
+  @JsonProperty("description")
+  private String description;
+  @JsonProperty("edition")
+  private String edition;
+  @JsonProperty("proxy")
+  private Proxy proxy;
+  @JsonProperty("url")
+  private String url;
+  @JsonProperty("contributorsList")
+  private List<Contributor> contributorsList;
+  @JsonProperty("identifiersList")
+  private List<Identifier> identifiersList;
+  @JsonProperty("customCoverageList")
+  private List<CoverageDates> customCoverageList;
+}

--- a/src/test/java/org/folio/rest/converter/ResourcesConverterTest.java
+++ b/src/test/java/org/folio/rest/converter/ResourcesConverterTest.java
@@ -1,0 +1,180 @@
+package org.folio.rest.converter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.folio.rest.impl.ResourcesTestData;
+import org.folio.rest.jaxrs.model.EmbargoPeriod;
+import org.folio.rest.jaxrs.model.EmbargoPeriod.EmbargoUnit;
+import org.folio.rest.jaxrs.model.Proxy;
+import org.folio.rest.jaxrs.model.PublicationType;
+import org.folio.rest.jaxrs.model.ResourceDataAttributes;
+import org.folio.rest.jaxrs.model.VisibilityData;
+import org.folio.rmapi.model.ResourcePut;
+import org.junit.Test;
+
+public class ResourcesConverterTest {
+  private ResourcesConverter resourcesConverter = new ResourcesConverter();
+
+  @Test
+  public void shouldCreateRequestToSelectManagedResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPIResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)));
+    assertTrue(resourcePut.getIsSelected());
+  }
+  
+  @Test
+  public void shouldCreateRequestToSelectCustomResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPICustomResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)));
+    assertTrue(resourcePut.getIsSelected());
+  }
+
+  @Test
+  public void shouldCreateRequestToUpdateProxyForManagedResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPIResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withProxy(new Proxy()
+          .withId("test-proxy-id"))));
+    assertEquals("test-proxy-id", resourcePut.getProxy().getId());
+  }
+  
+  @Test
+  public void shouldCreateRequestToUpdateProxyForCustomResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPICustomResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withProxy(new Proxy()
+          .withId("test-proxy-id"))));
+    assertEquals("test-proxy-id", resourcePut.getProxy().getId());
+  }
+  
+  @Test
+  public void shouldCreateRequestToUpdateIsHiddenForCustomResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPICustomResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withVisibilityData(new VisibilityData()
+          .withIsHidden(true))));
+    assertTrue(resourcePut.getIsHidden());
+  }
+  
+  @Test
+  public void shouldCreateRequestToUpdateCoverageStatementForManagedResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPIResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withCoverageStatement("test coverage stmt")));
+      assertEquals("test coverage stmt", resourcePut.getCoverageStatement());
+  }
+  
+  @Test
+  public void shouldCreateRequestToUpdateCoverageStatementForCustomResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPICustomResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withCoverageStatement("test coverage stmt")));
+    assertEquals("test coverage stmt", resourcePut.getCoverageStatement());
+  }
+  
+  @Test
+  public void shouldCreateRequestToUpdateIsHiddenForManagedResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPIResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withVisibilityData(new VisibilityData()
+            .withIsHidden(false))));
+      assertFalse(resourcePut.getIsHidden());
+  }
+  
+  @Test
+  public void shouldCreateRequestToUpdateCustomEmbargoPeriodForManagedResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPIResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withCustomEmbargoPeriod(new EmbargoPeriod()
+            .withEmbargoUnit(EmbargoUnit.DAYS)
+            .withEmbargoValue(10))));
+      assertEquals("Days", resourcePut.getCustomEmbargoPeriod().getEmbargoUnit());
+      assertEquals(10, (long)resourcePut.getCustomEmbargoPeriod().getEmbargoValue());
+  }
+  
+  @Test
+  public void shouldCreateRequestToUpdateCustomEmbargoPeriodForCustomResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPICustomResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withCustomEmbargoPeriod(new EmbargoPeriod()
+            .withEmbargoUnit(EmbargoUnit.YEARS)
+            .withEmbargoValue(10))));
+      assertEquals("Years", resourcePut.getCustomEmbargoPeriod().getEmbargoUnit());
+      assertEquals(10, (long)resourcePut.getCustomEmbargoPeriod().getEmbargoValue());
+  }
+
+  @Test
+  public void shouldCreateRequestToUpdatePublicationTypeForCustomResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPICustomResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withPublicationType(PublicationType.BOOK_SERIES)));
+      assertEquals("Book Series", resourcePut.getPubType());
+  }
+  
+  @Test
+  public void shouldCreateRequestToUpdateIsPeerReviewedForCustomResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPICustomResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withIsPeerReviewed(false)));
+    assertFalse(resourcePut.getIsPeerReviewed());
+  }
+
+  @Test
+  public void shouldCreateRequestToUpdateResourceNameForCustomResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPICustomResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withName("test name")));
+    assertEquals("test name", resourcePut.getTitleName());
+  }
+
+  @Test
+  public void shouldCreateRequestToUpdatePublisherNameForCustomResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPICustomResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withPublisherName("test pub name")));
+    assertEquals("test pub name", resourcePut.getPublisherName());
+  }
+
+  @Test
+  public void shouldCreateRequestToUpdateEditionForCustomResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPICustomResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withEdition("test edition")));
+    assertEquals("test edition", resourcePut.getEdition());
+  }
+
+  @Test
+  public void shouldCreateRequestToUpdateDescriptionForCustomResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPICustomResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withDescription("test description")));
+    assertEquals("test description", resourcePut.getDescription());
+  }
+
+  @Test
+  public void shouldCreateRequestToUpdateUrlForCustomResource() {
+    ResourcePut resourcePut = resourcesConverter.convertToRMAPICustomResourcePutRequest(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+        .withIsSelected(true)
+        .withUrl("test url")));
+    assertEquals("test url", resourcePut.getUrl());
+  }
+}

--- a/src/test/java/org/folio/rest/impl/EholdingsResourcesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsResourcesImplTest.java
@@ -7,8 +7,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.folio.rest.util.RestConstants.PACKAGES_TYPE;
 import static org.folio.rest.util.RestConstants.PROVIDERS_TYPE;
 import static org.folio.rest.util.RestConstants.TITLES_TYPE;
-import static org.folio.util.TestUtil.mockConfiguration;
 import static org.folio.util.TestUtil.readFile;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static org.folio.util.TestUtil.mockConfiguration;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -41,11 +43,16 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 @RunWith(VertxUnitRunner.class)
 public class EholdingsResourcesImplTest extends WireMockTestBase {
 
-  private static final String STUB_RESOURCE_ID = "583-4345-762169";
-  private static final String VENDOR_ID = "583";
-  private static final String PACKAGE_ID = "4345";
-  private static final String TITLE_ID = "762169";
-  private static final String RESOURCE_ENDPOINT = "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + VENDOR_ID + "/packages/" + PACKAGE_ID + "/titles/" + TITLE_ID;
+  private static final String STUB_MANAGED_RESOURCE_ID = "583-4345-762169";
+  private static final String STUB_MANAGED_VENDOR_ID = "583";
+  private static final String STUB_MANAGED_PACKAGE_ID = "4345";
+  private static final String STUB_MANAGED_TITLE_ID = "762169";
+  private static final String STUB_CUSTOM_RESOURCE_ID = "123356-3157070-19412030";
+  private static final String STUB_CUSTOM_VENDOR_ID = "123356";
+  private static final String STUB_CUSTOM_PACKAGE_ID = "3157070";
+  private static final String STUB_CUSTOM_TITLE_ID = "19412030";
+  private static final String MANAGED_RESOURCE_ENDPOINT = "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + STUB_MANAGED_VENDOR_ID + "/packages/" + STUB_MANAGED_PACKAGE_ID + "/titles/" + STUB_MANAGED_TITLE_ID;
+  private static final String CUSTOM_RESOURCE_ENDPOINT = "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + STUB_CUSTOM_VENDOR_ID + "/packages/" + STUB_CUSTOM_PACKAGE_ID + "/titles/" + STUB_CUSTOM_TITLE_ID;
 
   @Test
   public void shouldReturnResourceWhenValidId() throws IOException, URISyntaxException {
@@ -55,7 +62,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
     mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
     mockResource(stubResponseFile);
 
-    String resourceByIdEndpoint = "eholdings/resources/" + STUB_RESOURCE_ID;
+    String resourceByIdEndpoint = "eholdings/resources/" + STUB_MANAGED_RESOURCE_ID;
 
     String actualResponse = RestAssured.given()
       .spec(getRequestSpecification())
@@ -78,7 +85,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
     TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, wiremockUrl);
 
     mockResource(stubResponseFile);
-    String resourceByIdEndpoint = "eholdings/resources/" + STUB_RESOURCE_ID + "?include=title";
+    String resourceByIdEndpoint = "eholdings/resources/" + STUB_MANAGED_RESOURCE_ID + "?include=title";
 
     String actualResponse = RestAssured.given()
       .spec(getRequestSpecification())
@@ -97,7 +104,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
       .withTitle(new HasOneRelationship()
         .withData(new RelationshipData()
           .withType(TITLES_TYPE)
-          .withId(TITLE_ID)));
+          .withId(STUB_MANAGED_TITLE_ID)));
     JSONAssert.assertEquals(
       mapper.writeValueAsString(resource), actualResponse, false);
   }
@@ -115,7 +122,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
     mockResource(stubResourceResponseFile);
     mockVendor(stubVendorResponseFile);
 
-    String resourceByIdEndpoint = "eholdings/resources/" + STUB_RESOURCE_ID + "?include=provider";
+    String resourceByIdEndpoint = "eholdings/resources/" + STUB_MANAGED_RESOURCE_ID + "?include=provider";
 
     String actualResponse = RestAssured.given()
       .spec(getRequestSpecification())
@@ -135,7 +142,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
       .withProvider(new HasOneRelationship()
         .withData(new RelationshipData()
           .withType(PROVIDERS_TYPE)
-          .withId(VENDOR_ID)));
+          .withId(STUB_MANAGED_VENDOR_ID)));
     JSONAssert.assertEquals(
       mapper.writeValueAsString(resource), actualResponse, false);
   }
@@ -153,7 +160,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
     mockResource(stubResourceResponseFile);
     mockPackage(stubPackageResponseFile);
 
-    String resourceByIdEndpoint = "eholdings/resources/" + STUB_RESOURCE_ID + "?include=package";
+    String resourceByIdEndpoint = "eholdings/resources/" + STUB_MANAGED_RESOURCE_ID + "?include=package";
 
     String actualResponse = RestAssured.given()
       .spec(getRequestSpecification())
@@ -173,7 +180,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
       .withPackage(new HasOneRelationship()
         .withData(new RelationshipData()
           .withType(PACKAGES_TYPE)
-          .withId(VENDOR_ID + "-" + PACKAGE_ID)));
+          .withId(STUB_MANAGED_VENDOR_ID + "-" + STUB_MANAGED_PACKAGE_ID)));
     JSONAssert.assertEquals(
       mapper.writeValueAsString(resource), actualResponse, false);
   }
@@ -195,7 +202,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
     mockVendor(stubVendorResponseFile);
     mockPackage(stubPackageResponseFile);
 
-    String resourceByIdEndpoint = "eholdings/resources/" + STUB_RESOURCE_ID + "?include=package,title,provider";
+    String resourceByIdEndpoint = "eholdings/resources/" + STUB_MANAGED_RESOURCE_ID + "?include=package,title,provider";
 
     String actualResponse = RestAssured.given()
       .spec(getRequestSpecification())
@@ -218,15 +225,15 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
       .withPackage(new HasOneRelationship()
         .withData(new RelationshipData()
           .withType(PACKAGES_TYPE)
-          .withId(VENDOR_ID + "-" + PACKAGE_ID)))
+          .withId(STUB_MANAGED_VENDOR_ID + "-" + STUB_MANAGED_PACKAGE_ID)))
       .withProvider(new HasOneRelationship()
         .withData(new RelationshipData()
           .withType(PROVIDERS_TYPE)
-          .withId(String.valueOf(VENDOR_ID))))
+          .withId(String.valueOf(STUB_MANAGED_VENDOR_ID))))
       .withTitle(new HasOneRelationship()
         .withData(new RelationshipData()
           .withType(TITLES_TYPE)
-          .withId(TITLE_ID)));
+          .withId(STUB_MANAGED_TITLE_ID)));
     JSONAssert.assertEquals(
       mapper.writeValueAsString(resource), actualResponse, false);
   }
@@ -237,12 +244,12 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
 
     mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
     stubFor(
-        get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + VENDOR_ID + "/packages/" + PACKAGE_ID + "/titles.*"), true))
+        get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + STUB_MANAGED_VENDOR_ID + "/packages/" + STUB_MANAGED_PACKAGE_ID + "/titles.*"), true))
         .willReturn(new ResponseDefinitionBuilder()
             .withBody(readFile(stubResponseFile))
             .withStatus(404)));
 
-    String resourceByIdEndpoint = "eholdings/resources/" + STUB_RESOURCE_ID;
+    String resourceByIdEndpoint = "eholdings/resources/" + STUB_MANAGED_RESOURCE_ID;
 
     JsonapiError error = RestAssured.given()
     .spec(getRequestSpecification())
@@ -276,11 +283,11 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
   public void shouldReturn500WhenRMApiReturns500ErrorOnResourceGet() throws IOException, URISyntaxException {
     mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
     stubFor(
-      get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + VENDOR_ID + "/packages/" + PACKAGE_ID + "/titles.*"), true))
+      get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + STUB_MANAGED_VENDOR_ID + "/packages/" + STUB_MANAGED_PACKAGE_ID + "/titles.*"), true))
         .willReturn(new ResponseDefinitionBuilder()
           .withStatus(500)));
 
-    String resourceByIdEndpoint = "eholdings/resources/" + STUB_RESOURCE_ID;
+    String resourceByIdEndpoint = "eholdings/resources/" + STUB_MANAGED_RESOURCE_ID;
 
     RestAssured.given()
       .spec(getRequestSpecification())
@@ -289,6 +296,184 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
       .get(resourceByIdEndpoint)
       .then()
       .statusCode(500);
+  }
+  
+  @Test
+  public void shouldReturnUpdatedValuesManagedResourceOnSuccessfulPut() throws IOException, URISyntaxException {
+    String stubResponseFile = "responses/rmapi/resources/get-managed-resource-updated-response.json";
+
+    mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
+
+    stubFor(
+      get(new UrlPathPattern(new RegexPattern(MANAGED_RESOURCE_ENDPOINT), false))
+        .willReturn(new ResponseDefinitionBuilder().withBody(readFile(stubResponseFile))));
+
+    stubFor(
+      put(new UrlPathPattern(new RegexPattern(MANAGED_RESOURCE_ENDPOINT), true))
+        .willReturn(new ResponseDefinitionBuilder().withStatus(HttpStatus.SC_NO_CONTENT)));
+    
+    Resource expected = ResourcesTestData.getExpectedManagedResource();
+    
+    String updateResourceEndpoint = "eholdings/resources/" + STUB_MANAGED_RESOURCE_ID;
+
+    Resource resource = RestAssured
+      .given()
+      .spec(getRequestSpecification())
+      .header(CONTENT_TYPE_HEADER)
+      .body(readFile("requests/kb-ebsco/resource/put-managed-resource.json"))
+      .when()
+      .put(updateResourceEndpoint)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .extract().as(Resource.class);
+    
+    compareResource(resource, expected);
+
+    verify(1, putRequestedFor(new UrlPathPattern(new RegexPattern(MANAGED_RESOURCE_ENDPOINT), true))
+      .withRequestBody(equalToJson(readFile("requests/rmapi/resources/put-managed-resource-is-selected-multiple-attributes.json"))));
+  }
+  
+  @Test
+  public void shouldReturnUpdatedValuesCustomResourceOnSuccessfulPut() throws IOException, URISyntaxException {
+    String stubResponseFile = "responses/rmapi/resources/get-custom-resource-updated-response.json";
+
+    mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
+
+    stubFor(
+      get(new UrlPathPattern(new RegexPattern(CUSTOM_RESOURCE_ENDPOINT), false))
+        .willReturn(new ResponseDefinitionBuilder().withBody(readFile(stubResponseFile))));
+
+    stubFor(
+      put(new UrlPathPattern(new RegexPattern(CUSTOM_RESOURCE_ENDPOINT), true))
+        .willReturn(new ResponseDefinitionBuilder().withStatus(HttpStatus.SC_NO_CONTENT)));
+    
+    Resource expected = ResourcesTestData.getExpectedCustomResource();
+    
+    String updateResourceEndpoint = "eholdings/resources/" + STUB_CUSTOM_RESOURCE_ID;
+
+    Resource resource = RestAssured
+      .given()
+      .spec(getRequestSpecification())
+      .header(CONTENT_TYPE_HEADER)
+      .body(readFile("requests/kb-ebsco/resource/put-custom-resource.json"))
+      .when()
+      .put(updateResourceEndpoint)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .extract().as(Resource.class);
+    
+    compareResource(resource, expected);
+
+    verify(1, putRequestedFor(new UrlPathPattern(new RegexPattern(CUSTOM_RESOURCE_ENDPOINT), true))
+      .withRequestBody(equalToJson(readFile("requests/rmapi/resources/put-custom-resource-is-selected-multiple-attributes.json"))));
+  }
+  
+  @Test
+  public void shouldReturn422WhenManagedResourceIsNotSelectedAndTryToUpdateOtherFields() throws URISyntaxException, IOException {
+    String stubResponseFile = "responses/rmapi/resources/get-managed-resource-updated-response.json";
+
+    mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
+
+    stubFor(
+      get(new UrlPathPattern(new RegexPattern(MANAGED_RESOURCE_ENDPOINT), false))
+        .willReturn(new ResponseDefinitionBuilder().withBody(readFile(stubResponseFile))));
+    
+    String updateResourceEndpoint = "eholdings/resources/" + STUB_MANAGED_RESOURCE_ID;
+    
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .header(CONTENT_TYPE_HEADER)
+      .when()
+      .body(readFile("requests/kb-ebsco/resource/put-managed-resource-not-selected-update-fields.json"))
+      .put(updateResourceEndpoint)
+      .then()
+      .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+  }
+  
+  @Test
+  public void shouldReturn422WhenInvalidUrlIsProvidedForCustomResource() throws URISyntaxException, IOException {
+    String stubResponseFile = "responses/rmapi/resources/get-custom-resource-updated-response.json";
+
+    mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
+
+    stubFor(
+      get(new UrlPathPattern(new RegexPattern(CUSTOM_RESOURCE_ENDPOINT), false))
+        .willReturn(new ResponseDefinitionBuilder().withBody(readFile(stubResponseFile))));
+    
+    String updateResourceEndpoint = "eholdings/resources/" + STUB_CUSTOM_RESOURCE_ID;
+    
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .header(CONTENT_TYPE_HEADER)
+      .when()
+      .body(readFile("requests/kb-ebsco/resource/put-custom-resource-invalid-url.json"))
+      .put(updateResourceEndpoint)
+      .then()
+      .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+  }
+  
+  @Test
+  public void shouldReturn422WhenNameIsNotProvidedForCustomResource() throws URISyntaxException, IOException {
+    String stubResponseFile = "responses/rmapi/resources/get-custom-resource-updated-response.json";
+
+    mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
+
+    stubFor(
+      get(new UrlPathPattern(new RegexPattern(CUSTOM_RESOURCE_ENDPOINT), false))
+        .willReturn(new ResponseDefinitionBuilder().withBody(readFile(stubResponseFile))));
+    
+    String updateResourceEndpoint = "eholdings/resources/" + STUB_CUSTOM_RESOURCE_ID;
+    
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .header(CONTENT_TYPE_HEADER)
+      .when()
+      .body(readFile("requests/kb-ebsco/resource/put-custom-resource-null-name.json"))
+      .put(updateResourceEndpoint)
+      .then()
+      .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+  }
+  
+  @Test
+  public void shouldReturn422WhenPublicationTypeIsNotProvidedForCustomResource() throws URISyntaxException, IOException {
+    String stubResponseFile = "responses/rmapi/resources/get-custom-resource-updated-response.json";
+
+    mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
+
+    stubFor(
+      get(new UrlPathPattern(new RegexPattern(CUSTOM_RESOURCE_ENDPOINT), false))
+        .willReturn(new ResponseDefinitionBuilder().withBody(readFile(stubResponseFile))));
+    
+    String updateResourceEndpoint = "eholdings/resources/" + STUB_CUSTOM_RESOURCE_ID;
+    
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .header(CONTENT_TYPE_HEADER)
+      .when()
+      .body(readFile("requests/kb-ebsco/resource/put-custom-resource-null-publication-type.json"))
+      .put(updateResourceEndpoint)
+      .then()
+      .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+  }
+
+  private void compareResource(Resource actual, Resource expected) {
+    assertThat(actual.getData().getType(), equalTo(expected.getData().getType()));
+    assertThat(actual.getData().getId(), equalTo(expected.getData().getId()));
+    assertThat(actual.getData().getAttributes().getIsSelected(), equalTo(expected.getData().getAttributes().getIsSelected()));
+    assertThat(actual.getData().getAttributes().getProxy().getId(), equalTo(expected.getData().getAttributes().getProxy().getId()));
+    assertThat(actual.getData().getAttributes().getProxy().getInherited(), equalTo(expected.getData().getAttributes().getProxy().getInherited()));
+    assertThat(actual.getData().getAttributes().getCoverageStatement(), equalTo(expected.getData().getAttributes().getCoverageStatement()));
+    assertThat(actual.getData().getAttributes().getVisibilityData().getIsHidden(), equalTo(expected.getData().getAttributes().getVisibilityData().getIsHidden()));
+    assertThat(actual.getData().getAttributes().getCustomEmbargoPeriod().getEmbargoUnit(), equalTo(expected.getData().getAttributes().getCustomEmbargoPeriod().getEmbargoUnit()));
+    assertThat(actual.getData().getAttributes().getCustomEmbargoPeriod().getEmbargoValue(), equalTo(expected.getData().getAttributes().getCustomEmbargoPeriod().getEmbargoValue()));
+    assertThat(actual.getData().getAttributes().getDescription(), equalTo(expected.getData().getAttributes().getDescription()));
+    assertThat(actual.getData().getAttributes().getEdition(), equalTo(expected.getData().getAttributes().getEdition()));
+    assertThat(actual.getData().getAttributes().getIsPeerReviewed(), equalTo(expected.getData().getAttributes().getIsPeerReviewed()));
+    assertThat(actual.getData().getAttributes().getIsTitleCustom(), equalTo(expected.getData().getAttributes().getIsTitleCustom()));
+    assertThat(actual.getData().getAttributes().getPublisherName(), equalTo(expected.getData().getAttributes().getPublisherName()));
+    assertThat(actual.getData().getAttributes().getName(), equalTo(expected.getData().getAttributes().getName()));
+    assertThat(actual.getData().getAttributes().getPublicationType(), equalTo(expected.getData().getAttributes().getPublicationType()));
+    assertThat(actual.getData().getAttributes().getUrl(), equalTo(expected.getData().getAttributes().getUrl()));
   }
 
   @Test
@@ -312,7 +497,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
     mockResource(stubTitleResponseFile);
 
     WireMock.stubFor(
-      WireMock.put(new UrlPathPattern(new RegexPattern(RESOURCE_ENDPOINT), true))
+      WireMock.put(new UrlPathPattern(new RegexPattern(MANAGED_RESOURCE_ENDPOINT), true))
         .withRequestBody(putRequestBodyPattern)
         .willReturn(new ResponseDefinitionBuilder()
           .withStatus(HttpStatus.SC_NO_CONTENT)));
@@ -329,7 +514,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
     JSONAssert.assertEquals(
       readFile(expectedResourceFile), actualResponse, false);
 
-    verify(1, putRequestedFor(new UrlPathPattern(new EqualToPattern(RESOURCE_ENDPOINT), false))
+    verify(1, putRequestedFor(new UrlPathPattern(new EqualToPattern(MANAGED_RESOURCE_ENDPOINT), false))
       .withRequestBody(putRequestBodyPattern));
   }
 
@@ -346,7 +531,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
           .withStatus(404)));
 
     WireMock.stubFor(
-      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + VENDOR_ID + "/packages/" + PACKAGE_ID), true))
+      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + STUB_MANAGED_VENDOR_ID + "/packages/" + STUB_MANAGED_PACKAGE_ID), true))
         .willReturn(new ResponseDefinitionBuilder()
           .withStatus(404)));
 
@@ -387,7 +572,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
 
   private void mockPackageResources(String stubPackageResourcesFile) throws IOException, URISyntaxException {
     UrlPathPattern packagesResourcesPattern = new UrlPathPattern(
-      new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + VENDOR_ID + "/packages/" + PACKAGE_ID + "/titles.*"), true);
+      new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + STUB_MANAGED_VENDOR_ID + "/packages/" + STUB_MANAGED_PACKAGE_ID + "/titles.*"), true);
     WireMock.stubFor(
       WireMock.get(packagesResourcesPattern)
         .willReturn(new ResponseDefinitionBuilder()
@@ -396,14 +581,14 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
 
   private void mockPackage(String responseFile) throws IOException, URISyntaxException {
     WireMock.stubFor(
-      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + VENDOR_ID + "/packages/" + PACKAGE_ID), true))
+      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + STUB_MANAGED_VENDOR_ID + "/packages/" + STUB_MANAGED_PACKAGE_ID), true))
         .willReturn(new ResponseDefinitionBuilder()
           .withBody(TestUtil.readFile(responseFile))));
   }
 
   private void mockResource(String responseFile) throws IOException, URISyntaxException {
     WireMock.stubFor(
-      WireMock.get(new UrlPathPattern(new RegexPattern(RESOURCE_ENDPOINT), false))
+      WireMock.get(new UrlPathPattern(new RegexPattern(MANAGED_RESOURCE_ENDPOINT), false))
         .willReturn(new ResponseDefinitionBuilder()
           .withBody(readFile(responseFile))));
   }
@@ -417,7 +602,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
 
   private void mockVendor(String responseFile) throws IOException, URISyntaxException {
     WireMock.stubFor(
-      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + VENDOR_ID), true))
+      WireMock.get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + STUB_MANAGED_VENDOR_ID), true))
         .willReturn(new ResponseDefinitionBuilder()
           .withBody(TestUtil.readFile(responseFile))));
   }

--- a/src/test/java/org/folio/rest/impl/ResourcesTestData.java
+++ b/src/test/java/org/folio/rest/impl/ResourcesTestData.java
@@ -1,0 +1,113 @@
+package org.folio.rest.impl;
+
+import java.util.Collections;
+
+import org.folio.rest.jaxrs.model.EmbargoPeriod;
+import org.folio.rest.jaxrs.model.EmbargoPeriod.EmbargoUnit;
+import org.folio.rest.jaxrs.model.Proxy;
+import org.folio.rest.jaxrs.model.PublicationType;
+import org.folio.rest.jaxrs.model.ResourceCollectionItem;
+import org.folio.rest.jaxrs.model.ResourceDataAttributes;
+import org.folio.rest.jaxrs.model.ResourcePutData;
+import org.folio.rest.jaxrs.model.ResourcePutRequest;
+import org.folio.rest.jaxrs.model.VisibilityData;
+import org.folio.rest.jaxrs.model.Resource;
+import org.folio.rest.util.RestConstants;
+
+
+public class ResourcesTestData {
+  
+  public static ResourcePutRequest getResourcePutRequest(ResourceDataAttributes attributes) {
+    return new ResourcePutRequest()
+      .withData(new ResourcePutData()
+        .withType(ResourcePutData.Type.RESOURCES)
+        .withAttributes(attributes));
+  }
+  
+  public static Resource getExpectedManagedResource() {
+    return new Resource().withData(new ResourceCollectionItem()
+      .withId("583-4345-762169")
+      .withType(ResourceCollectionItem.Type.RESOURCES)
+      .withAttributes(new ResourceDataAttributes()
+          .withDescription(null)
+          .withEdition(null)
+          .withIsPeerReviewed(false)
+          .withIsTitleCustom(false)
+          .withPublisherName("Praeger")
+          .withTitleId(762169)
+          .withContributors(Collections.emptyList())
+          .withIdentifiers(Collections.emptyList())
+          .withName("\"Great Satan\" Vs. the \"Mad Mullahs\": How the United States and Iran Demonize Each Other")
+          .withPublicationType(PublicationType.BOOK)
+          .withSubjects(Collections.emptyList())
+          .withCoverageStatement("test coverage statement")
+          .withCustomEmbargoPeriod(new EmbargoPeriod()
+              .withEmbargoUnit(EmbargoUnit.YEARS)
+              .withEmbargoValue(10))
+          .withIsPackageCustom(false)
+          .withIsSelected(true)
+          .withIsTokenNeeded(false)
+          .withLocationId(6926225)
+          .withManagedEmbargoPeriod(new EmbargoPeriod()
+              .withEmbargoValue(0))
+          .withPackageId("583-4345")
+          .withPackageName("OhioLINK Electronic Book Center: EBC")
+          .withUrl("https://publisher.abc-clio.com/9780313068003/")
+          .withProviderId(583)
+          .withProviderName("OhioLINK")
+          .withVisibilityData(new VisibilityData()
+              .withIsHidden(false)
+              .withReason(""))
+          .withManagedCoverages(Collections.emptyList())
+          .withCustomCoverages(Collections.emptyList())
+          .withProxy(new Proxy()
+              .withId("Test-proxy-id")
+              .withInherited(false))
+        ))
+      .withJsonapi(RestConstants.JSONAPI);
+  }
+  
+  public static Resource getExpectedCustomResource() {
+    return new Resource().withData(new ResourceCollectionItem()
+      .withId("123356-3157070-19412030")
+      .withType(ResourceCollectionItem.Type.RESOURCES)
+      .withAttributes(new ResourceDataAttributes()
+          .withDescription("test description")
+          .withEdition("test edition")
+          .withIsPeerReviewed(true)
+          .withIsTitleCustom(true)
+          .withPublisherName("Not Empty")
+          .withTitleId(19412030)
+          .withContributors(Collections.emptyList())
+          .withIdentifiers(Collections.emptyList())
+          .withName("sd-test-java-again")
+          .withPublicationType(PublicationType.BOOK)
+          .withSubjects(Collections.emptyList())
+          .withCoverageStatement("My test statement")
+          .withCustomEmbargoPeriod(new EmbargoPeriod()
+              .withEmbargoUnit(EmbargoUnit.WEEKS)
+              .withEmbargoValue(30))
+          .withIsPackageCustom(true)
+          .withIsSelected(true)
+          .withIsTokenNeeded(false)
+          .withLocationId(43006476)
+          .withManagedEmbargoPeriod(new EmbargoPeriod()
+              .withEmbargoUnit(EmbargoUnit.DAYS)
+              .withEmbargoValue(10))
+          .withPackageId("123356-3157070")
+          .withPackageName("Andrii custom packageC")
+          .withUrl("https://hello")
+          .withProviderId(123356)
+          .withProviderName("API DEV GOVERNMENT CUSTOMER")
+          .withVisibilityData(new VisibilityData()
+              .withIsHidden(false)
+              .withReason(""))
+          .withManagedCoverages(Collections.emptyList())
+          .withCustomCoverages(Collections.emptyList())
+          .withProxy(new Proxy()
+              .withId("Proxy-ID-234")
+              .withInherited(false))
+        ))
+      .withJsonapi(RestConstants.JSONAPI);
+  }
+}

--- a/src/test/java/org/folio/rest/validator/ResourcePutBodyValidatorTest.java
+++ b/src/test/java/org/folio/rest/validator/ResourcePutBodyValidatorTest.java
@@ -1,0 +1,192 @@
+package org.folio.rest.validator;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.folio.rest.exception.InputValidationException;
+import org.folio.rest.impl.ResourcesTestData;
+import org.folio.rest.jaxrs.model.EmbargoPeriod;
+import org.folio.rest.jaxrs.model.EmbargoPeriod.EmbargoUnit;
+import org.folio.rest.jaxrs.model.PublicationType;
+import org.folio.rest.jaxrs.model.ResourceDataAttributes;
+import org.folio.rest.jaxrs.model.VisibilityData;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ResourcePutBodyValidatorTest {
+  private final ResourcePutBodyValidator validator = new ResourcePutBodyValidator();
+  
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+  
+  @Test
+  public void shouldThrowExceptionWhenNameIsBlankForACustomResource() {
+    expectedEx.expect(InputValidationException.class);
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+        new ResourceDataAttributes()
+          .withIsSelected(true)
+          .withName("")), true);
+  }
+  
+  @Test
+  public void shouldThrowExceptionWhenNameExceedsLengthForACustomResource() {
+    expectedEx.expect(InputValidationException.class);
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+        new ResourceDataAttributes()
+          .withIsSelected(true)
+          .withName(RandomStringUtils.randomAlphanumeric(500))), true);
+  }
+  
+  @Test
+  public void shouldNotThrowExceptionWhenNameIsNotBlankAndWithinLimitForACustomResource() {
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+        new ResourceDataAttributes()
+          .withIsSelected(true)
+          .withName(RandomStringUtils.randomAlphanumeric(399))
+          .withPublicationType(PublicationType.AUDIOBOOK)), true);
+  }
+
+  @Test
+  public void shouldNotThrowExceptionWhenPublicationTypeIsNotBlankForACustomResource() {
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+        new ResourceDataAttributes()
+          .withIsSelected(true)
+          .withName("some name")
+          .withPublicationType(PublicationType.AUDIOBOOK)), true);
+  }
+  
+  @Test
+  public void shouldThrowExceptionWhenPublisherNameExceedsLengthForACustomResource() {
+    expectedEx.expect(InputValidationException.class);
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+        new ResourceDataAttributes()
+          .withIsSelected(true)
+          .withName("some name")
+          .withPublicationType(PublicationType.AUDIOBOOK)
+          .withPublisherName(RandomStringUtils.randomAlphanumeric(251))), true);
+  }
+  
+  @Test
+  public void shouldNotThrowExceptionWhenPublisherNameIsWithinLimitForACustomResource() {
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+        new ResourceDataAttributes()
+          .withIsSelected(true)
+          .withName("some name")
+          .withPublicationType(PublicationType.AUDIOBOOK)
+          .withPublisherName(RandomStringUtils.randomAlphanumeric(249))), true);
+  }
+  
+  @Test
+  public void shouldThrowExceptionWhenEditionExceedsLengthForACustomResource() {
+    expectedEx.expect(InputValidationException.class);
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+        new ResourceDataAttributes()
+          .withIsSelected(true)
+          .withName("some name")
+          .withPublicationType(PublicationType.AUDIOBOOK)
+          .withEdition(RandomStringUtils.randomAlphanumeric(251))), true);
+  }
+  
+  @Test
+  public void shouldNotThrowExceptionWhenEditionIsWithinLimitForACustomResource() {
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+        new ResourceDataAttributes()
+          .withIsSelected(true)
+          .withName("some name")
+          .withPublicationType(PublicationType.AUDIOBOOK)
+          .withEdition(RandomStringUtils.randomAlphanumeric(249))), true);
+  }
+  
+  @Test
+  public void shouldThrowExceptionWhenDescriptionExceedsLengthForACustomResource() {
+    expectedEx.expect(InputValidationException.class);
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+        new ResourceDataAttributes()
+          .withIsSelected(true)
+          .withName("some name")
+          .withPublicationType(PublicationType.AUDIOBOOK)
+          .withDescription(RandomStringUtils.randomAlphanumeric(1501))), true);
+  }
+  
+  @Test
+  public void shouldNotThrowExceptionWhenDescriptionIsWithinLimitForACustomResource() {
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+        new ResourceDataAttributes()
+          .withIsSelected(true)
+          .withName("some name")
+          .withPublicationType(PublicationType.AUDIOBOOK)
+          .withDescription(RandomStringUtils.randomAlphanumeric(249))), true);
+  }
+  
+  @Test
+  public void shouldNotThrowExceptionWhenUrlIsValidFormatForACustomResource() {
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+        new ResourceDataAttributes()
+          .withIsSelected(true)
+          .withName("some name")
+          .withPublicationType(PublicationType.AUDIOBOOK)
+          .withUrl("https://hello")), true);
+  }
+  
+  @Test
+  public void shouldThrowExceptionWhenUrlIsInvalidFormatForACustomResource() {
+    expectedEx.expect(InputValidationException.class);
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+        new ResourceDataAttributes()
+          .withIsSelected(true)
+          .withName("some name")
+          .withPublicationType(PublicationType.AUDIOBOOK)
+          .withUrl("hello")), true);
+  }
+  
+  @Test
+  public void shouldThrowExceptionWhenCvgStmtExceedsLengthForACustomResource() {
+    expectedEx.expect(InputValidationException.class);
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+        new ResourceDataAttributes()
+          .withIsSelected(true)
+          .withName("some name")
+          .withPublicationType(PublicationType.AUDIOBOOK)
+          .withCoverageStatement(RandomStringUtils.randomAlphanumeric(251))), true);
+  }
+  
+  @Test
+  public void shouldNotThrowExceptionWhenCvgStmtIsValidForACustomResource() {
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+        new ResourceDataAttributes()
+          .withIsSelected(true)
+          .withName("some name")
+          .withPublicationType(PublicationType.AUDIOBOOK)
+          .withCoverageStatement("my test coverage statement")), true);
+  }
+  
+  @Test
+  public void shouldThrowExceptionWhenResourceIsNotSelectedAndIsHiddenIsTrue() {
+    expectedEx.expect(InputValidationException.class);
+    expectedEx.expectMessage("Resource cannot be updated unless added to holdings");
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+      .withIsSelected(false)
+      .withVisibilityData(new VisibilityData()
+        .withIsHidden(true))), false);
+  }
+  
+  @Test
+  public void shouldThrowExceptionWhenResourceIsNotSelectedAndCvgStmtIsNotNull() {
+    expectedEx.expect(InputValidationException.class);
+    expectedEx.expectMessage("Resource cannot be updated unless added to holdings");
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+      .withIsSelected(false)
+      .withCoverageStatement("hello")), false);
+  }
+  
+  @Test
+  public void shouldThrowExceptionWhenResourceIsNotSelectedAndCustomEmbargoIsNotNull() {
+    expectedEx.expect(InputValidationException.class);
+    expectedEx.expectMessage("Resource cannot be updated unless added to holdings");
+    validator.validate(ResourcesTestData.getResourcePutRequest(
+      new ResourceDataAttributes()
+      .withIsSelected(false)
+      .withCustomEmbargoPeriod(new EmbargoPeriod().withEmbargoUnit(EmbargoUnit.DAYS))), false);
+  }
+}

--- a/src/test/resources/requests/kb-ebsco/resource/put-custom-resource-invalid-url.json
+++ b/src/test/resources/requests/kb-ebsco/resource/put-custom-resource-invalid-url.json
@@ -1,0 +1,60 @@
+{
+  "data": {
+    "id": "123356-3157070-19412030",
+    "type": "resources",
+    "attributes": {
+      "description": "test description",
+      "edition": "test edition",
+      "isPeerReviewed": true,
+      "isTitleCustom": true,
+      "publisherName": "Not Empty",
+      "titleId": 19412030,
+      "contributors": [
+        {
+          "type": "Author",
+          "contributor": "Rappaport, Helen"
+        }
+      ],
+      "identifiers": [
+        {
+          "id": "978-1-280-71298-2",
+          "type": "ISBN",
+          "subtype": "Online"
+        }
+      ],
+      "name": "sd-test-java-again",
+      "publicationType": "Book",
+      "subjects": [],
+      "coverageStatement": "My test statement",
+      "customEmbargoPeriod": {
+        "embargoValue": 30,
+        "embargoUnit": "Weeks"
+      },
+      "isSelected": true,
+      "managedEmbargoPeriod": {
+        "embargoUnit": null,
+        "embargoValue": 0
+      },
+      "packageId": "123356-3157070",
+      "packageName": "Andrii custom package ",
+      "url": "hello",
+      "providerId": 123356,
+      "providerName": "API DEV GOVERNMENT CUSTOMER",
+      "visibilityData": {
+        "isHidden": false,
+        "reason": ""
+      },
+      "managedCoverages": [],
+      "customCoverages": [
+        {
+          "beginCoverage": "2018-01-10",
+          "endCoverage": "2018-01-11"
+        }
+      ],
+      "proxy": {
+        "id": "Proxy-ID-234",
+        "inherited": false
+      }
+    }
+  }
+}

--- a/src/test/resources/requests/kb-ebsco/resource/put-custom-resource-null-name.json
+++ b/src/test/resources/requests/kb-ebsco/resource/put-custom-resource-null-name.json
@@ -1,0 +1,60 @@
+{
+  "data": {
+    "id": "123356-3157070-19412030",
+    "type": "resources",
+    "attributes": {
+      "description": "test description",
+      "edition": "test edition",
+      "isPeerReviewed": true,
+      "isTitleCustom": true,
+      "publisherName": "Not Empty",
+      "titleId": 19412030,
+      "contributors": [
+        {
+          "type": "Author",
+          "contributor": "Rappaport, Helen"
+        }
+      ],
+      "identifiers": [
+        {
+          "id": "978-1-280-71298-2",
+          "type": "ISBN",
+          "subtype": "Online"
+        }
+      ],
+      "name": null,
+      "publicationType": "Book",
+      "subjects": [],
+      "coverageStatement": "My test statement",
+      "customEmbargoPeriod": {
+        "embargoValue": 30,
+        "embargoUnit": "Weeks"
+      },
+      "isSelected": true,
+      "managedEmbargoPeriod": {
+        "embargoUnit": null,
+        "embargoValue": 0
+      },
+      "packageId": "123356-3157070",
+      "packageName": "Andrii custom package ",
+      "url": "https://hello",
+      "providerId": 123356,
+      "providerName": "API DEV GOVERNMENT CUSTOMER",
+      "visibilityData": {
+        "isHidden": false,
+        "reason": ""
+      },
+      "managedCoverages": [],
+      "customCoverages": [
+        {
+          "beginCoverage": "2018-01-10",
+          "endCoverage": "2018-01-11"
+        }
+      ],
+      "proxy": {
+        "id": "Proxy-ID-234",
+        "inherited": false
+      }
+    }
+  }
+}

--- a/src/test/resources/requests/kb-ebsco/resource/put-custom-resource-null-publication-type.json
+++ b/src/test/resources/requests/kb-ebsco/resource/put-custom-resource-null-publication-type.json
@@ -1,0 +1,60 @@
+{
+  "data": {
+    "id": "123356-3157070-19412030",
+    "type": "resources",
+    "attributes": {
+      "description": "test description",
+      "edition": "test edition",
+      "isPeerReviewed": true,
+      "isTitleCustom": true,
+      "publisherName": "Not Empty",
+      "titleId": 19412030,
+      "contributors": [
+        {
+          "type": "Author",
+          "contributor": "Rappaport, Helen"
+        }
+      ],
+      "identifiers": [
+        {
+          "id": "978-1-280-71298-2",
+          "type": "ISBN",
+          "subtype": "Online"
+        }
+      ],
+      "name": "sd-test-java-again",
+      "publicationType": null,
+      "subjects": [],
+      "coverageStatement": "My test statement",
+      "customEmbargoPeriod": {
+        "embargoValue": 30,
+        "embargoUnit": "Weeks"
+      },
+      "isSelected": true,
+      "managedEmbargoPeriod": {
+        "embargoUnit": null,
+        "embargoValue": 0
+      },
+      "packageId": "123356-3157070",
+      "packageName": "Andrii custom package ",
+      "url": "https://hello",
+      "providerId": 123356,
+      "providerName": "API DEV GOVERNMENT CUSTOMER",
+      "visibilityData": {
+        "isHidden": false,
+        "reason": ""
+      },
+      "managedCoverages": [],
+      "customCoverages": [
+        {
+          "beginCoverage": "2018-01-10",
+          "endCoverage": "2018-01-11"
+        }
+      ],
+      "proxy": {
+        "id": "Proxy-ID-234",
+        "inherited": false
+      }
+    }
+  }
+}

--- a/src/test/resources/requests/kb-ebsco/resource/put-custom-resource.json
+++ b/src/test/resources/requests/kb-ebsco/resource/put-custom-resource.json
@@ -1,0 +1,60 @@
+{
+  "data": {
+    "id": "123356-3157070-19412030",
+    "type": "resources",
+    "attributes": {
+      "description": "test description",
+      "edition": "test edition",
+      "isPeerReviewed": true,
+      "isTitleCustom": true,
+      "publisherName": "Not Empty",
+      "titleId": 19412030,
+      "contributors": [
+        {
+          "type": "Author",
+          "contributor": "Rappaport, Helen"
+        }
+      ],
+      "identifiers": [
+        {
+          "id": "978-1-280-71298-2",
+          "type": "ISBN",
+          "subtype": "Online"
+        }
+      ],
+      "name": "sd-test-java-again",
+      "publicationType": "Book",
+      "subjects": [],
+      "coverageStatement": "My test statement",
+      "customEmbargoPeriod": {
+        "embargoValue": 30,
+        "embargoUnit": "Weeks"
+      },
+      "isSelected": true,
+      "managedEmbargoPeriod": {
+        "embargoUnit": null,
+        "embargoValue": 0
+      },
+      "packageId": "123356-3157070",
+      "packageName": "Andrii custom package ",
+      "url": "https://hello",
+      "providerId": 123356,
+      "providerName": "API DEV GOVERNMENT CUSTOMER",
+      "visibilityData": {
+        "isHidden": false,
+        "reason": ""
+      },
+      "managedCoverages": [],
+      "customCoverages": [
+        {
+          "beginCoverage": "2018-01-10",
+          "endCoverage": "2018-01-11"
+        }
+      ],
+      "proxy": {
+        "id": "Proxy-ID-234",
+        "inherited": false
+      }
+    }
+  }
+}

--- a/src/test/resources/requests/kb-ebsco/resource/put-managed-resource-not-selected-update-fields.json
+++ b/src/test/resources/requests/kb-ebsco/resource/put-managed-resource-not-selected-update-fields.json
@@ -1,0 +1,60 @@
+{
+  "data" : {
+    "id" : "583-4345-762169",
+    "type" : "resources",
+    "attributes" : {
+      "isPeerReviewed" : false,
+      "isTitleCustom" : false,
+      "publisherName" : "Praeger",
+      "titleId" : 762169,
+      "contributors" : [ {
+        "type" : "Author",
+        "contributor" : "Beeman, William O."
+      } ],
+      "identifiers" : [ {
+        "id" : "978-0-275-98214-0",
+        "subtype" : "Print",
+        "type" : "ISBN"
+      }, {
+        "id" : "978-0-313-06800-3",
+        "subtype" : "Online",
+        "type" : "ISBN"
+      }, {
+        "id" : "978-1-282-40979-8",
+        "subtype" : "Online",
+        "type" : "ISBN"
+      } ],
+      "name" : "\"Great Satan\" Vs. the \"Mad Mullahs\": How the United States and Iran Demonize Each Other",
+      "publicationType" : "Book",
+      "subjects" : [ {
+        "subject" : "SOCIAL SCIENCE / Ethnic Studies / General",
+        "type" : "BISAC"
+      } ],
+      "coverageStatement" : "test coverage statement",
+      "customEmbargoPeriod" : {
+        "embargoValue" : 10,
+        "embargoUnit": "Years"
+      },
+      "isPackageCustom" : false,
+      "isSelected" : false,
+      "isTokenNeeded" : false,
+      "locationId" : 2863717,
+      "managedEmbargoPeriod" : {
+        "embargoValue" : 0
+      },
+      "packageId" : "583-4345",
+      "packageName" : "ABC-CLIO eBook Collection",
+      "url" : "https://publisher.abc-clio.com/9780313068003/",
+      "providerId" : 583,
+      "providerName" : "ABC-CLIO",
+      "visibilityData" : {
+        "isHidden" : false,
+        "reason" : ""
+      },
+      "proxy" : {
+        "id" : "Test-proxy-id",
+        "inherited" : true
+      }
+    }
+  }
+}

--- a/src/test/resources/requests/kb-ebsco/resource/put-managed-resource.json
+++ b/src/test/resources/requests/kb-ebsco/resource/put-managed-resource.json
@@ -1,0 +1,60 @@
+{
+  "data" : {
+    "id" : "583-4345-762169",
+    "type" : "resources",
+    "attributes" : {
+      "isPeerReviewed" : false,
+      "isTitleCustom" : false,
+      "publisherName" : "Praeger",
+      "titleId" : 762169,
+      "contributors" : [ {
+        "type" : "Author",
+        "contributor" : "Beeman, William O."
+      } ],
+      "identifiers" : [ {
+        "id" : "978-0-275-98214-0",
+        "subtype" : "Print",
+        "type" : "ISBN"
+      }, {
+        "id" : "978-0-313-06800-3",
+        "subtype" : "Online",
+        "type" : "ISBN"
+      }, {
+        "id" : "978-1-282-40979-8",
+        "subtype" : "Online",
+        "type" : "ISBN"
+      } ],
+      "name" : "\"Great Satan\" Vs. the \"Mad Mullahs\": How the United States and Iran Demonize Each Other",
+      "publicationType" : "Book",
+      "subjects" : [ {
+        "subject" : "SOCIAL SCIENCE / Ethnic Studies / General",
+        "type" : "BISAC"
+      } ],
+      "coverageStatement" : "test coverage statement",
+      "customEmbargoPeriod" : {
+        "embargoValue" : 10,
+        "embargoUnit": "Years"
+      },
+      "isPackageCustom" : false,
+      "isSelected" : true,
+      "isTokenNeeded" : false,
+      "locationId" : 2863717,
+      "managedEmbargoPeriod" : {
+        "embargoValue" : 0
+      },
+      "packageId" : "583-4345",
+      "packageName" : "ABC-CLIO eBook Collection",
+      "url" : "https://publisher.abc-clio.com/9780313068003/",
+      "providerId" : 583,
+      "providerName" : "ABC-CLIO",
+      "visibilityData" : {
+        "isHidden" : false,
+        "reason" : ""
+      },
+      "proxy" : {
+        "id" : "Test-proxy-id",
+        "inherited" : true
+      }
+    }
+  }
+}

--- a/src/test/resources/requests/rmapi/resources/put-custom-resource-is-selected-multiple-attributes.json
+++ b/src/test/resources/requests/rmapi/resources/put-custom-resource-is-selected-multiple-attributes.json
@@ -1,0 +1,33 @@
+{
+  "isSelected": true,
+  "isHidden": false,
+  "coverageStatement": "My test statement",
+  "customEmbargoPeriod": {
+    "embargoUnit": "Weeks",
+    "embargoValue": 30
+  },
+  "titleName": "sd-test-java-again",
+  "pubType": "Book",
+  "publisherName": "Not Empty",
+  "isPeerReviewed": true,
+  "description": "test description",
+  "edition": "test edition",
+  "proxy": {
+    "id": "Proxy-ID-234",
+    "inherited": false
+  },
+  "url": "https://hello",
+  "contributorsList": [{
+    "type": "Author",
+    "contributor": "Rappaport, Helen"
+  }],
+  "identifiersList": [{
+    "id": "978-1-280-71298-2",
+    "subtype": 2,
+    "type": 1
+  }],
+  "customCoverageList": [{
+   "beginCoverage": "2018-01-10",
+   "endCoverage": "2018-01-11"
+  }]
+}

--- a/src/test/resources/requests/rmapi/resources/put-managed-resource-is-selected-multiple-attributes.json
+++ b/src/test/resources/requests/rmapi/resources/put-managed-resource-is-selected-multiple-attributes.json
@@ -1,0 +1,23 @@
+{
+  "isSelected": true,
+  "isHidden": false,
+  "coverageStatement": "test coverage statement",
+  "customEmbargoPeriod": {
+    "embargoUnit": "Years",
+    "embargoValue": 10
+  },
+  "titleName": null,
+  "pubType": "Book",
+  "publisherName": null,
+  "isPeerReviewed": false,
+  "description": null,
+  "edition": null,
+  "proxy": {
+    "id": "Test-proxy-id",
+    "inherited": false
+  },
+  "url": null,
+  "contributorsList": null,
+  "identifiersList": null,
+  "customCoverageList": null
+}

--- a/src/test/resources/responses/rmapi/resources/get-custom-resource-updated-response.json
+++ b/src/test/resources/responses/rmapi/resources/get-custom-resource-updated-response.json
@@ -1,0 +1,69 @@
+{
+  "titleId": 19412030,
+  "titleName": "sd-test-java-again",
+  "publisherName": "Not Empty",
+  "identifiersList": [
+    {
+      "id": "978-1-280-71298-2",
+      "source": "ResourceIdentifier",
+      "subtype": 2,
+      "type": 1
+    }
+  ],
+  "subjectsList": [],
+  "isTitleCustom": true,
+  "pubType": "Book",
+  "customerResourcesList": [
+    {
+      "titleId": 19412030,
+      "packageId": 3157070,
+      "packageName": "Andrii custom package ",
+      "packageType": "Custom",
+      "proxy": {
+        "id": "Proxy-ID-234",
+        "inherited": false
+      },
+      "isPackageCustom": true,
+      "vendorId": 123356,
+      "vendorName": "API DEV GOVERNMENT CUSTOMER",
+      "locationId": 43006476,
+      "isSelected": true,
+      "isTokenNeeded": false,
+      "visibilityData": {
+        "isHidden": false,
+        "reason": ""
+      },
+      "managedCoverageList": [],
+      "customCoverageList": [
+        {
+          "beginCoverage": "2018-01-10",
+          "endCoverage": "2018-01-11"
+        }
+      ],
+      "coverageStatement": "My test statement",
+      "managedEmbargoPeriod": {
+        "embargoUnit": null,
+        "embargoValue": 0
+      },
+      "customEmbargoPeriod": {
+        "embargoUnit": "Weeks",
+        "embargoValue": 30
+      },
+      "url": "https://hello",
+      "userDefinedField1": null,
+      "userDefinedField2": null,
+      "userDefinedField3": null,
+      "userDefinedField4": null,
+      "userDefinedField5": null
+    }
+  ],
+  "description": "test description",
+  "edition": "test edition",
+  "isPeerReviewed": true,
+  "contributorsList": [
+    {
+      "type": "author",
+      "contributor": "Rappaport, Helen"
+    }
+  ]
+}

--- a/src/test/resources/responses/rmapi/resources/get-managed-resource-updated-response.json
+++ b/src/test/resources/responses/rmapi/resources/get-managed-resource-updated-response.json
@@ -1,0 +1,98 @@
+{
+  "titleId": 762169,
+  "titleName": "\"Great Satan\" Vs. the \"Mad Mullahs\": How the United States and Iran Demonize Each Other",
+  "publisherName": "Praeger",
+  "identifiersList": [
+    {
+      "id": "300079",
+      "source": "ResourceIdentifier",
+      "subtype": 0,
+      "type": 7
+    },
+    {
+      "id": "762169",
+      "source": "AtoZ",
+      "subtype": 0,
+      "type": 9
+    },
+    {
+      "id": "978-0-275-98214-0",
+      "source": "ResourceIdentifier",
+      "subtype": 1,
+      "type": 1
+    },
+    {
+      "id": "978-0-313-06800-3",
+      "source": "ResourceIdentifier",
+      "subtype": 2,
+      "type": 1
+    },
+    {
+      "id": "978-1-282-40979-8",
+      "source": "ResourceIdentifier",
+      "subtype": 2,
+      "type": 1
+    }
+  ],
+  "subjectsList": [
+    {
+      "type": "BISAC",
+      "subject": "SOCIAL SCIENCE / Ethnic Studies / General"
+    }
+  ],
+  "isTitleCustom": false,
+  "pubType": "Book",
+  "customerResourcesList": [
+    {
+      "titleId": 762169,
+      "packageId": 4345,
+      "packageName": "ABC-CLIO eBook Collection",
+      "packageType": "Variable",
+      "proxy": {
+        "id": "Test-proxy-id",
+        "inherited": false
+      },
+      "isPackageCustom": false,
+      "vendorId": 583,
+      "vendorName": "ABC-CLIO",
+      "locationId": 2863717,
+      "isSelected": true,
+      "isTokenNeeded": false,
+      "visibilityData": {
+        "isHidden": false,
+        "reason": "Hidden by Customer"
+      },
+      "managedCoverageList": [
+        {
+          "beginCoverage": "2005-01-01",
+          "endCoverage": "2005-12-31"
+        }
+      ],
+      "customCoverageList": [],
+      "coverageStatement": "test coverage statement",
+      "managedEmbargoPeriod": {
+        "embargoUnit": null,
+        "embargoValue": 0
+      },
+      "customEmbargoPeriod": {
+        "embargoUnit": "Years",
+        "embargoValue": 10
+      },
+      "url": "https://publisher.abc-clio.com/9780313068003/",
+      "userDefinedField1": null,
+      "userDefinedField2": null,
+      "userDefinedField3": null,
+      "userDefinedField4": null,
+      "userDefinedField5": null
+    }
+  ],
+  "description": null,
+  "edition": null,
+  "isPeerReviewed": false,
+  "contributorsList": [
+    {
+      "type": "author",
+      "contributor": "Beeman, William O."
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-32, we are supposed to implement PUT for managed as well as custom resources. This PR addresses that.

## Approach
- Update module-descriptor to include this method and related permissions
- Support update to managed and custom resources
- Managed resources can be updated only if selected; else error
- Add validations for fields that can be updated in both managed and custom packages
- Add relevant unit tests

#### TODOS and Open Questions
- [ ] Create a gif for this PR; will do tomorrow
