### PR TITLE
MODKBEKBJ-126: Steps to replace mod-kb-ebsco Ruby with Java module

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildMvn {
-  publishModDescriptor = 'no'
+  publishModDescriptor = 'yes'
   mvnDeploy = 'yes'
   publishAPI = 'yes'
   runLintRamlCop = 'yes'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+## v2.0.0-SNAPSHOT 2019-01-22
+ * MODKBEKBJ-2 - Setting up the project
+ * MODKBEKBJ-4 - Rewrite Configuration
+ * MODKBEKBJ-6 - Rewrite Proxy related endpoints
+ * MODKBEKBJ-7 - Rewrite Providers endpoints
+ * MODKBEKBJ-8 - Rewrite Packages endpoints
+ * MODKBEKBJ-9 - Rewrite Resources endpoints
+ * MODKBEKBJ-10 - Rewrite Titles endpoints
+ * Replace mod-kb-ebsco (ruby version) with mod-kb-ebsco-java in environments
+  
 ## v0.1.0 2018-10-04
  * Added raml files
  * Initial module setup

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-kb-ebsco-java</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>EBSCO KB Broker</name>


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-126 need to coordinate on the replacement process for mod-kb-ebsco (ruby module) with mod-kb-ebsco (Java module)

Work for doing the replacement is noted here:
https://issues.folio.org/browse/FOLIO-1727

NOTE: This PR should not be merged until we  are ready to swap out the ruby-based module in folio-snapshot environment. Initially swap will be done in folio/testing environment and tested before updating all environments.  (Q42018 environment is not impacted by this change and will continue to use mod-kb-ebsco (Ruby module)

## Approach
- Set Jenkinsfile publishModDescriptor = ‘yes’ 
- Upgrade version of mod-kb-ebsco-java to version 2.0.0-SNAPSHOT in pom file. It is should to be a later version than the current Ruby version of mod-kb-ebsco
- Update news.md to reflect the changes

#### TODOS and Open Questions

## Learning