### PR TITLE
MODKBEKBJ-187: Implement search of providers by list of tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-holdingsiq-client</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/ramls/providers.raml
+++ b/ramls/providers.raml
@@ -21,6 +21,7 @@ traits:
   sortable: !include traits/sortable.raml
   pageable: !include traits/pageable.raml
   filterable: !include traits/filterable.raml
+  tagable: !include traits/tagable.raml
   includable: !include traits/includePackages.raml
 
 /eholdings/providers:
@@ -28,7 +29,7 @@ traits:
   description: Collection of available providers in eholdings.
   get:
     description: Get a list of providers based on the search query.
-    is: [queriable, sortable, pageable]
+    is: [queriable, sortable, tagable, pageable]
     responses:
       200:
         description: OK

--- a/ramls/traits/tagable.raml
+++ b/ramls/traits/tagable.raml
@@ -1,0 +1,7 @@
+queryParameters:
+  filter[tags]:
+    displayName: Tags
+    type: string
+    description: Filter to narrow down results based on assigned tags. Contains list of required tags separated by comma.
+    example: tag1,tag2
+    required: false

--- a/src/main/java/org/folio/rest/util/template/RMAPIServicesFactory.java
+++ b/src/main/java/org/folio/rest/util/template/RMAPIServicesFactory.java
@@ -1,0 +1,44 @@
+package org.folio.rest.util.template;
+
+import io.vertx.core.Vertx;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import org.folio.holdingsiq.model.Configuration;
+import org.folio.holdingsiq.service.HoldingsIQService;
+import org.folio.holdingsiq.service.TitlesHoldingsIQService;
+import org.folio.holdingsiq.service.impl.HoldingsIQServiceImpl;
+import org.folio.holdingsiq.service.impl.TitlesHoldingsIQServiceImpl;
+import org.folio.rmapi.PackageServiceImpl;
+import org.folio.rmapi.ProvidersServiceImpl;
+import org.folio.rmapi.ResourcesServiceImpl;
+
+@Component
+@Qualifier("rmapiServicesFactory")
+public class RMAPIServicesFactory {
+
+  public HoldingsIQService createHoldingsService(Configuration config, Vertx vertx){
+    return new HoldingsIQServiceImpl(config, vertx);
+  }
+
+  public TitlesHoldingsIQService createTitlesHoldingsIQService(Configuration config, Vertx vertx){
+    return new TitlesHoldingsIQServiceImpl(config, vertx);
+  }
+
+  public ProvidersServiceImpl createProvidersServiceImpl(Configuration config, Vertx vertx){
+    ProvidersServiceImpl providersService = new ProvidersServiceImpl(config, vertx, createHoldingsService(config, vertx));
+    PackageServiceImpl packageService = new PackageServiceImpl(config, vertx, providersService,
+      createTitlesHoldingsIQService(config, vertx));
+    providersService.setPackagesService(packageService);
+    return providersService;
+  }
+
+  public PackageServiceImpl createPackageServiceImpl(Configuration config, Vertx vertx){
+    return new PackageServiceImpl(config, vertx, createProvidersServiceImpl(config, vertx), createTitlesHoldingsIQService(config,vertx));
+  }
+
+  public ResourcesServiceImpl createResourcesServiceImpl(Configuration config, Vertx vertx){
+    return new ResourcesServiceImpl(config, vertx, createProvidersServiceImpl(config, vertx), createPackageServiceImpl(config, vertx));
+  }
+}

--- a/src/main/java/org/folio/rest/util/template/RMAPITemplateFactory.java
+++ b/src/main/java/org/folio/rest/util/template/RMAPITemplateFactory.java
@@ -7,6 +7,7 @@ import javax.ws.rs.core.Response;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.stereotype.Component;
@@ -24,8 +25,10 @@ public class RMAPITemplateFactory {
   private ConversionService conversionService;
   @Autowired
   private HeaderValidator headerValidator;
+  @Autowired
+  private RMAPIServicesFactory servicesFactory;
 
   public RMAPITemplate createTemplate(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler){
-    return new RMAPITemplate(configurationService, vertx, conversionService, headerValidator, okapiHeaders, asyncResultHandler);
+    return new RMAPITemplate(servicesFactory, configurationService, vertx, conversionService, headerValidator, okapiHeaders, asyncResultHandler);
   }
 }

--- a/src/main/java/org/folio/tag/repository/TagTableConstants.java
+++ b/src/main/java/org/folio/tag/repository/TagTableConstants.java
@@ -13,6 +13,10 @@ public class TagTableConstants {
     "SELECT " + TAG_COLUMN + " FROM %s "
       + "WHERE " + RECORD_ID_COLUMN + "=? AND " + RECORD_TYPE_COLUMN + "=?";
 
+  public static final String SELECT_RECORD_IDS_BY_TAG_VALUES_AND_TYPE =
+    "SELECT DISTINCT " + RECORD_ID_COLUMN + " FROM %s "
+      + "WHERE " + TAG_COLUMN + " IN (%s) AND " + RECORD_TYPE_COLUMN + "=?";
+
   public static  final String UPDATE_INSERT_STATEMENT_FOR_PROVIDER =
     "INSERT INTO %s (id, record_id, record_type, tag) VALUES " +
       "%s;";

--- a/src/test/java/org/folio/rest/converter/packages/PackageRequestConverterTest.java
+++ b/src/test/java/org/folio/rest/converter/packages/PackageRequestConverterTest.java
@@ -4,10 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import org.folio.holdingsiq.model.PackagePut;
 import org.folio.rest.impl.PackagesTestData;
@@ -15,13 +11,9 @@ import org.folio.rest.jaxrs.model.ContentType;
 import org.folio.rest.jaxrs.model.Coverage;
 import org.folio.rest.jaxrs.model.PackageDataAttributes;
 import org.folio.rest.jaxrs.model.VisibilityData;
-import org.folio.spring.config.TestConfig;
 
-@RunWith(SpringRunner.class)
-@ContextConfiguration(classes = TestConfig.class)
 public class PackageRequestConverterTest {
-  @Autowired
-  private PackageRequestConverter packagesConverter;
+  private PackageRequestConverter packagesConverter = new PackageRequestConverter();
 
   @Test
   public void shouldCreateRequestToSelectPackage() {

--- a/src/test/java/org/folio/spring/config/TestConfig.java
+++ b/src/test/java/org/folio/spring/config/TestConfig.java
@@ -1,11 +1,11 @@
 package org.folio.spring.config;
 
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-
-import io.vertx.core.Context;
-import io.vertx.core.Vertx;
 
 @Configuration
 @Import(ApplicationConfig.class)

--- a/src/test/java/org/folio/spring/config/VertxTestConfig.java
+++ b/src/test/java/org/folio/spring/config/VertxTestConfig.java
@@ -1,0 +1,24 @@
+package org.folio.spring.config;
+
+import static org.mockito.Mockito.spy;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+
+import org.folio.rest.util.template.RMAPIServicesFactory;
+
+@Configuration
+@Import(ApplicationConfig.class)
+public class VertxTestConfig {
+
+  @Bean
+  @Primary
+  @Qualifier("spyRmApiServicesFactory")
+  public RMAPIServicesFactory spyRmApiServicesFactory(@Qualifier("rmapiServicesFactory") RMAPIServicesFactory rmapiServicesFactory)
+  {
+    return spy(rmapiServicesFactory);
+  }
+}

--- a/src/test/resources/responses/kb-ebsco/providers/expected-providers-by-tags.json
+++ b/src/test/resources/responses/kb-ebsco/providers/expected-providers-by-tags.json
@@ -1,0 +1,27 @@
+{
+  "data": [
+    {
+      "id": "19",
+      "type": "providers",
+      "attributes": {
+        "name": "vendor name",
+        "providerToken": {
+          "value": "vendor token"
+        }
+      }
+    },
+    {
+      "id": "18",
+      "type": "providers",
+      "attributes": {
+        "name": "vendor name 2",
+        "providerToken": {
+          "value": "vendor token 2"
+        }
+      }
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}


### PR DESCRIPTION
## Purpose
Add ability to search providers by only tags

## Approach
Get list of provider ids from mod-kb-ebsco-java database by using tags,
Call provider service to get all providers by from id list
Mock provider service in unit test by putting Mockito spy into spring context

#### TODOS and Open Questions
- [x] This PR depends on https://github.com/folio-org/folio-holdingsiq-client/pull/16
- [ ] folio-holdingsiq-client module needs to be release with implemented method for getting providers by list of ids.