### PR TITLE
MODKBEKBJ-96 - Changes for API Tests PUT /eholdings/root-proxy endpoint

### DIFF
--- a/ramls/types/providers/providerPutData.json
+++ b/ramls/types/providers/providerPutData.json
@@ -21,5 +21,9 @@
       "description": "Provider Data Attributes",
       "$ref": "providerDataAttributes.json"
     }
-  }
+  },
+  "required": [
+    "type",
+    "attributes"
+  ]
 }

--- a/ramls/types/providers/providerPutRequest.json
+++ b/ramls/types/providers/providerPutRequest.json
@@ -11,5 +11,8 @@
       "description": "Data object of provider put request",
       "$ref": "providerPutData.json"
     }
-  }
+  },
+  "required": [
+    "data"
+  ]
 }

--- a/ramls/types/proxies/rootProxyPutData.json
+++ b/ramls/types/proxies/rootProxyPutData.json
@@ -21,5 +21,9 @@
       "description": "Root Proxy Data Attributes",
       "$ref": "rootProxyDataAttributes.json"
     }
-  }
+  },
+  "required": [
+    "type",
+    "attributes"
+  ]
 }

--- a/ramls/types/proxies/rootProxyPutRequest.json
+++ b/ramls/types/proxies/rootProxyPutRequest.json
@@ -11,5 +11,8 @@
       "description": "Data object of root proxy put request",
       "$ref": "rootProxyPutData.json"
     }
-  }
+  },
+  "required": [
+    "data"
+  ]
 }


### PR DESCRIPTION

## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-96 we want to fix API Tests for PUT /eholdings/root-proxy endpoint. In case "attributes" property is null mod-kb-ebsco-java returns 500 code, but mod-kb-ebsco returns 422. Also, in order to have same style for an error message if "attributes" is null we need to change response with error message for providers.

## Approach
 - made attributes and type required for proxies and providers like in cases with titles,packages,resources
