### PR TITLE
MODKBEKBJ-167 - Create database script to store tag data

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -149,6 +149,21 @@
           "pathPattern" : "/_/ramls"
         }
       ]
+    },
+    {
+      "id": "_tenant",
+      "version": "1.0",
+      "interfaceType": "system",
+      "handlers": [
+        {
+          "methods": ["POST"],
+          "pathPattern": "/_/tenant"
+        },
+        {
+          "methods": ["DELETE"],
+          "pathPattern": "/_/tenant"
+        }
+      ]
     }
   ],
   "permissionSets": [

--- a/src/main/java/org/folio/rest/impl/TenantApiImpl.java
+++ b/src/main/java/org/folio/rest/impl/TenantApiImpl.java
@@ -1,0 +1,80 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.TenantTool;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+public class TenantApiImpl extends TenantAPI {
+
+  private static final String TEST_DATA_SQL = "templates/db_scripts/test-data.sql";
+  private static final String OKAPI_TENANT_HEADER = "x-okapi-tenant";
+  private static final String TENANT_PLACEHOLDER = "${myuniversity}";
+  private static final String MODULE_PLACEHOLDER = "${mymodule}";
+  private static final String TEST_MODE = "test.mode";
+  private final Logger logger = LoggerFactory.getLogger(TenantApiImpl.class);
+
+  @Validate
+  @Override
+  public void postTenant(TenantAttributes entity, Map<String, String> headers, Handler<AsyncResult<Response>> handlers,
+                         Context context) {
+    super.postTenant(entity, headers, result -> {
+      if (result.failed()) {
+        handlers.handle(result);
+      } else {
+        setupTestData(headers, context).setHandler(event -> handlers.handle(result));
+      }
+    }, context);
+  }
+
+  private Future<List<String>> setupTestData(Map<String, String> headers, Context context) {
+    try {
+
+      if (!Boolean.TRUE.equals(Boolean.valueOf(System.getenv(TEST_MODE)))) {
+        logger.info("Test data will not be initialized.");
+        return Future.succeededFuture();
+      }
+
+      InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(TEST_DATA_SQL);
+
+      if (inputStream == null) {
+        logger.info("Test data will not be initialized: no resources found: {}", TEST_DATA_SQL);
+        return Future.succeededFuture();
+      }
+
+      String sqlScript = IOUtils.toString(inputStream, StandardCharsets.UTF_8.name());
+      if (StringUtils.isBlank(sqlScript)) {
+        return Future.succeededFuture();
+      }
+
+      String tenantId = TenantTool.calculateTenantId(headers.get(OKAPI_TENANT_HEADER));
+      String moduleName = PostgresClient.getModuleName();
+
+      sqlScript = sqlScript.replace(TENANT_PLACEHOLDER, tenantId).replace(MODULE_PLACEHOLDER, moduleName);
+
+      Future<List<String>> future = Future.future();
+      PostgresClient.getInstance(context.owner()).runSQLFile(sqlScript, false, future);
+
+      logger.info("Received flag to initialize test data. Check the server log for details.");
+      logger.info("************ Creating test data ************");
+
+      return future;
+    } catch (IOException e) {
+      return Future.failedFuture(e);
+    }
+  }
+}

--- a/src/main/resources/templates/db_scripts/create-table.sql
+++ b/src/main/resources/templates/db_scripts/create-table.sql
@@ -1,0 +1,10 @@
+ALTER TABLE tags
+DROP COLUMN jsonb,
+ADD COLUMN record_id VARCHAR (50) NOT NULL,
+ADD COLUMN record_type VARCHAR (50) NOT NULL,
+ADD COLUMN tag VARCHAR (50) NOT NULL;
+
+INSERT INTO tags (record_id, record_type, tag) VALUES
+('583-4345-762169', 'resource', 'first tag'),
+('4345', 'package', 'second tag'),
+('762169', 'title', 'third tag');

--- a/src/main/resources/templates/db_scripts/create-table.sql
+++ b/src/main/resources/templates/db_scripts/create-table.sql
@@ -4,7 +4,5 @@ ADD COLUMN record_id VARCHAR (50) NOT NULL,
 ADD COLUMN record_type VARCHAR (50) NOT NULL,
 ADD COLUMN tag VARCHAR (50) NOT NULL;
 
-INSERT INTO tags (record_id, record_type, tag) VALUES
-('583-4345-762169', 'resource', 'first tag'),
-('4345', 'package', 'second tag'),
-('762169', 'title', 'third tag');
+CREATE INDEX record_id_index ON tags (record_id);
+CREATE INDEX tag_index ON tags (tag);

--- a/src/main/resources/templates/db_scripts/create-table.sql
+++ b/src/main/resources/templates/db_scripts/create-table.sql
@@ -1,7 +1,7 @@
 ALTER TABLE tags
 DROP COLUMN jsonb,
 ADD COLUMN record_id VARCHAR (50) NOT NULL,
-ADD COLUMN record_type VARCHAR (50) NOT NULL,
+ADD COLUMN record_type VARCHAR (10) CHECK (record_type IN ('provider', 'package', 'title', 'resource')),
 ADD COLUMN tag VARCHAR (50) NOT NULL;
 
 CREATE INDEX record_id_index ON tags (record_id);

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1,0 +1,12 @@
+{
+  "tables": [
+    {
+      "tableName": "tags",
+      "withMetadata": false,
+      "pkColumnName": "id",
+      "generateId": true,
+      "withAuditing": false,
+      "customSnippetPath": "create-table.sql"
+    }
+  ]
+}

--- a/src/main/resources/templates/db_scripts/test-data.sql
+++ b/src/main/resources/templates/db_scripts/test-data.sql
@@ -1,0 +1,4 @@
+INSERT INTO ${myuniversity}_${mymodule}.tags (record_id, record_type, tag) VALUES
+('583-4345-762169', 'resource', 'EBSCO'),
+('4345', 'package', 'folio'),
+('762169', 'title', 'spitfire');

--- a/src/main/resources/templates/db_scripts/test-data.sql
+++ b/src/main/resources/templates/db_scripts/test-data.sql
@@ -1,4 +1,5 @@
 INSERT INTO ${myuniversity}_${mymodule}.tags (record_id, record_type, tag) VALUES
-('583-4345-762169', 'resource', 'EBSCO'),
-('4345', 'package', 'folio'),
-('762169', 'title', 'spitfire');
+('53-2767121-90099', 'resource', 'EBSCO'),
+('53-2767121', 'package', 'folio'),
+('413-1988660', 'package', 'spitfire');
+('36-2728041', 'package', 'EBSCO');


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-167 we want to be able to store tag data 

## Approach
* added /_/tenant endpoint to ModuleDescriptor file because database schema creation triggers on the step of enabling the module to a tenant.
* created a schema to store tags
* added tested data

## Learn
* Tenant Api - https://github.com/folio-org/raml-module-builder#tenant-api
<img width="1677" alt="screen shot 2019-02-01 at 11 32 37 am" src="https://user-images.githubusercontent.com/37537790/52114612-2a752600-2615-11e9-9ed3-6034fd2f4385.png">

* To enable test data creation we have to specify an environment variable called `test.mode` in DeploymentDescriptor.
<img width="822" alt="screen shot 2019-02-04 at 11 35 08 am" src="https://user-images.githubusercontent.com/37537790/52200788-54775400-2872-11e9-8db1-216e2f22e676.png">
the corresponding log file with message about test data creation can be viewed by 
`docker logs <docker_container_name>`
<img width="1680" alt="screen shot 2019-02-04 at 11 36 11 am" src="https://user-images.githubusercontent.com/37537790/52200379-4aa12100-2871-11e9-9e79-10ccbba8f0a6.png">


