### PR TITLE
MODKBEKBJ-43: Use new endpoint to get VendorId for custom packages

### DIFF
--- a/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
@@ -81,10 +81,15 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
 
     templateFactory.createTemplate(okapiHeaders, asyncResultHandler)
       .requestAction((rmapiService, okapiData) ->
-        rmapiService.getVendors(isFilterCustom)
-          .thenCompose(vendors ->
-            rmapiService.retrievePackages(filterSelected, filterType, rmapiService.getFirstProviderElement(vendors),
-              q, page, count, nameSort)))
+      {
+        if (isFilterCustom) {
+          return rmapiService.getVendorId()
+            .thenCompose(vendorId ->
+              rmapiService.retrievePackages(filterSelected, filterType, vendorId, q, page, count, nameSort));
+        } else {
+          return rmapiService.retrievePackages(filterSelected, filterType, null, q, page, count, nameSort);
+        }
+      })
       .addErrorMapper(RMAPIServiceException.class,
         exception ->
           GetEholdingsPackagesResponse.respond400WithApplicationVndApiJson(

--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -19,7 +19,6 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.mutable.MutableObject;
-
 import org.folio.rest.jaxrs.model.RootProxyPutRequest;
 import org.folio.rest.model.FilterQuery;
 import org.folio.rest.model.PackageId;
@@ -42,8 +41,8 @@ import org.folio.rmapi.model.Packages;
 import org.folio.rmapi.model.Proxies;
 import org.folio.rmapi.model.Proxy;
 import org.folio.rmapi.model.ResourceDeletePayload;
-import org.folio.rmapi.model.ResourceSelectedPayload;
 import org.folio.rmapi.model.ResourcePut;
+import org.folio.rmapi.model.ResourceSelectedPayload;
 import org.folio.rmapi.model.RootProxyCustomLabels;
 import org.folio.rmapi.model.Title;
 import org.folio.rmapi.model.TitleCreated;
@@ -287,22 +286,15 @@ public class RMAPIService {
       .sort(sort)
       .build();
 
-    String packagesPath = providerId == null ? PACKAGES_PATH + "?" : VENDORS_PATH+ '/' + providerId + '/' + PACKAGES_PATH + "?";
+    String packagesPath = providerId == null ? PACKAGES_PATH + "?" : VENDORS_PATH + '/' + providerId + '/' + PACKAGES_PATH + "?";
 
     return this.getRequest(constructURL(packagesPath + path), Packages.class);
   }
 
-  public CompletableFuture<Vendors> getVendors(boolean filterCustom){
-    CompletableFuture<Vendors> vendorsList = completedFuture(Vendors.builder().build());
-    if (filterCustom) {
-      return retrieveProviders(customerId, 1, 25, Sort.RELEVANCE);
-    }
-    return vendorsList;
-  }
-
-  public Long getFirstProviderElement(Vendors vendors) {
-    List<Vendor> vendorList = vendors.getVendorList();
-    return (CollectionUtils.isEmpty(vendorList)) ? null : vendorList.get(0).getVendorId();
+  public CompletableFuture<Long> getVendorId(){
+    return retrieveRootProxyCustomLabels()
+      .thenCompose(rootProxyCustomLabels ->
+        CompletableFuture.completedFuture(Long.parseLong(rootProxyCustomLabels.getVendorId())));
   }
 
   public CompletableFuture<VendorResult> retrieveProvider(long id, String include) {
@@ -439,9 +431,7 @@ public class RMAPIService {
 
     MutableObject providerId = new MutableObject();
      return this
-      .retrieveProviders(customerId, 1, 25, Sort.RELEVANCE)
-      .thenCompose(
-        vendors -> completedFuture(this.getFirstProviderElement(vendors)))
+      .getVendorId()
       .thenCompose(vendorId -> {
         providerId.setValue(vendorId);
         return this.postPackage(entity, vendorId);

--- a/src/main/java/org/folio/rmapi/model/RootProxyCustomLabels.java
+++ b/src/main/java/org/folio/rmapi/model/RootProxyCustomLabels.java
@@ -14,8 +14,11 @@ public class RootProxyCustomLabels {
 
   @JsonProperty("proxy")
   private Proxy proxy;
-  
+
+  @JsonProperty("vendorId")
+  private String vendorId;
+
   @JsonProperty("labels")
   private List<CustomLabel> labelList;
-  
+
 }

--- a/src/test/java/org/folio/rest/impl/EholdingsPackagesTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsPackagesTest.java
@@ -81,11 +81,11 @@ public class EholdingsPackagesTest extends WireMockTestBase {
   @Test
   public void shouldReturnPackagesOnGetWithPackageId() throws IOException, URISyntaxException {
     String packagesStubResponseFile = "responses/rmapi/packages/get-packages-by-provider-id.json";
-    String providerByCustIdStubResponseFile = "responses/rmapi/packages/get-package-provider-by-id.json";
+    String providerIdByCustIdStubResponseFile = "responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-success-response.json";
 
     mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
 
-    mockGet(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors.*"), providerByCustIdStubResponseFile);
+    mockGet(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), providerIdByCustIdStubResponseFile);
     mockGet(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/vendors/" + STUB_VENDOR_ID + "/packages.*")
       , packagesStubResponseFile);
 
@@ -496,7 +496,7 @@ public class EholdingsPackagesTest extends WireMockTestBase {
     String stubResponseFile = "responses/rmapi/packages/get-package-resources-400-response.json";
 
     TestUtil.mockConfiguration(CONFIGURATION_STUB_FILE, getWiremockUrl());
-    
+
     stubFor(
       get(
         new UrlPathPattern(new RegexPattern(

--- a/src/test/resources/requests/rmapi/proxiescustomlabels/put-root-proxy-custom-labels-without-empty-display-labels.json
+++ b/src/test/resources/requests/rmapi/proxiescustomlabels/put-root-proxy-custom-labels-without-empty-display-labels.json
@@ -3,6 +3,7 @@
     "id": "Test-Proxy-ID-123",
     "inherited": null
   },
+  "vendorId": "111111",
   "labels": [
     {
       "id": 1,

--- a/src/test/resources/requests/rmapi/proxiescustomlabels/put-root-proxy-custom-labels.json
+++ b/src/test/resources/requests/rmapi/proxiescustomlabels/put-root-proxy-custom-labels.json
@@ -3,6 +3,7 @@
     "id": "Test-Proxy-ID-123",
     "inherited": null
   },
+  "vendorId": "111111",
   "labels": [
     {
       "id": 1,

--- a/src/test/resources/responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-success-response.json
+++ b/src/test/resources/responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-success-response.json
@@ -2,6 +2,7 @@
   "proxy": {
     "id": "<n>"
   },
+  "vendorId": "111111",
   "labels": [
     {
       "id": 1,

--- a/src/test/resources/responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-updated-response.json
+++ b/src/test/resources/responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-updated-response.json
@@ -2,6 +2,7 @@
   "proxy": {
     "id": "Test-Proxy-ID-123"
   },
+  "vendorId": "111111",
   "labels": [
     {
       "id": 1,

--- a/src/test/resources/responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-with-empty-labels-success-response.json
+++ b/src/test/resources/responses/rmapi/proxiescustomlabels/get-root-proxy-custom-labels-with-empty-labels-success-response.json
@@ -2,6 +2,7 @@
   "proxy": {
     "id": "Test-Proxy-ID-123"
   },
+  "vendorId": "111111",
   "labels": [
     {
       "id": 1,


### PR DESCRIPTION

## Purpose
Use updated "GET /rm/rmaccounts/{custid}" endpoint for getting vendor id of custom packages

## Approach
Change implementation to use GET /rm/rmaccounts/{custid} endpoint

#### TODOS and Open Questions
- [ ] Production environment (https://api.ebsco.io) returns vendor id correctly, but https://sandbox.ebsco.io currently returns following error 
```
{
    "errors": [
        {
            "code": "1004",
            "message": "IProxyClient#getCustomerProxies(String) timed-out and no fallback available.",
            "subCode": "0"
        }
    ]
}
```
So applying these changes will temporarily break get and update endpoints for custom packages on test environments.