### PR TITLE
MODKBEKBJ-155 - Refactor Postman API test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>23.2.0</raml-module-builder.version>
+    <raml-module-builder.version>23.5.0</raml-module-builder.version>
     <vertx.version>3.5.4</vertx.version>
     <aspectj.version>1.9.1</aspectj.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
@@ -232,7 +232,6 @@
             </goals>
             <configuration>
               <mainClass>org.folio.rest.tools.GenerateRunner</mainClass>
-              <!-- <executable>java</executable> -->
               <cleanupDaemonThreads>false</cleanupDaemonThreads>
               <systemProperties>
                 <systemProperty>


### PR DESCRIPTION
updated RMB version

## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-155 we want to use the newest version of RMB to be able to get the list of JSON schemas available for mod-kb-ebsco-java module.

## Approach
changed RMB version to latest 23.5.0
https://github.com/folio-org/raml-module-builder/releases/tag/v23.5.0
<img width="1079" alt="screen shot 2019-01-29 at 4 13 24 pm" src="https://user-images.githubusercontent.com/37537790/51914139-d2ee7480-23e0-11e9-9256-d3fb7bc73240.png">

