### PR TITLE
MODKBEKBJ-112 -  load and use module schemas in API tests for validat…

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -126,6 +126,28 @@
           "permissionsRequired" :["kb-ebsco.cache.delete"]
         }
       ]
+    },
+    {
+      "id": "_jsonSchemas",
+      "version": "1.0",
+      "interfaceType" : "multiple",
+      "handlers" : [
+        {
+          "methods" : [ "GET" ],
+          "pathPattern" : "/_/jsonSchemas"
+        }
+      ]
+    },
+    {
+      "id": "_ramls",
+      "version": "1.0",
+      "interfaceType" : "multiple",
+      "handlers" : [
+        {
+          "methods" : [ "GET" ],
+          "pathPattern" : "/_/ramls"
+        }
+      ]
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-112 we want to have the ability to get JSON schemas for response validation used in postman API tests. 
this PR consists of two parts - adding system endpoints and refactoring tests, which will be linked.

## Approach
added `_jsonSchemas` and `_ramls` service endpoints

#### TODOS and Open Questions
- after this PR merged there is a second one related to api-tests which also should be reviewed. 

## Learning
* here is documentation describes system endpoints
 JSON Schema API - https://github.com/folio-org/raml-module-builder#json-schemas-api     
 RAML API - https://github.com/folio-org/raml-module-builder#ramls-api
