### PR TITLE
MODKBEKBJ-200 - Invalid filter for packages does not return Validatio…

### DIFF
--- a/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
@@ -101,7 +101,7 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
     if(Objects.nonNull(filterCustom) && !Boolean.parseBoolean(filterCustom)){
       throw new ValidationException("Invalid Query Parameter for filter[custom]");
     }
-    String selected = RestConstants.FILTER_SELECTED_MAPPING.get(filterSelected);
+    String selected = RestConstants.FILTER_SELECTED_MAPPING.getOrDefault(filterSelected, filterSelected);
     packageParametersValidator.validate(selected, filterType, sort, q);
 
     boolean isFilterCustom = Boolean.parseBoolean(filterCustom);


### PR DESCRIPTION
## Purpose
fix for https://issues.folio.org/browse/MODKBEKBJ-200

## Approach
* fixed validation for packages filter[selected] in case of invalid value or null
