### PR TITLE
MODKBEKBJ-194 - Custom Coverages are not returned in descending order

### DIFF
--- a/src/main/java/org/folio/rest/converter/resources/CommonResourceConverter.java
+++ b/src/main/java/org/folio/rest/converter/resources/CommonResourceConverter.java
@@ -1,7 +1,9 @@
 package org.folio.rest.converter.resources;
 
+import java.util.Comparator;
 import java.util.List;
 
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
@@ -68,7 +70,10 @@ public class CommonResourceConverter {
       .withProviderName(resource.getVendorName())
       .withVisibilityData(visibilityInfoConverter.convert(resource.getVisibilityData()))
       .withManagedCoverages(coverageDatesConverter.convert(resource.getManagedCoverageList()))
-      .withCustomCoverages(coverageDatesConverter.convert(resource.getCustomCoverageList()))
+      .withCustomCoverages(coverageDatesConverter.convert(
+        resource.getCustomCoverageList().stream()
+        .sorted(Comparator.comparing(CoverageDates::getBeginCoverage).reversed())
+        .collect(Collectors.toList())))
       .withProxy(proxyConverter.convert(resource.getProxy()));
   }
 

--- a/src/test/java/org/folio/rest/converter/packages/PackageRequestConverterTest.java
+++ b/src/test/java/org/folio/rest/converter/packages/PackageRequestConverterTest.java
@@ -1,4 +1,4 @@
-package org.folio.rest.converter;
+package org.folio.rest.converter.packages;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -10,7 +10,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import org.folio.holdingsiq.model.PackagePut;
-import org.folio.rest.converter.packages.PackageRequestConverter;
 import org.folio.rest.impl.PackagesTestData;
 import org.folio.rest.jaxrs.model.ContentType;
 import org.folio.rest.jaxrs.model.Coverage;

--- a/src/test/java/org/folio/rest/converter/packages/PackageResponseConverterTest.java
+++ b/src/test/java/org/folio/rest/converter/packages/PackageResponseConverterTest.java
@@ -1,0 +1,51 @@
+package org.folio.rest.converter.packages;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import org.folio.holdingsiq.model.Title;
+import org.folio.rest.jaxrs.model.Coverage;
+import org.folio.rest.jaxrs.model.Resource;
+import org.folio.rmapi.result.ResourceResult;
+import org.folio.spring.config.TestConfig;
+import org.folio.util.TestUtil;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestConfig.class)
+public class PackageResponseConverterTest {
+
+  @Autowired
+  private ConversionService conversionService;
+
+  @Test
+  public void shouldReturnCustomCoverageInDescendingOrder() throws URISyntaxException, IOException {
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    Title title = mapper.readValue(TestUtil.getFile("responses/rmapi/titles/get-custom-title-with-coverage-dates-asc.json"), Title.class);
+
+    final ResourceResult resourceResult = new ResourceResult(title, null, null, false);
+    final Resource resource = conversionService.convert(resourceResult, Resource.class);
+
+    final List<Coverage> customCoverages = resource.getData().getAttributes().getCustomCoverages();
+    assertThat(customCoverages.size(), equalTo(2));
+    assertThat(customCoverages.get(0).getBeginCoverage(), equalTo("2004-03-01"));
+    assertThat(customCoverages.get(0).getEndCoverage(), equalTo("2004-03-04"));
+
+    assertThat(customCoverages.get(1).getBeginCoverage(), equalTo("2001-01-01"));
+    assertThat(customCoverages.get(1).getEndCoverage(), equalTo("2004-02-01"));
+
+  }
+}

--- a/src/test/java/org/folio/rest/converter/resources/ResourceRequestConverterTest.java
+++ b/src/test/java/org/folio/rest/converter/resources/ResourceRequestConverterTest.java
@@ -1,4 +1,4 @@
-package org.folio.rest.converter;
+package org.folio.rest.converter.resources;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -14,7 +14,6 @@ import org.folio.holdingsiq.model.CustomerResources;
 import org.folio.holdingsiq.model.ResourcePut;
 import org.folio.holdingsiq.model.Title;
 import org.folio.holdingsiq.model.VisibilityInfo;
-import org.folio.rest.converter.resources.ResourceRequestConverter;
 import org.folio.rest.impl.ResourcesTestData;
 import org.folio.rest.jaxrs.model.EmbargoPeriod;
 import org.folio.rest.jaxrs.model.EmbargoPeriod.EmbargoUnit;

--- a/src/test/resources/responses/rmapi/titles/get-custom-title-with-coverage-dates-asc.json
+++ b/src/test/resources/responses/rmapi/titles/get-custom-title-with-coverage-dates-asc.json
@@ -1,0 +1,69 @@
+{
+  "titleId": 1111111111,
+  "titleName": "test-custom-title-132a648d",
+  "publisherName": "test publisher",
+  "identifiersList": [
+
+  ],
+  "subjectsList": [
+
+  ],
+  "isTitleCustom": true,
+  "pubType": "Database",
+  "customerResourcesList": [
+    {
+      "titleId": 1111111111,
+      "packageId": 222222,
+      "packageName": "test-custom-title-132a648d",
+      "packageType": "Custom",
+      "proxy": {
+        "id": "<n>",
+        "inherited": true
+      },
+      "isPackageCustom": true,
+      "vendorId": 1111111,
+      "vendorName": "TEST CUSTOMER",
+      "locationId": 0,
+      "isSelected": true,
+      "isTokenNeeded": false,
+      "visibilityData": {
+        "isHidden": false,
+        "reason": ""
+      },
+      "managedCoverageList": [
+
+      ],
+      "customCoverageList": [
+        {
+          "beginCoverage": "2001-01-01",
+          "endCoverage": "2004-02-01"
+        },
+        {
+          "beginCoverage": "2004-03-01",
+          "endCoverage": "2004-03-04"
+        }
+      ],
+      "coverageStatement": "Test Coverage Statement",
+      "managedEmbargoPeriod": {
+        "embargoUnit": null,
+        "embargoValue": 0
+      },
+      "customEmbargoPeriod": {
+        "embargoUnit": "Months",
+        "embargoValue": 5
+      },
+      "url": null,
+      "userDefinedField1": null,
+      "userDefinedField2": null,
+      "userDefinedField3": null,
+      "userDefinedField4": null,
+      "userDefinedField5": null
+    }
+  ],
+  "description": "This is the sample description for test",
+  "edition": "test edition",
+  "isPeerReviewed": true,
+  "contributorsList": [
+
+  ]
+}


### PR DESCRIPTION
## Purpose
Due to  https://issues.folio.org/browse/MODKBEKBJ-194 coverage dates return to UI in asc order but should be in desc order.

## Approach
* fixed for resource custom coverage to return dates in desc order
