### PR TITLE
MODKBEKBJ-182 Update tags for provider with 0 selected packages

### DIFF
--- a/src/test/java/org/folio/rest/impl/WireMockTestBase.java
+++ b/src/test/java/org/folio/rest/impl/WireMockTestBase.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
 import io.restassured.RestAssured;
 import io.restassured.http.Header;
 import io.restassured.response.ExtractableResponse;
@@ -18,6 +19,7 @@ import io.restassured.specification.RequestSpecification;
 import io.vertx.core.Vertx;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+
 import org.apache.http.HttpStatus;
 import org.apache.http.protocol.HTTP;
 import org.junit.AfterClass;
@@ -140,6 +142,10 @@ public abstract class WireMockTestBase {
   }
 
   protected <T> T sendPutRequestAndRetrieveResponse(String endpoint, String putBody, Class<T> clazz){
+    return sendPutRequestAndRetrieveResponse(endpoint, putBody).as(clazz);
+  }
+
+  protected <T> ExtractableResponse<Response> sendPutRequestAndRetrieveResponse(String endpoint, String putBody){
     return RestAssured
       .given()
       .spec(getRequestSpecification())
@@ -149,7 +155,7 @@ public abstract class WireMockTestBase {
       .put(endpoint)
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .extract().as(clazz);
+      .extract();
   }
 
   protected <T> T sendPostRequestAndRetrieveResponse(String endpoint, String postBody, Class<T> clazz){

--- a/src/test/resources/responses/kb-ebsco/providers/expected-provider-with-packages.json
+++ b/src/test/resources/responses/kb-ebsco/providers/expected-provider-with-packages.json
@@ -1,0 +1,77 @@
+{
+  "data": {
+    "id": "19",
+    "type": "providers",
+    "attributes": {
+      "name": "EBSCO",
+      "packagesTotal": 625,
+      "packagesSelected": 11,
+      "providerToken": {
+        "value": "sampleToken"
+      },
+      "supportsCustomPackages": false,
+      "proxy": {
+        "id": "<n>",
+        "inherited": true
+      },
+      "tags": {
+        "tagList": []
+      }
+    },
+    "relationships": {
+      "packages": {
+        "data": [
+          {
+            "type": "packages",
+            "id": "1111111-2222222"
+          }
+        ],
+        "meta": {
+          "included": true
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "1111111-2222222",
+      "type": "packages",
+      "attributes": {
+        "contentType": "Online Reference",
+        "customCoverage": {
+          "beginCoverage": "",
+          "endCoverage": ""
+        },
+        "isCustom": true,
+        "isSelected": true,
+        "name": "TEST_PACKAGE_NAME",
+        "packageId": 2222222,
+        "packageType": "Custom",
+        "providerId": 1111111,
+        "providerName": "TEST_VENDOR_NAME",
+        "selectedCount": 5,
+        "titleCount": 5,
+        "visibilityData": {
+          "isHidden": false,
+          "reason": ""
+        }
+      },
+      "relationships": {
+        "resources": {
+          "data": [],
+          "meta": {
+            "included": false
+          }
+        },
+        "provider": {
+          "meta": {
+            "included": false
+          }
+        }
+      }
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/src/test/resources/responses/kb-ebsco/providers/expected-provider-with-updated-tags.json
+++ b/src/test/resources/responses/kb-ebsco/providers/expected-provider-with-updated-tags.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "id": "19",
+    "type": "providers",
+    "attributes": {
+      "name": "EBSCO",
+      "packagesTotal": 625,
+      "packagesSelected": 0,
+      "providerToken": {
+        "factName": "[[galesiteid]]",
+        "prompt": "/itweb/",
+        "helpText": "<ul><li>Enter site id</li></ul>",
+        "value": "My Test Token"
+      },
+      "supportsCustomPackages": false,
+      "proxy": {
+        "id": "<n>",
+        "inherited": false
+      },
+      "tags" : {
+        "tagList" : [
+          "tag one",
+          "tag 2"
+        ]
+      }
+    },
+    "relationships": {
+      "packages": {
+        "meta": {
+          "included": false
+        }
+      }
+    }
+  },
+  "included": []
+}

--- a/src/test/resources/responses/kb-ebsco/providers/expected-provider.json
+++ b/src/test/resources/responses/kb-ebsco/providers/expected-provider.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "id": "19",
+    "type": "providers",
+    "attributes": {
+      "name": "EBSCO",
+      "packagesTotal": 625,
+      "packagesSelected": 11,
+      "providerToken": {
+        "value": "sampleToken"
+      },
+      "supportsCustomPackages": false,
+      "proxy": {
+        "id": "<n>",
+        "inherited": true
+      }
+    },
+    "relationships": {
+      "packages": {
+        "meta": {
+          "included": false
+        }
+      }
+    }
+  },
+  "included": []
+}

--- a/src/test/resources/responses/kb-ebsco/providers/expected-updated-provider.json
+++ b/src/test/resources/responses/kb-ebsco/providers/expected-updated-provider.json
@@ -1,0 +1,30 @@
+{
+  "data": {
+    "id": "19",
+    "type": "providers",
+    "attributes": {
+      "name": "EBSCO",
+      "packagesTotal": 625,
+      "packagesSelected": 11,
+      "providerToken": {
+        "factName": "[[galesiteid]]",
+        "prompt": "/itweb/",
+        "helpText": "<ul><li>Enter site id</li></ul>",
+        "value": "My Test Token"
+      },
+      "supportsCustomPackages": false,
+      "proxy": {
+        "id": "<n>",
+        "inherited": false
+      }
+    },
+    "relationships": {
+      "packages": {
+        "meta": {
+          "included": false
+        }
+      }
+    }
+  },
+  "included": []
+}

--- a/src/test/resources/responses/rmapi/vendors/get-vendor-without-selected-packages-response.json
+++ b/src/test/resources/responses/rmapi/vendors/get-vendor-without-selected-packages-response.json
@@ -1,0 +1,17 @@
+{
+  "isCustomer": false,
+  "packagesSelected": 0,
+  "packagesTotal": 625,
+  "vendorId": 19,
+  "vendorName": "EBSCO",
+  "proxy": {
+    "id": "<n>",
+    "inherited": false
+  },
+  "vendorToken": {
+    "factName": "[[galesiteid]]",
+    "prompt": "/itweb/",
+    "helpText": "<ul><li>Enter site id</li></ul>",
+    "value": "My Test Token"
+    }
+}


### PR DESCRIPTION
## Purpose
Make provider tags updateable when provider has no selected packages.

## Approach
Don't send request to RM API when provider doesn't have selected packages.
Add unit, change provider tests to use json files