### PR TITLE
MODKBEKBJ-33: Delete resource by resource id

### DIFF
--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -38,6 +38,7 @@ import org.folio.rmapi.model.PackageSelectedPayload;
 import org.folio.rmapi.model.Packages;
 import org.folio.rmapi.model.Proxies;
 import org.folio.rmapi.model.Proxy;
+import org.folio.rmapi.model.ResourceDeletePayload;
 import org.folio.rmapi.model.ResourceSelectedPayload;
 import org.folio.rmapi.model.ResourcePut;
 import org.folio.rmapi.model.RootProxyCustomLabels;
@@ -467,5 +468,10 @@ public class RMAPIService {
   public CompletionStage<Void> updateResource(ResourceId parsedResourceId, ResourcePut resourcePutBody) {
     final String path = VENDORS_PATH + '/' + parsedResourceId.getProviderIdPart() + '/' + PACKAGES_PATH + '/' + parsedResourceId.getPackageIdPart() + '/' + TITLES_PATH + '/' + parsedResourceId.getTitleIdPart();
     return this.putRequest(constructURL(path), resourcePutBody);
+  }
+
+  public CompletableFuture<Void> deleteResource(ResourceId parsedResourceId) {
+    final String path = VENDORS_PATH + '/' + parsedResourceId.getProviderIdPart() + '/' + PACKAGES_PATH + '/' + parsedResourceId.getPackageIdPart() + '/' + TITLES_PATH + '/' + parsedResourceId.getTitleIdPart();
+    return this.putRequest(constructURL(path), new ResourceDeletePayload(false));
   }
 }

--- a/src/main/java/org/folio/rmapi/model/ResourceDeletePayload.java
+++ b/src/main/java/org/folio/rmapi/model/ResourceDeletePayload.java
@@ -1,0 +1,12 @@
+package org.folio.rmapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Value;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ResourceDeletePayload {
+  @JsonProperty("isSelected")
+  private boolean isSelected;
+}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-33, we are supposed to be able to delete managed or custom resource associated with a custom package.

## Approach
- Add permissions for DELETE resource by resource id endpoint.
- Validate that the resourceId we get is valid; else respond with 400
- Validate that resource is indeed associated with a custom resource; else respond with 400 
- If its a valid resourceId, internally this sends a PUT request to RM API with `isSelected=false` and after successful deletion returns a 204
- Added associated unit tests.

## Screenshots
![delete_resource](https://user-images.githubusercontent.com/33662516/49968728-b495ed80-fef4-11e8-99be-39ed644dc479.gif)
