### PR TITLE
MODKBEKBJ-62: Support '?include=resources' for /eholdings/packages/{packageId}

### DIFF
--- a/src/main/java/org/folio/rest/converter/PackagesConverter.java
+++ b/src/main/java/org/folio/rest/converter/PackagesConverter.java
@@ -1,6 +1,7 @@
 package org.folio.rest.converter;
 
 import static org.folio.rest.util.RestConstants.PACKAGES_TYPE;
+import static org.folio.rest.util.RestConstants.RESOURCES_TYPE;
 
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -22,6 +23,7 @@ import org.folio.rest.jaxrs.model.PackagePostRequest;
 import org.folio.rest.jaxrs.model.PackagePutRequest;
 import org.folio.rest.jaxrs.model.PackageRelationship;
 import org.folio.rest.jaxrs.model.Proxy;
+import org.folio.rest.jaxrs.model.RelationshipData;
 import org.folio.rest.jaxrs.model.VisibilityData;
 import org.folio.rest.util.RestConstants;
 import org.folio.rmapi.model.CoverageDates;
@@ -30,6 +32,7 @@ import org.folio.rmapi.model.PackageData;
 import org.folio.rmapi.model.PackagePost;
 import org.folio.rmapi.model.PackagePut;
 import org.folio.rmapi.model.Packages;
+import org.folio.rmapi.model.Titles;
 import org.folio.rmapi.model.TokenInfo;
 
 public class PackagesConverter {
@@ -64,13 +67,15 @@ public class PackagesConverter {
   }
 
   private CommonAttributesConverter commonConverter;
+  private ResourcesConverter resourcesConverter;
 
   public PackagesConverter() {
-    this(new CommonAttributesConverter());
+    this(new CommonAttributesConverter(), new ResourcesConverter());
   }
 
-  public PackagesConverter(CommonAttributesConverter commonConverter) {
+  public PackagesConverter(CommonAttributesConverter commonConverter, ResourcesConverter resourcesConverter) {
     this.commonConverter = commonConverter;
+    this.resourcesConverter = resourcesConverter;
   }
 
   public PackageCollection convert(Packages packages) {
@@ -84,17 +89,34 @@ public class PackagesConverter {
   }
 
   public Package convert(PackageByIdData packageByIdData) {
-    PackageCollectionItem packageCollectionItem = convertPackage(packageByIdData);
-    packageCollectionItem
-      .withId(packageByIdData.getVendorId() + "-" + packageByIdData.getPackageId())
+    return convert(packageByIdData, null);
+  }
+
+  public Package convert(PackageByIdData packageByIdData, Titles titles) {
+    Package packageData = new Package()
+      .withData(convertPackage(packageByIdData))
+      .withJsonapi(RestConstants.JSONAPI);
+
+    packageData.getData()
       .withRelationships(EMPTY_PACKAGES_RELATIONSHIP)
       .withType(PACKAGES_TYPE)
       .getAttributes()
-      .withProxy(convertToProxy(packageByIdData.getProxy()))
-      .withPackageToken(commonConverter.convertToken(packageByIdData.getPackageToken()));
-    return new Package()
-      .withData(packageCollectionItem)
-      .withJsonapi(RestConstants.JSONAPI);
+        .withProxy(convertToProxy(packageByIdData.getProxy()))
+        .withPackageToken(commonConverter.convertToken(packageByIdData.getPackageToken()));
+
+    if (titles != null) {
+      packageData.getData()
+        .withRelationships(new PackageRelationship()
+          .withResources(new HasManyRelationship()
+            .withMeta(new MetaDataIncluded()
+              .withIncluded(true))
+            .withData(convertResourcesRelationship(packageByIdData, titles))));
+
+      packageData
+        .getIncluded()
+          .addAll(resourcesConverter.convertFromRMAPIResourceList(titles).getData());
+    }
+    return packageData;
   }
 
   private PackageCollectionItem convertPackage(PackageData packageData) {
@@ -202,4 +224,12 @@ public class PackagesConverter {
     return postRequest.build();
   }
 
+  private List<RelationshipData> convertResourcesRelationship(PackageByIdData packageByIdData, Titles titles) {
+    return titles.getTitleList().stream()
+      .map(title ->
+        new RelationshipData()
+          .withId(packageByIdData.getVendorId() + "-" + packageByIdData.getPackageId() + "-" + title.getTitleId())
+          .withType(RESOURCES_TYPE))
+      .collect(Collectors.toList());
+  }
 }

--- a/src/main/java/org/folio/rest/converter/ResourcesConverter.java
+++ b/src/main/java/org/folio/rest/converter/ResourcesConverter.java
@@ -21,8 +21,8 @@ public class ResourcesConverter {
   private PackagesConverter packagesConverter;
   public ResourcesConverter() {
     this.commonConverter = new CommonAttributesConverter();
-    this.vendorConverter = new VendorConverter();
-    this.packagesConverter = new PackagesConverter();
+    this.packagesConverter = new PackagesConverter(commonConverter, this);
+    this.vendorConverter = new VendorConverter(commonConverter, packagesConverter);
     this.titleConverter = new TitleConverter(commonConverter,this);
   }
 

--- a/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
@@ -1,18 +1,17 @@
 package org.folio.rest.impl;
 
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static org.folio.http.HttpConsts.CONTENT_TYPE_HEADER;
 import static org.folio.http.HttpConsts.JSON_API_TYPE;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+
 import javax.ws.rs.core.Response;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.http.HttpStatus;
 import org.folio.config.RMAPIConfigurationServiceCache;
@@ -34,13 +33,25 @@ import org.folio.rest.model.Sort;
 import org.folio.rest.parser.IdParser;
 import org.folio.rest.util.ErrorHandler;
 import org.folio.rest.util.ErrorUtil;
-import org.folio.rest.validator.*;
+import org.folio.rest.validator.CustomPackagePutBodyValidator;
+import org.folio.rest.validator.HeaderValidator;
+import org.folio.rest.validator.PackageParametersValidator;
+import org.folio.rest.validator.PackagePutBodyValidator;
+import org.folio.rest.validator.PackagesPostBodyValidator;
+import org.folio.rest.validator.TitleParametersValidator;
 import org.folio.rmapi.RMAPIService;
 import org.folio.rmapi.exception.RMAPIResourceNotFoundException;
 import org.folio.rmapi.exception.RMAPIServiceException;
 import org.folio.rmapi.exception.RMAPIUnAuthorizedException;
 import org.folio.rmapi.model.PackagePost;
 import org.folio.rmapi.model.PackagePut;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 public class EholdingsPackagesImpl implements EholdingsPackages {
 
@@ -181,16 +192,18 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
   public void getEholdingsPackagesByPackageId(String packageId, String include, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PackageId parsedPackageId = idParser.parsePackageId(packageId);
     headerValidator.validate(okapiHeaders);
+    List<String> includedObjects = include != null ? Arrays.asList(include.split(",")) : Collections.emptyList();
     CompletableFuture.completedFuture(null)
       .thenCompose(okapiData -> configurationService.retrieveConfiguration(new OkapiData(okapiHeaders)))
       .thenCompose(rmapiConfiguration -> {
         RMAPIService rmapiService = new RMAPIService(rmapiConfiguration.getCustomerId(), rmapiConfiguration.getAPIKey(),
           rmapiConfiguration.getUrl(), vertxContext.owner());
-        return rmapiService.retrievePackage(parsedPackageId);
+        return rmapiService.retrievePackage(parsedPackageId, includedObjects);
       })
-      .thenAccept(packageData ->
+      .thenAccept(result ->
         asyncResultHandler.handle(Future.succeededFuture(
-          GetEholdingsPackagesByPackageIdResponse.respond200WithApplicationVndApiJson(converter.convert(packageData)))))
+          GetEholdingsPackagesByPackageIdResponse.respond200WithApplicationVndApiJson(
+            converter.convert(result.getPackageData(), result.getTitles())))))
       .exceptionally(e -> {
         logger.error(INTERNAL_SERVER_ERROR, e);
         handleError(asyncResultHandler, e);

--- a/src/main/java/org/folio/rest/util/RestConstants.java
+++ b/src/main/java/org/folio/rest/util/RestConstants.java
@@ -10,6 +10,7 @@ public final class RestConstants {
   public static final String PACKAGES_TYPE = "packages";
   public static final String PROVIDERS_TYPE = "providers";
   public static final String TITLES_TYPE = "titles";
+  public static final String RESOURCES_TYPE = "resources";
 
   private RestConstants(){ }
 }

--- a/src/main/java/org/folio/rmapi/result/PackageResult.java
+++ b/src/main/java/org/folio/rmapi/result/PackageResult.java
@@ -1,0 +1,22 @@
+package org.folio.rmapi.result;
+
+import org.folio.rmapi.model.PackageByIdData;
+import org.folio.rmapi.model.Titles;
+
+public class PackageResult {
+  private PackageByIdData packageData;
+  private Titles titles;
+
+  public PackageResult(PackageByIdData packageData, Titles titles) {
+    this.packageData = packageData;
+    this.titles = titles;
+  }
+
+  public PackageByIdData getPackageData() {
+    return packageData;
+  }
+
+  public Titles getTitles() {
+    return titles;
+  }
+}

--- a/src/test/java/org/folio/rest/impl/PackagesTestData.java
+++ b/src/test/java/org/folio/rest/impl/PackagesTestData.java
@@ -49,41 +49,6 @@ public class PackagesTestData {
 
   }
 
-  public static Package getExpectedPackage() {
-    return new Package().withData(new PackageCollectionItem()
-      .withId("111111-3964")
-      .withType(PACKAGES_TYPE)
-      .withAttributes(new PackageDataAttributes()
-        .withName("carole and sams test")
-        .withPackageId(3964)
-        .withIsCustom(true)
-        .withProviderId(111111)
-        .withProviderName("APIDEV CORPORATE CUSTOMER")
-        .withTitleCount(6)
-        .withIsSelected(true)
-        .withSelectedCount(6)
-        .withPackageType("Custom")
-        .withContentType(ContentType.AGGREGATED_FULL_TEXT)
-        .withCustomCoverage(new Coverage()
-          .withBeginCoverage("")
-          .withEndCoverage(""))
-        .withVisibilityData(new VisibilityData()
-          .withIsHidden(false)
-          .withReason("")
-        )
-        .withProxy(new Proxy()
-          .withId("<n>")
-          .withInherited(true))
-        .withAllowKbToAddTitles(false)
-        .withPackageToken(new Token()
-          .withFactName("[[gale.customcode.infocust]]")
-          .withHelpText("help text")
-          .withValue("token value")
-          .withPrompt("res_id=info:sid/gale:")
-        )))
-      .withJsonapi(RestConstants.JSONAPI);
-  }
-
   public static PackageCollection getExpectedCollectionPackageItem() {
     List<PackageCollectionItem> collectionItems = new ArrayList<>();
     PackageCollectionItem collectionItem = new PackageCollectionItem()

--- a/src/test/resources/responses/kb-ebsco/packages/expected-package-by-id.json
+++ b/src/test/resources/responses/kb-ebsco/packages/expected-package-by-id.json
@@ -1,0 +1,40 @@
+{
+  "data": {
+    "id": "111111-3964",
+    "type": "packages",
+    "attributes": {
+      "name": "carole and sams test",
+      "packageId": 3964,
+      "isCustom": true,
+      "providerId": 111111,
+      "providerName": "APIDEV CORPORATE CUSTOMER",
+      "titleCount": 6,
+      "isSelected": true,
+      "selectedCount": 6,
+      "packageType": "Custom",
+      "contentType": "Aggregated Full Text",
+      "customCoverage": {
+        "beginCoverage": "",
+        "endCoverage": ""
+      },
+      "visibilityData": {
+        "isHidden": false,
+        "reason": ""
+      },
+      "proxy": {
+        "id": "<n>",
+        "inherited": true
+      },
+      "allowKbToAddTitles": false,
+      "packageToken": {
+        "factName": "[[gale.customcode.infocust]]",
+        "helpText": "help text",
+        "value": "token value",
+        "prompt": "res_id=info:sid/gale:"
+      }
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}


### PR DESCRIPTION
## Purpose
Support '?include=resources' for /eholdings/packages/{packageId}

## Approach
Retrieved resources by package id and added them to package response if
include flag is set to include=resources.
Moved package test fixture to json file, made other small test refactorings