### PR TITLE
MODKBEKBJ-142 add schema path as a property to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <vertx.version>3.5.4</vertx.version>
     <aspectj.version>1.9.1</aspectj.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
+    <jsonschema_paths>types/**</jsonschema_paths>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mod-configuration-client.version>4.0.3</mod-configuration-client.version>
     <spring.version>5.1.1.RELEASE</spring.version>
@@ -241,6 +242,10 @@
                 <systemProperty>
                   <key>raml_files</key>
                   <value>${ramlfiles_path}</value>
+                </systemProperty>
+                <systemProperty>
+                  <key>schema_paths</key>
+                  <value>${jsonschema_paths}</value>
                 </systemProperty>
               </systemProperties>
             </configuration>


### PR DESCRIPTION
## Purpose
Set system property which is used by RAML generator to build a list of module's json schemas

## Approach
RAML generator can build a list of json schemas defined in the module. The list is then retrieved from `/_/jsonSchemas` endpoint. There is a special system property `schema_paths` to be used for file filter configuration. In this PR the property is set to
`types/**`
Thus all json schemas contained inside `types` folder will be included in the list