### PR TITLE
Fix name and id in ModuleDescriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1,9 +1,9 @@
 {
   "id": "${artifactId}-${version}",
-  "name": "EBSCO KB Broker",
+  "name": "kb-ebsco",
   "provides": [
     {
-      "id": "kb-ebsco-java",
+      "id": "eholdings",
       "version": "1.0",
       "handlers": [
         {


### PR DESCRIPTION
## Purpose
UI only recognizes Eholdings module if it has specific name and id
Changed name and id to correspond to mod-kb-ebsco