### PR TITLE
FOLIO-1753 - Release 2.0.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildMvn {
-  publishModDescriptor = 'no'
+  publishModDescriptor = 'yes'
   mvnDeploy = 'yes'
   publishAPI = 'yes'
   runLintRamlCop = 'yes'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+## v2.0.0-SNAPSHOT 2019-01-22
+ * MODKBEKBJ-2 - Setting up the project
+ * MODKBEKBJ-4 - Rewrite Configuration
+ * MODKBEKBJ-6 - Rewrite Proxy related endpoints
+ * MODKBEKBJ-7 - Rewrite Providers endpoints
+ * MODKBEKBJ-8 - Rewrite Packages endpoints
+ * MODKBEKBJ-9 - Rewrite Resources endpoints
+ * MODKBEKBJ-10 - Rewrite Titles endpoints
+ * Replace mod-kb-ebsco (ruby version) with mod-kb-ebsco-java in environments
+
 ## v0.1.0 2018-10-04
  * Added raml files
  * Initial module setup

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-kb-ebsco-java</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.1</version>
   <packaging>jar</packaging>
 
   <name>EBSCO KB Broker</name>
@@ -495,7 +495,7 @@
     <url>https://github.com/folio-org/mod-kb-ebsco-java</url>
     <connection>scm:git:git://github.com/folio-org/mod-kb-ebsco-java</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-kb-ebsco-java.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.0.1</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-kb-ebsco-java</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>2.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>EBSCO KB Broker</name>
@@ -232,7 +232,6 @@
             </goals>
             <configuration>
               <mainClass>org.folio.rest.tools.GenerateRunner</mainClass>
-              <!-- <executable>java</executable> -->
               <cleanupDaemonThreads>false</cleanupDaemonThreads>
               <systemProperties>
                 <systemProperty>
@@ -445,11 +444,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.1</version>
         <configuration>
-          <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader
-               https://issues.folio.org/browse/FOLIO-1609
-               https://issues.apache.org/jira/browse/SUREFIRE-1588
-          -->
-          <useSystemClassLoader>false</useSystemClassLoader>
+         <useSystemClassLoader>false</useSystemClassLoader>
           <systemPropertyVariables>
             <vertx.logger-delegate-factory-class-name>
               io.vertx.core.logging.Log4j2LogDelegateFactory

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-kb-ebsco-java</artifactId>
-  <version>2.0.1</version>
+  <version>2.0.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>EBSCO KB Broker</name>
@@ -495,7 +495,7 @@
     <url>https://github.com/folio-org/mod-kb-ebsco-java</url>
     <connection>scm:git:git://github.com/folio-org/mod-kb-ebsco-java</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-kb-ebsco-java.git</developerConnection>
-    <tag>v2.0.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/FOLIO-1753 we are releasing mod-kb-ebsco-java module so that it can be included in environments and we can start deprecating the use of mod-kb-ebsco (Ruby Version). Of note - the Ruby version will continue to be included as part of Q3 and Q4 releases. Of note -  The Java module provides eholdings interface version 1.0, the Ruby module provides eholdings interface version 0.1

## Approach
- Update version, news and set publishModDescriptor = yes
- Used `mvn -DautoVersionSubmodules=true release:clean release:prepare` so to properly handle release and snapshot versioning
- Release was updated from 2.0.0 to 2.0.1 due to an sonar reported issue regarding commented code in pom -- resolved this and updated release version

#### TODOS and Open Questions
- [ ] A follow on release of eholdings is required. It will be updated to reference the newer 1.0 eholdings interface version

## Learning
Followed release procedures as noted at https://dev.folio.org/guidelines/release-procedures/#maven-based-modules 
