### PR TITLE
MODKBEKBJ-186 add endpoint to return all tags assigned to records of particular type(s)

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -130,6 +130,11 @@
           "methods": ["DELETE"],
           "pathPattern": "/eholdings/cache",
           "permissionsRequired" :["kb-ebsco.cache.delete"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/eholdings/tags",
+          "permissionsRequired": ["kb-ebsco.tags.collection.get"]
         }
       ]
     },
@@ -297,6 +302,11 @@
       "description": "Put root proxy"
     },
     {
+      "permissionName": "kb-ebsco.tags.collection.get",
+      "displayName": "get record tags",
+      "description": "Get record tags"
+    },
+    {
       "permissionName": "kb-ebsco.all",
       "displayName": "EBSCO KB Broker - all permissions",
       "description": "All permissions for EBSCO KB module",
@@ -325,7 +335,8 @@
         "kb-ebsco.resources.item.delete",
         "kb-ebsco.proxy-types.collection.get",
         "kb-ebsco.root-proxy.get",
-        "kb-ebsco.root-proxy.put"
+        "kb-ebsco.root-proxy.put",
+        "kb-ebsco.tags.collection.get"
       ]
     }
   ],

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>23.5.0</raml-module-builder.version>
+    <raml-module-builder.version>23.11.1</raml-module-builder.version>
     <vertx.version>3.5.4</vertx.version>
     <aspectj.version>1.9.1</aspectj.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
@@ -255,6 +255,18 @@
                 <systemProperty>
                   <key>schema_paths</key>
                   <value>${jsonschema_paths}</value>
+                </systemProperty>
+                <systemProperty>
+                  <key>jsonschema2pojo.config.includeToString</key>
+                  <value>true</value>
+                </systemProperty>
+                <systemProperty>
+                  <key>jsonschema2pojo.config.includeHashcodeAndEquals</key>
+                  <value>true</value>
+                </systemProperty>
+                <systemProperty>
+                  <key>jsonschema2pojo.config.useCommonsLang3</key>
+                  <value>true</value>
                 </systemProperty>
               </systemProperties>
             </configuration>

--- a/ramls/examples/tags/tags_get_200_response.json
+++ b/ramls/examples/tags/tags_get_200_response.json
@@ -1,10 +1,53 @@
 {
   "data": [
-    "academic",
-    "journal"
+    {
+      "id": "2cf21797-d25b-46dc-8427-1759d1db2057",
+      "type": "tags",
+      "attributes": {
+        "value": "package-tag1"
+      },
+      "relationships": {
+        "record": {
+          "data": {
+            "type": "packages",
+            "id": "11111-23456"
+          }
+        }
+      }
+    },
+    {
+      "id": "8c415595-ec6b-4dec-a1a7-91711e093d05",
+      "type": "tags",
+      "attributes": {
+        "value": "provider-tag1"
+      },
+      "relationships": {
+        "record": {
+          "data": {
+            "type": "providers",
+            "id": "11111"
+          }
+        }
+      }
+    },
+    {
+      "id": "07a4dd13-c749-459e-84a7-8db208c3059e",
+      "type": "tags",
+      "attributes": {
+        "value": "provider-tag2"
+      },
+      "relationships": {
+        "record": {
+          "data": {
+            "type": "providers",
+            "id": "11111"
+          }
+        }
+      }
+    }
   ],
   "meta": {
-    "totalResults": 2
+    "totalResults": 3
   },
   "jsonapi": {
     "version": "1.0"

--- a/ramls/examples/tags/tags_get_200_response.json
+++ b/ramls/examples/tags/tags_get_200_response.json
@@ -1,0 +1,12 @@
+{
+  "data": [
+    "academic",
+    "journal"
+  ],
+  "meta": {
+    "totalResults": 2
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/examples/tags/tags_get_400_response.json
+++ b/ramls/examples/tags/tags_get_400_response.json
@@ -1,0 +1,8 @@
+{
+  "errors": [{
+    "title": "Invalid filter parameter"
+  }],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/tags.raml
+++ b/ramls/tags.raml
@@ -24,7 +24,7 @@ types:
 /eholdings/tags:
   displayName: Tags
   get:
-    description: Retrieve a collection of tags associated with eholding resords.
+    description: Retrieve a collection of tags associated with eholding records.
     queryParameters:
       filter[rectype]?:
         displayName: Query by Record type(s)

--- a/ramls/tags.raml
+++ b/ramls/tags.raml
@@ -1,0 +1,58 @@
+#%RAML 1.0
+title: mod-kb-ebsco-java
+baseUri: https://github.com/folio-org/mod-kb-ebsco-java
+protocols: [ HTTPS ]
+version: v1
+mediaType: "application/vnd.api+json"
+
+documentation:
+  - title: mod-kb-ebsco-java
+    content: Implements the eholdings interface using EBSCO KB as backend.
+
+traits:
+  pageable: !include traits/pageable.raml
+
+types:
+  tagCollection: !include types/tags/tagCollection.json
+  jsonapiError: !include types/jsonapiError.json
+  recordType:
+    type: string
+    description: Eholdings record type. Possible values are provider, package, title, resource.
+  recordTypes:
+    type: recordType[]
+
+/eholdings/tags:
+  displayName: Tags
+  get:
+    description: Retrieve a collection of tags associated with eholding resords.
+    queryParameters:
+      filter[rectype]?:
+        displayName: Query by Record type(s)
+        type: recordTypes
+        uniqueItems: true
+        minItems: 1
+        description: Filter tags by one or more record types.
+            Several types can be specified in form of `filter[rectype]=provider&filter[rectype]=package`
+            Possible values are `provider`, `package`, `title`, `resource`
+        example:
+          - provider
+          - package
+    responses:
+      200:
+        description: OK
+        body:
+          application/vnd.api+json:
+            description: |
+              An array of tags comprising the results of the query sorted in alpahbetical order.
+            type: tagCollection
+            example:
+              strict: false
+              value: !include examples/tags/tags_get_200_response.json
+      400:
+        description: Bad Request
+        body:
+          application/vnd.api+json:
+            type: jsonapiError
+            example:
+              strict: false
+              value: !include examples/tags/tags_get_400_response.json

--- a/ramls/types/tags/tagCollection.json
+++ b/ramls/types/tags/tagCollection.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Package Collection Schema",
+  "description": "Tag Collection Schema",
+  "javaType": "org.folio.rest.jaxrs.model.TagCollection",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "data": {
+      "type": "array",
+      "description": "List of tags",
+      "items": {
+        "type": "string"
+      }
+    },
+    "meta": {
+      "type": "object",
+      "description": "metadata containing total results in packages collection",
+      "$ref": "../metaTotalResults.json"
+    },
+    "jsonapi": {
+      "type": "object",
+      "description": "version of json api",
+      "$ref": "../jsonapi.json"
+    }
+  },
+  "required": [
+    "data",
+    "jsonapi"
+  ]
+}

--- a/ramls/types/tags/tagCollection.json
+++ b/ramls/types/tags/tagCollection.json
@@ -10,7 +10,8 @@
       "type": "array",
       "description": "List of tags",
       "items": {
-        "type": "string"
+        "type": "object",
+        "$ref": "tagCollectionItem.json"
       }
     },
     "meta": {

--- a/ramls/types/tags/tagCollection.json
+++ b/ramls/types/tags/tagCollection.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Package Collection Schema",
+  "title": "Tag Collection Schema",
   "description": "Tag Collection Schema",
   "javaType": "org.folio.rest.jaxrs.model.TagCollection",
   "type": "object",

--- a/ramls/types/tags/tagCollectionItem.json
+++ b/ramls/types/tags/tagCollectionItem.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Tag object schema for a collection",
+  "description": "Tag object schema for a collection",
+  "javaType": "org.folio.rest.jaxrs.model.TagCollectionItem",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "UUID of tag assigned to the record",
+      "example": "eab7a945-9d0c-487a-a4d8-a6df4dd8d0fd"
+    },
+    "type": {
+      "type": "string",
+      "description": "Type of resource",
+      "example": "tags"
+    },
+    "attributes": {
+      "type": "object",
+      "description": "Tag object data attributes",
+      "$ref": "tagDataAttributes.json"
+    },
+    "relationships": {
+      "type": "object",
+      "description": "Displays if any record is included in relationships",
+      "$ref": "tagRelationships.json"
+    }
+  }
+}

--- a/ramls/types/tags/tagDataAttributes.json
+++ b/ramls/types/tags/tagDataAttributes.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Tag Data Attributes Schema",
+  "description": "Tag Data Attributes",
+  "javaType": "org.folio.rest.jaxrs.model.TagDataAttributes",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "value": {
+      "type": "string",
+      "description": "Tag value/label",
+      "example": "very-important"
+    }
+  }
+}

--- a/ramls/types/tags/tagRelationships.json
+++ b/ramls/types/tags/tagRelationships.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Tag relationships object schema in tag collection item",
+  "description": "Tag relationships object schema in tag collection item",
+  "javaType": "org.folio.rest.jaxrs.model.TagRelationship",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "record": {
+      "type": "object",
+      "description": "Displays relationship to record",
+      "$ref": "../hasOneRelationship.json"
+    }
+  }
+}

--- a/src/main/java/org/folio/common/FutureUtils.java
+++ b/src/main/java/org/folio/common/FutureUtils.java
@@ -1,0 +1,17 @@
+package org.folio.common;
+
+import java.util.concurrent.CompletableFuture;
+
+public class FutureUtils {
+
+  private FutureUtils() {
+  }
+
+  public static <T> CompletableFuture<T> failedFuture(Throwable ex) {
+    CompletableFuture<T> f = new CompletableFuture<>();
+
+    f.completeExceptionally(ex);
+    
+    return f;
+  }
+}

--- a/src/main/java/org/folio/common/ListUtils.java
+++ b/src/main/java/org/folio/common/ListUtils.java
@@ -1,0 +1,15 @@
+package org.folio.common;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class ListUtils {
+
+  private ListUtils() {
+  }
+
+  public static <T, R> List<R> mapItems(List<T> source, Function<? super T, ? extends R> mapper) {
+    return source.stream().map(mapper).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/org/folio/rest/converter/common/attr/ContributorsConverterPair.java
+++ b/src/main/java/org/folio/rest/converter/common/attr/ContributorsConverterPair.java
@@ -1,9 +1,10 @@
 package org.folio.rest.converter.common.attr;
 
+import static org.folio.common.ListUtils.mapItems;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
 import org.springframework.core.convert.converter.Converter;
@@ -27,12 +28,10 @@ public class ContributorsConverterPair {
       if (Objects.isNull(contributorList)) {
         return Collections.emptyList();
       }
-      return contributorList.stream().map(contributor ->
-        new Contributors()
-          .withContributor(contributor.getTitleContributor())
-          .withType(StringUtils.capitalize(contributor.getType()))
-      )
-        .collect(Collectors.toList());
+      return mapItems(contributorList,
+        contributor -> new Contributors()
+            .withContributor(contributor.getTitleContributor())
+            .withType(StringUtils.capitalize(contributor.getType())));
     }
   }
 
@@ -41,12 +40,10 @@ public class ContributorsConverterPair {
 
     @Override
     public List<Contributor> convert(@NonNull List<Contributors> contributorList) {
-      return contributorList.stream().map(contributor ->
-          org.folio.holdingsiq.model.Contributor.builder()
+      return mapItems(contributorList,
+          contributor ->org.folio.holdingsiq.model.Contributor.builder()
             .titleContributor(contributor.getContributor())
-            .type(StringUtils.capitalize(contributor.getType())).build()
-        )
-        .collect(Collectors.toList());
+            .type(StringUtils.capitalize(contributor.getType())).build());
     }
   }
   

--- a/src/main/java/org/folio/rest/converter/common/attr/CoverageDatesConverter.java
+++ b/src/main/java/org/folio/rest/converter/common/attr/CoverageDatesConverter.java
@@ -1,9 +1,10 @@
 package org.folio.rest.converter.common.attr;
 
+import static org.folio.common.ListUtils.mapItems;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.Nullable;
@@ -20,12 +21,10 @@ public class CoverageDatesConverter implements Converter<List<CoverageDates>, Li
     if(Objects.isNull(coverageList)) {
       return Collections.emptyList();
     }
-    return coverageList.stream().map(coverageItem ->
-      new Coverage()
+    return mapItems(coverageList,
+      coverageItem -> new Coverage()
         .withBeginCoverage(coverageItem.getBeginCoverage())
-        .withEndCoverage(coverageItem.getEndCoverage())
-    )
-      .collect(Collectors.toList());
+        .withEndCoverage(coverageItem.getEndCoverage()));
   }
 
 }

--- a/src/main/java/org/folio/rest/converter/common/attr/SubjectsConverter.java
+++ b/src/main/java/org/folio/rest/converter/common/attr/SubjectsConverter.java
@@ -1,9 +1,10 @@
 package org.folio.rest.converter.common.attr;
 
+import static org.folio.common.ListUtils.mapItems;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.Nullable;
@@ -20,12 +21,10 @@ public class SubjectsConverter implements Converter<List<Subject>, List<TitleSub
     if(Objects.isNull(subjectsList)) {
       return Collections.emptyList();
     }
-    return subjectsList.stream().map(subject ->
-      new TitleSubject()
+    return mapItems(subjectsList,
+      subject -> new TitleSubject()
         .withSubject(subject.getValue())
-        .withType(subject.getType())
-    )
-      .collect(Collectors.toList());
+        .withType(subject.getType()));
   }
 
 }

--- a/src/main/java/org/folio/rest/converter/packages/PackageCollectionConverter.java
+++ b/src/main/java/org/folio/rest/converter/packages/PackageCollectionConverter.java
@@ -1,7 +1,8 @@
 package org.folio.rest.converter.packages;
 
+import static org.folio.common.ListUtils.mapItems;
+
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
@@ -23,9 +24,9 @@ public class PackageCollectionConverter implements Converter<Packages, PackageCo
 
   @Override
   public PackageCollection convert(@NonNull Packages packages) {
-    List<PackageCollectionItem> packageList = packages.getPackagesList().stream()
-      .map(packageData -> packageCollectionItemConverter.convert(packageData))
-      .collect(Collectors.toList());
+    List<PackageCollectionItem> packageList = mapItems(packages.getPackagesList(),
+      packageData -> packageCollectionItemConverter.convert(packageData));
+    
     return new PackageCollection()
       .withJsonapi(RestConstants.JSONAPI)
       .withMeta(new MetaTotalResults().withTotalResults(packages.getTotalResults()))

--- a/src/main/java/org/folio/rest/converter/packages/PackageConverter.java
+++ b/src/main/java/org/folio/rest/converter/packages/PackageConverter.java
@@ -1,12 +1,12 @@
 package org.folio.rest.converter.packages;
 
+import static org.folio.common.ListUtils.mapItems;
 import static org.folio.rest.converter.packages.PackageConverterUtils.createEmptyPackageRelationship;
 import static org.folio.rest.util.RestConstants.PACKAGES_TYPE;
 import static org.folio.rest.util.RestConstants.PROVIDERS_TYPE;
 import static org.folio.rest.util.RestConstants.RESOURCES_TYPE;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
@@ -93,11 +93,9 @@ public class PackageConverter implements Converter<PackageResult, Package> {
   }
 
   private List<RelationshipData> convertResourcesRelationship(PackageByIdData packageByIdData, Titles titles) {
-    return titles.getTitleList().stream()
-      .map(title ->
-        new RelationshipData()
+    return mapItems(titles.getTitleList(),
+      title ->new RelationshipData()
           .withId(packageByIdData.getVendorId() + "-" + packageByIdData.getPackageId() + "-" + title.getTitleId())
-          .withType(RESOURCES_TYPE))
-      .collect(Collectors.toList());
+          .withType(RESOURCES_TYPE));
   }
 }

--- a/src/main/java/org/folio/rest/converter/providers/ProviderCollectionConverter.java
+++ b/src/main/java/org/folio/rest/converter/providers/ProviderCollectionConverter.java
@@ -1,7 +1,8 @@
 package org.folio.rest.converter.providers;
 
+import static org.folio.common.ListUtils.mapItems;
+
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
@@ -22,9 +23,8 @@ public class ProviderCollectionConverter implements Converter<Vendors, ProviderC
 
   @Override
   public ProviderCollection convert(@NonNull Vendors vendors) {
-    List<Providers> providerList = vendors.getVendorList().stream()
-      .map(providersConverter::convert)
-      .collect(Collectors.toList());
+    List<Providers> providerList = mapItems(vendors.getVendorList(), providersConverter::convert);
+    
     return new ProviderCollection()
       .withJsonapi(RestConstants.JSONAPI)
       .withMeta(new MetaTotalResults().withTotalResults(vendors.getTotalResults()))

--- a/src/main/java/org/folio/rest/converter/providers/ProviderConverter.java
+++ b/src/main/java/org/folio/rest/converter/providers/ProviderConverter.java
@@ -1,11 +1,11 @@
 package org.folio.rest.converter.providers;
 
+import static org.folio.common.ListUtils.mapItems;
 import static org.folio.rest.converter.providers.ProviderConverterUtils.createEmptyProviderRelationships;
 import static org.folio.rest.util.RestConstants.PACKAGES_TYPE;
 import static org.folio.rest.util.RestConstants.PROVIDERS_TYPE;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
@@ -72,11 +72,9 @@ public class ProviderConverter implements Converter<VendorResult, Provider> {
   }
 
   private List<RelationshipData> convertPackagesRelationship(org.folio.holdingsiq.model.Packages packages) {
-    return packages.getPackagesList().stream()
-      .map(packageData ->
-        new RelationshipData()
+    return mapItems(packages.getPackagesList(),
+      packageData -> new RelationshipData()
           .withId(packageData.getVendorId() + "-" + packageData.getPackageId())
-          .withType(PACKAGES_TYPE))
-      .collect(Collectors.toList());
+          .withType(PACKAGES_TYPE));
   }
 }

--- a/src/main/java/org/folio/rest/converter/proxy/ProxiesConverter.java
+++ b/src/main/java/org/folio/rest/converter/proxy/ProxiesConverter.java
@@ -1,7 +1,8 @@
 package org.folio.rest.converter.proxy;
 
+import static org.folio.common.ListUtils.mapItems;
+
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.NonNull;
@@ -19,9 +20,7 @@ public class ProxiesConverter implements Converter<Proxies, ProxyTypes> {
 
   @Override
   public ProxyTypes convert(@NonNull Proxies proxies) {
-    List<ProxyTypesData> providerList = proxies.getProxyList().stream()
-      .map(this::convertProxy)
-      .collect(Collectors.toList());
+    List<ProxyTypesData> providerList = mapItems(proxies.getProxyList(), this::convertProxy);
 
     return new ProxyTypes().withJsonapi(RestConstants.JSONAPI).withData(providerList);
   }

--- a/src/main/java/org/folio/rest/converter/resources/ResourceCollectionConverter.java
+++ b/src/main/java/org/folio/rest/converter/resources/ResourceCollectionConverter.java
@@ -1,7 +1,8 @@
 package org.folio.rest.converter.resources;
 
+import static org.folio.common.ListUtils.mapItems;
+
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
@@ -23,9 +24,8 @@ public class ResourceCollectionConverter implements Converter<Titles, ResourceCo
 
   @Override
   public ResourceCollection convert(@NonNull Titles titles) {
-    List<ResourceCollectionItem> titleList = titles.getTitleList().stream()
-      .map(converter::convert)
-      .collect(Collectors.toList());
+    List<ResourceCollectionItem> titleList = mapItems(titles.getTitleList(), converter::convert);
+    
     return new ResourceCollection()
       .withJsonapi(RestConstants.JSONAPI)
       .withMeta(new MetaTotalResults().withTotalResults(titles.getTotalResults()))

--- a/src/main/java/org/folio/rest/converter/resources/ResourceRequestConverter.java
+++ b/src/main/java/org/folio/rest/converter/resources/ResourceRequestConverter.java
@@ -1,7 +1,8 @@
 package org.folio.rest.converter.resources;
 
+import static org.folio.common.ListUtils.mapItems;
+
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
@@ -97,10 +98,10 @@ public class ResourceRequestConverter {
   }
 
   private List<CoverageDates> convertToRMAPICustomCoverageList(List<Coverage> customCoverages) {
-    return customCoverages.stream().map(coverage -> CoverageDates.builder()
-      .beginCoverage(coverage.getBeginCoverage())
-      .endCoverage(coverage.getEndCoverage())
-      .build())
-      .collect(Collectors.toList());
+    return mapItems(customCoverages,
+      coverage -> CoverageDates.builder()
+        .beginCoverage(coverage.getBeginCoverage())
+        .endCoverage(coverage.getEndCoverage())
+        .build());
   }
 }

--- a/src/main/java/org/folio/rest/converter/resources/ResourceResultConverter.java
+++ b/src/main/java/org/folio/rest/converter/resources/ResourceResultConverter.java
@@ -1,7 +1,6 @@
 package org.folio.rest.converter.resources;
 
-import static java.util.stream.Collectors.toList;
-
+import static org.folio.common.ListUtils.mapItems;
 import static org.folio.rest.converter.resources.ResourceConverterUtils.createEmptyRelationship;
 import static org.folio.rest.util.RestConstants.PACKAGES_TYPE;
 import static org.folio.rest.util.RestConstants.PROVIDERS_TYPE;
@@ -49,46 +48,47 @@ public class ResourceResultConverter implements Converter<ResourceResult, List<R
     VendorById vendor = resourceResult.getVendor();
     boolean includeTitle = resourceResult.isIncludeTitle();
 
-    return title.getCustomerResourcesList().stream().map(resource -> {
-      Resource resultResource = new org.folio.rest.jaxrs.model.Resource()
-        .withData(new ResourceCollectionItem()
-          .withId(resource.getVendorId() + "-" + resource.getPackageId() + "-" + resource.getTitleId())
-          .withType(ResourceCollectionItem.Type.RESOURCES)
-          .withAttributes(commonResourceConverter.createResourceDataAttributes(title, resource))
-          .withRelationships(createEmptyRelationship())
-        )
-        .withIncluded(null)
-        .withJsonapi(RestConstants.JSONAPI);
-      resultResource.setIncluded(new ArrayList<>());
-      if (includeTitle) {
-        resultResource.getIncluded().add(titlesConverter.convert(new TitleResult(title, false)).getData());
-        resultResource.getData()
-          .getRelationships()
-          .withTitle(new HasOneRelationship()
-            .withData(new RelationshipData()
-              .withId(String.valueOf(title.getTitleId()))
-              .withType(TITLES_TYPE)));
-      }
-      if (vendor != null) {
-        resultResource.getIncluded().add(vendorConverter.convert(vendor).getData());
-        resultResource.getData()
-          .getRelationships()
-          .withProvider(new HasOneRelationship()
-            .withData(new RelationshipData()
-              .withId(String.valueOf(vendor.getVendorId()))
-              .withType(PROVIDERS_TYPE)));
-      }
-      if (packageData != null) {
-        resultResource.getIncluded().add(packageByIdConverter.convert(packageData).getData());
-        resultResource.getData()
-          .getRelationships()
-          .withPackage(new HasOneRelationship()
-            .withData(new RelationshipData()
-              .withId(packageData.getVendorId() + "-" + packageData.getPackageId())
-              .withType(PACKAGES_TYPE)));
-      }
-      return resultResource;
-    }).collect(toList());
+    return mapItems(title.getCustomerResourcesList(),
+      resource -> {
+        Resource resultResource = new org.folio.rest.jaxrs.model.Resource()
+          .withData(new ResourceCollectionItem()
+            .withId(resource.getVendorId() + "-" + resource.getPackageId() + "-" + resource.getTitleId())
+            .withType(ResourceCollectionItem.Type.RESOURCES)
+            .withAttributes(commonResourceConverter.createResourceDataAttributes(title, resource))
+            .withRelationships(createEmptyRelationship())
+          )
+          .withIncluded(null)
+          .withJsonapi(RestConstants.JSONAPI);
+        resultResource.setIncluded(new ArrayList<>());
+        if (includeTitle) {
+          resultResource.getIncluded().add(titlesConverter.convert(new TitleResult(title, false)).getData());
+          resultResource.getData()
+            .getRelationships()
+            .withTitle(new HasOneRelationship()
+              .withData(new RelationshipData()
+                .withId(String.valueOf(title.getTitleId()))
+                .withType(TITLES_TYPE)));
+        }
+        if (vendor != null) {
+          resultResource.getIncluded().add(vendorConverter.convert(vendor).getData());
+          resultResource.getData()
+            .getRelationships()
+            .withProvider(new HasOneRelationship()
+              .withData(new RelationshipData()
+                .withId(String.valueOf(vendor.getVendorId()))
+                .withType(PROVIDERS_TYPE)));
+        }
+        if (packageData != null) {
+          resultResource.getIncluded().add(packageByIdConverter.convert(packageData).getData());
+          resultResource.getData()
+            .getRelationships()
+            .withPackage(new HasOneRelationship()
+              .withData(new RelationshipData()
+                .withId(packageData.getVendorId() + "-" + packageData.getPackageId())
+                .withType(PACKAGES_TYPE)));
+        }
+        return resultResource;
+      });
 
   }
 }

--- a/src/main/java/org/folio/rest/converter/tags/RectypeConverter.java
+++ b/src/main/java/org/folio/rest/converter/tags/RectypeConverter.java
@@ -1,0 +1,36 @@
+package org.folio.rest.converter.tags;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+import org.folio.rest.util.RestConstants;
+
+
+@Component
+public class RectypeConverter implements Converter<String, org.folio.tag.RecordType> {
+
+  private static final Map<String, org.folio.tag.RecordType> MAPPING = new HashMap<>();
+
+  static {
+    MAPPING.put(RestConstants.PROVIDER_RECTYPE, org.folio.tag.RecordType.PROVIDER);
+    MAPPING.put(RestConstants.PACKAGE_RECTYPE, org.folio.tag.RecordType.PACKAGE);
+    MAPPING.put(RestConstants.TITLE_RECTYPE, org.folio.tag.RecordType.TITLE);
+    MAPPING.put(RestConstants.RESOURCE_RECTYPE, org.folio.tag.RecordType.RESOURCE);
+  }
+
+  @Override
+  public org.folio.tag.RecordType convert(@NonNull String source) {
+    org.folio.tag.RecordType result = MAPPING.get(source);
+
+    if (result == null) {
+      throw new IllegalArgumentException("Invalid record type: " + source);
+    }
+
+    return result;
+  }
+
+}

--- a/src/main/java/org/folio/rest/converter/tags/RectypesConverter.java
+++ b/src/main/java/org/folio/rest/converter/tags/RectypesConverter.java
@@ -1,0 +1,25 @@
+package org.folio.rest.converter.tags;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RectypesConverter implements Converter<List<String>, Set<org.folio.tag.RecordType>> {
+
+  @Autowired
+  private Converter<String, org.folio.tag.RecordType> recordTypeConverter;
+
+  @Override
+  public Set<org.folio.tag.RecordType> convert(@NonNull List<String> source) {
+    return source.stream()
+              .map(recType -> recordTypeConverter.convert(recType))
+              .collect(Collectors.toSet());
+  }
+
+}

--- a/src/main/java/org/folio/rest/converter/tags/TagConverter.java
+++ b/src/main/java/org/folio/rest/converter/tags/TagConverter.java
@@ -1,16 +1,52 @@
 package org.folio.rest.converter.tags;
 
+import java.util.EnumMap;
+import java.util.Map;
+
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
 
+import org.folio.rest.jaxrs.model.HasOneRelationship;
+import org.folio.rest.jaxrs.model.RelationshipData;
 import org.folio.rest.jaxrs.model.TagCollectionItem;
+import org.folio.rest.jaxrs.model.TagDataAttributes;
+import org.folio.rest.jaxrs.model.TagRelationship;
+import org.folio.rest.util.RestConstants;
+import org.folio.tag.RecordType;
 import org.folio.tag.Tag;
 
+@Component
 public class TagConverter implements Converter<Tag, TagCollectionItem> {
+
+  private static final Map<RecordType, String> RECORD_TYPES = new EnumMap<>(RecordType.class);
+
+  static {
+    RECORD_TYPES.put(RecordType.PACKAGE, RestConstants.PACKAGES_TYPE);
+    RECORD_TYPES.put(RecordType.PROVIDER, RestConstants.PROVIDERS_TYPE);
+    RECORD_TYPES.put(RecordType.TITLE, RestConstants.TITLES_TYPE);
+    RECORD_TYPES.put(RecordType.RESOURCE, RestConstants.RESOURCES_TYPE);
+  }
 
   @Override
   public TagCollectionItem convert(@NonNull Tag source) {
-    return null;
+    return new TagCollectionItem()
+      .withType(RestConstants.TAGS_TYPE)
+      .withId(source.getId())
+      .withAttributes(createAttributes(source))
+      .withRelationships(createRelationships(source));
+  }
+
+  private TagDataAttributes createAttributes(Tag source) {
+    return new TagDataAttributes().withValue(source.getValue());
+  }
+
+  private TagRelationship createRelationships(Tag source) {
+    return new TagRelationship().withRecord(
+            new HasOneRelationship().withData(
+                new RelationshipData()
+                  .withId(source.getRecordId())
+                  .withType(RECORD_TYPES.get(source.getRecordType()))));
   }
 
 }

--- a/src/main/java/org/folio/rest/converter/tags/TagConverter.java
+++ b/src/main/java/org/folio/rest/converter/tags/TagConverter.java
@@ -1,0 +1,16 @@
+package org.folio.rest.converter.tags;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+
+import org.folio.rest.jaxrs.model.TagCollectionItem;
+import org.folio.tag.Tag;
+
+public class TagConverter implements Converter<Tag, TagCollectionItem> {
+
+  @Override
+  public TagCollectionItem convert(@NonNull Tag source) {
+    return null;
+  }
+
+}

--- a/src/main/java/org/folio/rest/converter/tags/TagsConverters.java
+++ b/src/main/java/org/folio/rest/converter/tags/TagsConverters.java
@@ -1,0 +1,48 @@
+package org.folio.rest.converter.tags;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+import org.folio.rest.jaxrs.model.MetaTotalResults;
+import org.folio.rest.jaxrs.model.TagCollection;
+import org.folio.rest.jaxrs.model.Tags;
+import org.folio.rest.util.RestConstants;
+import org.folio.tag.Tag;
+
+public class TagsConverters  {
+
+  private TagsConverters() {
+  }
+
+  @Component
+  public static class ToTags implements Converter<List<Tag>, Tags> {
+
+    @Override
+    public Tags convert(@NonNull List<Tag> source) {
+      return new Tags().withTagList(toTagValues(source));
+    }
+
+  }
+
+  @Component
+  public static class ToTagCollection implements Converter<List<Tag>, TagCollection> {
+
+    @Override
+    public TagCollection convert(@NonNull List<Tag> source) {
+      return new TagCollection()
+                  .withData(toTagValues(source))
+                  .withJsonapi(RestConstants.JSONAPI)
+                  .withMeta(new MetaTotalResults().withTotalResults(source.size()));
+    }
+
+  }
+
+  private static List<String> toTagValues(List<Tag> source) {
+    return source.stream().map(Tag::getValue).collect(Collectors.toList());
+  }
+
+}

--- a/src/main/java/org/folio/rest/converter/tags/TagsConverters.java
+++ b/src/main/java/org/folio/rest/converter/tags/TagsConverters.java
@@ -1,8 +1,8 @@
 package org.folio.rest.converter.tags;
 
+import static org.folio.common.ListUtils.mapItems;
+
 import java.util.List;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
@@ -47,7 +47,4 @@ public class TagsConverters  {
     
   }
 
-  private static <T, R> List<R> mapItems(List<T> source, Function<? super T, ? extends R> mapper) {
-    return source.stream().map(mapper).collect(Collectors.toList());
-  }
 }

--- a/src/main/java/org/folio/rest/converter/titles/TitleCollectionConverter.java
+++ b/src/main/java/org/folio/rest/converter/titles/TitleCollectionConverter.java
@@ -1,7 +1,8 @@
 package org.folio.rest.converter.titles;
 
+import static org.folio.common.ListUtils.mapItems;
+
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
@@ -22,9 +23,8 @@ public class TitleCollectionConverter implements Converter<Titles, TitleCollecti
 
   @Override
   public TitleCollection convert(@NonNull Titles titles) {
-    List<org.folio.rest.jaxrs.model.Titles> titleList = titles.getTitleList().stream()
-      .map(titleConverter::convert)
-      .collect(Collectors.toList());
+    List<org.folio.rest.jaxrs.model.Titles> titleList = mapItems(titles.getTitleList(), titleConverter::convert);
+
     return new TitleCollection()
       .withJsonapi(RestConstants.JSONAPI)
       .withMeta(new MetaTotalResults().withTotalResults(titles.getTotalResults()))

--- a/src/main/java/org/folio/rest/converter/titles/TitleConverter.java
+++ b/src/main/java/org/folio/rest/converter/titles/TitleConverter.java
@@ -1,5 +1,6 @@
 package org.folio.rest.converter.titles;
 
+import static org.folio.common.ListUtils.mapItems;
 import static org.folio.rest.converter.titles.TitleConverterUtils.createEmptyResourcesRelationships;
 import static org.folio.rest.util.RestConstants.TITLES_TYPE;
 
@@ -84,11 +85,9 @@ public class TitleConverter implements Converter<TitleResult, Title> {
   }
 
   private List<RelationshipData> convertResourcesRelationship(List<CustomerResources> customerResources) {
-    return customerResources.stream()
-      .map(resourceData ->
-        new RelationshipData()
+    return mapItems(customerResources,
+      resourceData -> new RelationshipData()
           .withId(resourceData.getVendorId() + "-" + resourceData.getPackageId() + "-" + resourceData.getTitleId())
-          .withType(RESOURCES_TYPE))
-      .collect(Collectors.toList());
+          .withType(RESOURCES_TYPE));
   }
 }

--- a/src/main/java/org/folio/rest/impl/EholdingsTagsImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsTagsImpl.java
@@ -1,0 +1,102 @@
+package org.folio.rest.impl;
+
+import static io.vertx.core.Future.succeededFuture;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import javax.ws.rs.core.Response;
+import javax.xml.bind.ValidationException;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.converter.Converter;
+
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.aspect.HandleValidationErrors;
+import org.folio.rest.jaxrs.model.TagCollection;
+import org.folio.rest.jaxrs.resource.EholdingsTags;
+import org.folio.rest.tools.utils.TenantTool;
+import org.folio.rest.util.ErrorHandler;
+import org.folio.rest.util.ErrorUtil;
+import org.folio.rest.validator.RectypeParameterValidator;
+import org.folio.spring.SpringContextUtil;
+import org.folio.tag.Tag;
+import org.folio.tag.repository.TagRepository;
+
+public class EholdingsTagsImpl implements EholdingsTags {
+
+  private final Logger log = LoggerFactory.getLogger(EholdingsTagsImpl.class);
+
+  @Autowired
+  private RectypeParameterValidator recordTypeValidator;
+  @Autowired
+  private TagRepository tagRepository;
+  @Autowired
+  private Converter<List<String>, Set<org.folio.tag.RecordType>> recordTypesConverter;
+  @Autowired
+  private Converter<List<Tag>, TagCollection> tagsConverter;
+
+
+  public EholdingsTagsImpl() {
+    SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
+  }
+
+  @Validate
+  @HandleValidationErrors
+  @Override
+  public void getEholdingsTags(List<String> filterRectypes, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    validateRecordTypes(filterRectypes);
+
+    completedFuture(null)
+      .thenCompose(o -> findTags(filterRectypes, TenantTool.tenantId(okapiHeaders)))
+      .thenAccept(tags -> successfulGetTags(tags, asyncResultHandler))
+      .exceptionally(throwable -> failedGetTags(throwable, asyncResultHandler));
+  }
+
+  private void validateRecordTypes(List<String> filterRectypes) {
+    if (CollectionUtils.isNotEmpty(filterRectypes)) {
+      filterRectypes.forEach(recordTypeValidator::validate);
+    }
+  }
+
+  private CompletableFuture<List<Tag>> findTags(List<String> filterRectypes, String tenantId) {
+    log.info("Retrieving tags: tenantId = %s, recordTypes = %s", tenantId, filterRectypes);
+
+    if (CollectionUtils.isEmpty(filterRectypes)) {
+      return tagRepository.findAll(tenantId);
+    } else {
+      return tagRepository.findByRecordTypes(tenantId, recordTypesConverter.convert(filterRectypes));
+    }
+  }
+
+  private void successfulGetTags(List<Tag> tags, Handler<AsyncResult<Response>> handler) {
+    handler.handle(succeededFuture(GetEholdingsTagsResponse.respond200WithApplicationVndApiJson(
+      tagsConverter.convert(tags))));
+  }
+
+  private Void failedGetTags(Throwable th, Handler<AsyncResult<Response>> handler) {
+    log.error("Tag retrieval failed: " + th.getMessage(), th);
+
+    ErrorHandler errHandler = new ErrorHandler()
+        .add(ValidationException.class,
+          e -> GetEholdingsTagsResponse.respond400WithApplicationVndApiJson(ErrorUtil.createError(e.getMessage())))
+        .addInputValidationMapper()
+        .addDefaultMapper();
+
+    errHandler.handle(handler, th);
+
+    return null;
+  }
+
+}

--- a/src/main/java/org/folio/rest/impl/EholdingsTagsImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsTagsImpl.java
@@ -71,7 +71,7 @@ public class EholdingsTagsImpl implements EholdingsTags {
   }
 
   private CompletableFuture<List<Tag>> findTags(List<String> filterRectypes, String tenantId) {
-    log.info("Retrieving tags: tenantId = %s, recordTypes = %s", tenantId, filterRectypes);
+    log.info("Retrieving tags: tenantId = {}, recordTypes = {}", tenantId, filterRectypes);
 
     if (CollectionUtils.isEmpty(filterRectypes)) {
       return tagRepository.findAll(tenantId);

--- a/src/main/java/org/folio/rest/util/ErrorUtil.java
+++ b/src/main/java/org/folio/rest/util/ErrorUtil.java
@@ -1,9 +1,10 @@
 package org.folio.rest.util;
 
 
+import static org.folio.common.ListUtils.mapItems;
+
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -52,10 +53,9 @@ public class ErrorUtil {
           .build();
       }
 
-      List<JsonapiErrorResponse> jsonApiErrors = errorsObject.getErrorList().stream()
-        .map(error -> new JsonapiErrorResponse()
-          .withTitle(error.getMessage()))
-        .collect(Collectors.toList());
+      List<JsonapiErrorResponse> jsonApiErrors = mapItems(errorsObject.getErrorList(),
+        error -> new JsonapiErrorResponse()
+          .withTitle(error.getMessage()));
       configurationError.setErrors(jsonApiErrors);
       configurationError.setJsonapi(RestConstants.JSONAPI);
       return configurationError;

--- a/src/main/java/org/folio/rest/util/RestConstants.java
+++ b/src/main/java/org/folio/rest/util/RestConstants.java
@@ -17,6 +17,11 @@ public final class RestConstants {
   public static final String RESOURCES_TYPE = "resources";
   public static final String JSON_API_TYPE = "application/vnd.api+json";
 
+  public static final String PROVIDER_RECTYPE = "provider";
+  public static final String PACKAGE_RECTYPE = "package";
+  public static final String TITLE_RECTYPE = "title";
+  public static final String RESOURCE_RECTYPE = "resource";
+
   public static final Map<String, String> FILTER_SELECTED_MAPPING =
     ImmutableMap.of(
       "true", "selected",

--- a/src/main/java/org/folio/rest/util/RestConstants.java
+++ b/src/main/java/org/folio/rest/util/RestConstants.java
@@ -15,6 +15,7 @@ public final class RestConstants {
   public static final String PROVIDERS_TYPE = "providers";
   public static final String TITLES_TYPE = "titles";
   public static final String RESOURCES_TYPE = "resources";
+  public static final String TAGS_TYPE = "tags";
   public static final String JSON_API_TYPE = "application/vnd.api+json";
 
   public static final String PROVIDER_RECTYPE = "provider";

--- a/src/main/java/org/folio/rest/validator/RectypeParameterValidator.java
+++ b/src/main/java/org/folio/rest/validator/RectypeParameterValidator.java
@@ -1,0 +1,36 @@
+package org.folio.rest.validator;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.join;
+
+import static org.folio.rest.util.RestConstants.PACKAGE_RECTYPE;
+import static org.folio.rest.util.RestConstants.PROVIDER_RECTYPE;
+import static org.folio.rest.util.RestConstants.RESOURCE_RECTYPE;
+import static org.folio.rest.util.RestConstants.TITLE_RECTYPE;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.validation.ValidationException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RectypeParameterValidator {
+
+  private static final String PARAM_NAME = "filter[rectype]";
+  private static final List<String> FILTER_RECTYPE_VALUES = Arrays.asList(PROVIDER_RECTYPE, PACKAGE_RECTYPE,
+      TITLE_RECTYPE,RESOURCE_RECTYPE);
+
+  
+  public void validate(String rectype) {
+    if (StringUtils.isBlank(rectype)) {
+      throw new ValidationException(format("Parameter '%s' cannot be empty", PARAM_NAME));
+    }
+    if (!FILTER_RECTYPE_VALUES.contains(rectype)) {
+      throw new ValidationException(format("Invalid '%s' parameter value: %s. Possible values: %s",
+        PARAM_NAME, rectype, join(FILTER_RECTYPE_VALUES, ", ")));
+    }
+  }
+}

--- a/src/main/java/org/folio/tag/RecordType.java
+++ b/src/main/java/org/folio/tag/RecordType.java
@@ -13,4 +13,8 @@ public enum RecordType {
   public String getValue() {
     return value;
   }
+  
+  public static RecordType fromValue(String value) {
+    return valueOf(value.toUpperCase());
+  }
 }

--- a/src/main/java/org/folio/tag/Tag.java
+++ b/src/main/java/org/folio/tag/Tag.java
@@ -1,0 +1,15 @@
+package org.folio.tag;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder(toBuilder = true)
+public class Tag {
+
+  private String id;
+  private String recordId;
+  private RecordType recordType;
+  private String value;
+
+}

--- a/src/main/java/org/folio/tag/repository/TagRepository.java
+++ b/src/main/java/org/folio/tag/repository/TagRepository.java
@@ -1,176 +1,22 @@
 package org.folio.tag.repository;
 
-import static org.folio.tag.repository.TagTableConstants.DELETE_TAG_RECORD;
-import static org.folio.tag.repository.TagTableConstants.SELECT_TAG_VALUES_BY_ID_AND_TYPE;
-import static org.folio.tag.repository.TagTableConstants.TABLE_NAME;
-import static org.folio.tag.repository.TagTableConstants.TAG_COLUMN;
-import static org.folio.tag.repository.TagTableConstants.UPDATE_INSERT_STATEMENT_FOR_PROVIDER;
-
-import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-import io.vertx.ext.sql.ResultSet;
-import io.vertx.ext.sql.SQLConnection;
-import org.apache.commons.lang3.mutable.MutableObject;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
-import org.folio.rest.jaxrs.model.Tags;
-import org.folio.rest.persist.PostgresClient;
 import org.folio.tag.RecordType;
+import org.folio.tag.Tag;
 
-@Component
-public class TagRepository {
-  private static final Logger LOG = LoggerFactory.getLogger(TagRepository.class);
-  private Vertx vertx;
+public interface TagRepository {
 
-  @Autowired
-  public TagRepository(Vertx vertx) {
-    this.vertx = vertx;
-  }
+  CompletableFuture<List<Tag>> findAll(String tenantId);
 
-  public CompletableFuture<Tags> getTags(String tenantId, String recordId, RecordType recordType){
-    CompletableFuture<Tags> future = new CompletableFuture<>();
+  CompletableFuture<List<Tag>> findByRecord(String tenantId, String recordId, RecordType recordType);
 
-    JsonArray parameters = createParameters(recordId, recordType.getValue());
+  CompletableFuture<List<Tag>> findByRecordTypes(String tenantId, Set<RecordType> recordTypes);
 
-    PostgresClient.getInstance(vertx, tenantId)
-      .select(
-        String.format(SELECT_TAG_VALUES_BY_ID_AND_TYPE, getTableName(tenantId)),
-        parameters,
-        result -> readTags(result, future)
-      );
-    return future;
-  }
+  CompletableFuture<Boolean> updateRecordTags(String tenantId, String recordId, RecordType recordType, List<String> tags);
 
-  private void readTags(AsyncResult<ResultSet> result, CompletableFuture<Tags> future) {
-    ResultSet resultSet = result.result();
-    List<String> tagValues = resultSet.getRows().stream()
-      .map(row -> row.getString(TAG_COLUMN))
-      .collect(Collectors.toList());
-    future.complete(new Tags().withTagList(tagValues));
-  }
-
-  private String getTableName(String tenantId) {
-    return PostgresClient.convertToPsqlStandard(tenantId) + "." + TABLE_NAME;
-  }
-
-  public CompletableFuture<Boolean> updateTags(String tenantId, String recordId, RecordType recordType, List<String> tags) {
-    if(tags.isEmpty()){
-      return unAssignTags(null, tenantId, recordId, recordType);
-    }
-    return assignTags(tenantId, recordId, recordType, tags);
-  }
-
-  public CompletableFuture<Boolean> deleteTags(String tenantId, String recordId, RecordType recordType) {
-    return unAssignTags(null, tenantId, recordId, recordType);
-  }
-
-
-  private CompletableFuture<Boolean> assignTags(String tenantId, String recordId, RecordType recordType, List<String> tags) {
-    PostgresClient postgresClient = PostgresClient.getInstance(vertx, tenantId);
-    MutableObject<AsyncResult<SQLConnection>> mutableConnection = new MutableObject<>();
-    CompletableFuture<Boolean> future = CompletableFuture.completedFuture(null);
-    CompletableFuture<Boolean> rollbackFuture = new CompletableFuture<>();
-    return future
-      .thenCompose(o -> {
-        CompletableFuture<Boolean> startTxFuture = new CompletableFuture<>();
-        postgresClient.startTx(connection -> {
-          mutableConnection.setValue(connection);
-          startTxFuture.complete(null);
-        });
-        return startTxFuture;
-      })
-      .thenCompose(aBoolean -> unAssignTags(mutableConnection.getValue(), tenantId, recordId, recordType))
-      .thenCompose(aBoolean -> assignTags(mutableConnection.getValue(), tenantId, recordId, recordType, tags, postgresClient))
-      .whenComplete((result, ex) -> {
-        if(ex != null) {
-          LOG.info("Transaction was not successful. Roll back changes.");
-          postgresClient.rollbackTx(mutableConnection.getValue(), rollback -> rollbackFuture.completeExceptionally(ex));
-        } else {
-          rollbackFuture.complete(result);
-        }
-      })
-      .thenCombine(rollbackFuture, (o, aBoolean) -> true);
-  }
-
-
-
-  private CompletableFuture<Boolean> assignTags(AsyncResult<SQLConnection> connection, String tenantId, String recordId, RecordType recordType, List<String> tags, PostgresClient postgresClient) {
-    CompletableFuture<Boolean> future = new CompletableFuture<>();
-    JsonArray parameters = new JsonArray();
-    String updatedValues = createInsertStatement(recordId, recordType, tags, parameters);
-    final String query = String.format(UPDATE_INSERT_STATEMENT_FOR_PROVIDER, getTableName(tenantId), updatedValues);
-    LOG.info("Do insert query = " + query);
-    postgresClient.execute(connection, query, parameters, reply -> {
-      if (reply.succeeded()) {
-        LOG.info("Successfully inserted entries.");
-        postgresClient.endTx(connection, done -> future.complete(Boolean.TRUE));
-      } else {
-        LOG.info("Failed to insert entries");
-        future.completeExceptionally(reply.cause());
-      }
-    });
-    return future;
-  }
-
-  private CompletableFuture<Boolean> unAssignTags(AsyncResult<SQLConnection> connection, String tenantId, String recordId,
-      RecordType recordType) {
-    CompletableFuture<Boolean> future = new CompletableFuture<>();
-    final String deleteQuery = String.format(DELETE_TAG_RECORD, getTableName(tenantId), recordId, recordType);
-    LOG.info("Do delete query = " + deleteQuery);
-
-    JsonArray parameters = createParameters(recordId, recordType.getValue());
-        if (connection != null) {
-          PostgresClient.getInstance(vertx, tenantId)
-            .execute(connection, deleteQuery, parameters, result -> {
-            if (result.succeeded()) {
-              LOG.info("Successfully deleted entries.");
-              future.complete(Boolean.TRUE);
-            } else {
-              LOG.info("Failed to delete entries." + result.cause());
-              future.completeExceptionally(result.cause());
-          }
-          });
-        } else {
-          PostgresClient.getInstance(vertx, tenantId).execute(deleteQuery, parameters, result -> {
-            if (result.succeeded()) {
-              LOG.info("Successfully deleted entries.");
-              future.complete(Boolean.TRUE);
-            } else {
-              LOG.info("Failed to delete entries." + result.cause());
-              future.completeExceptionally(result.cause());
-            }
-          });
-        }
-      return future;
-  }
-
-  private JsonArray createParameters(String ... queryParameters) {
-    JsonArray parameters = new JsonArray();
-    for (Object parameter : queryParameters) {
-      parameters.add(parameter);
-    }
-    return parameters;
-  }
-
-  private String createInsertStatement(String recordId, RecordType recordType, List<String> tags, JsonArray params) {
-    tags.forEach(tag -> {
-      String id = UUID.randomUUID().toString();
-      params.add(id);
-      params.add(recordId);
-      params.add(recordType.getValue());
-      params.add(tag);
-    });
-    return String.join(",", Collections.nCopies(tags.size(),"(?,?,?,?)"));
-  }
-
+  CompletableFuture<Boolean> deleteRecordTags(String tenantId, String recordId, RecordType recordType);
+  
 }

--- a/src/main/java/org/folio/tag/repository/TagRepositoryImpl.java
+++ b/src/main/java/org/folio/tag/repository/TagRepositoryImpl.java
@@ -1,0 +1,245 @@
+package org.folio.tag.repository;
+
+import static java.util.Arrays.asList;
+
+import static org.folio.tag.repository.TagTableConstants.DELETE_TAG_RECORD;
+import static org.folio.tag.repository.TagTableConstants.ID_COLUMN;
+import static org.folio.tag.repository.TagTableConstants.RECORD_ID_COLUMN;
+import static org.folio.tag.repository.TagTableConstants.RECORD_TYPE_COLUMN;
+import static org.folio.tag.repository.TagTableConstants.SELECT_ALL_TAGS;
+import static org.folio.tag.repository.TagTableConstants.SELECT_TAGS_BY_RECORD_ID_AND_RECORD_TYPE;
+import static org.folio.tag.repository.TagTableConstants.SELECT_TAGS_BY_RECORD_TYPES;
+import static org.folio.tag.repository.TagTableConstants.TABLE_NAME;
+import static org.folio.tag.repository.TagTableConstants.TAG_COLUMN;
+import static org.folio.tag.repository.TagTableConstants.UPDATE_INSERT_STATEMENT_FOR_PROVIDER;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.sql.SQLConnection;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.mutable.MutableObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.folio.common.FutureUtils;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.tag.RecordType;
+import org.folio.tag.Tag;
+
+@Component
+class TagRepositoryImpl implements TagRepository {
+  
+  private static final Logger LOG = LoggerFactory.getLogger(TagRepositoryImpl.class);
+  private Vertx vertx;
+
+  @Autowired
+  public TagRepositoryImpl(Vertx vertx) {
+    this.vertx = vertx;
+  }
+
+  @Override
+  public CompletableFuture<List<Tag>> findAll(String tenantId) {
+    Future<ResultSet> resultSetFuture = Future.future();
+    PostgresClient.getInstance(vertx, tenantId)
+      .select(
+        String.format(SELECT_ALL_TAGS, getTableName(tenantId)),
+        resultSetFuture.completer()
+      );
+
+    return mapResultSet(resultSetFuture, this::readTags);
+  }
+
+  @Override
+  public CompletableFuture<List<Tag>> findByRecord(String tenantId, String recordId, RecordType recordType) {
+    JsonArray parameters = createParameters(asList(recordId, recordType.getValue()));
+
+    Future<ResultSet> resultSetFuture = Future.future();
+    PostgresClient.getInstance(vertx, tenantId)
+      .select(
+        String.format(SELECT_TAGS_BY_RECORD_ID_AND_RECORD_TYPE, getTableName(tenantId)),
+        parameters, resultSetFuture.completer()
+      );
+
+    return mapResultSet(resultSetFuture, this::readTags);
+  }
+
+  @Override
+  public CompletableFuture<List<Tag>> findByRecordTypes(String tenantId, Set<RecordType> recordTypes) {
+    if (CollectionUtils.isEmpty(recordTypes)) {
+      return FutureUtils.failedFuture(new IllegalArgumentException("At least one record type required"));
+    }
+    
+    JsonArray parameters = createParameters(toValues(recordTypes));
+    String placeholders = createPlaceholders(parameters);
+
+    Future<ResultSet> resultSetFuture = Future.future();
+    PostgresClient.getInstance(vertx, tenantId)
+      .select(
+        String.format(SELECT_TAGS_BY_RECORD_TYPES, getTableName(tenantId), placeholders),
+        parameters, resultSetFuture.completer()
+      );
+
+    return mapResultSet(resultSetFuture, this::readTags);
+  }
+
+  @Override
+  public CompletableFuture<Boolean> updateRecordTags(String tenantId, String recordId, RecordType recordType, List<String> tags) {
+    if(tags.isEmpty()){
+      return unAssignTags(null, tenantId, recordId, recordType);
+    }
+    return assignTags(tenantId, recordId, recordType, tags);
+  }
+
+  @Override
+  public CompletableFuture<Boolean> deleteRecordTags(String tenantId, String recordId, RecordType recordType) {
+    return unAssignTags(null, tenantId, recordId, recordType);
+  }
+
+  private <T> CompletableFuture<T> mapResultSet(Future<ResultSet> future, Function<ResultSet, T> mapper) {
+    CompletableFuture<T> result = new CompletableFuture<>();
+
+    future.map(mapper)
+      .map(result::complete)
+      .otherwise(result::completeExceptionally);
+
+    return result;
+  }
+
+  private List<Tag> readTags(ResultSet resultSet) {
+    return resultSet.getRows().stream()
+              .map(this::populateTag)
+              .collect(Collectors.toList());
+  }
+
+  private Tag populateTag(JsonObject row) {
+    return Tag.builder()
+            .id(row.getString(ID_COLUMN))
+            .recordId(row.getString(RECORD_ID_COLUMN))
+            .recordType(RecordType.fromValue(row.getString(RECORD_TYPE_COLUMN)))
+            .value(row.getString(TAG_COLUMN)).build();
+  }
+
+  private Set<String> toValues(Set<RecordType> recordTypes) {
+    return recordTypes.stream().map(RecordType::getValue).collect(Collectors.toSet());
+  }
+
+  private String getTableName(String tenantId) {
+    return PostgresClient.convertToPsqlStandard(tenantId) + "." + TABLE_NAME;
+  }
+
+  private CompletableFuture<Boolean> assignTags(String tenantId, String recordId, RecordType recordType, List<String> tags) {
+    PostgresClient postgresClient = PostgresClient.getInstance(vertx, tenantId);
+    MutableObject<AsyncResult<SQLConnection>> mutableConnection = new MutableObject<>();
+    CompletableFuture<Boolean> future = CompletableFuture.completedFuture(null);
+    CompletableFuture<Boolean> rollbackFuture = new CompletableFuture<>();
+    return future
+      .thenCompose(o -> {
+        CompletableFuture<Boolean> startTxFuture = new CompletableFuture<>();
+        postgresClient.startTx(connection -> {
+          mutableConnection.setValue(connection);
+          startTxFuture.complete(null);
+        });
+        return startTxFuture;
+      })
+      .thenCompose(aBoolean -> unAssignTags(mutableConnection.getValue(), tenantId, recordId, recordType))
+      .thenCompose(aBoolean -> assignTags(mutableConnection.getValue(), tenantId, recordId, recordType, tags, postgresClient))
+      .whenComplete((result, ex) -> {
+        if(ex != null) {
+          LOG.info("Transaction was not successful. Roll back changes.");
+          postgresClient.rollbackTx(mutableConnection.getValue(), rollback -> rollbackFuture.completeExceptionally(ex));
+        } else {
+          rollbackFuture.complete(result);
+        }
+      })
+      .thenCombine(rollbackFuture, (o, aBoolean) -> true);
+  }
+
+  private CompletableFuture<Boolean> assignTags(AsyncResult<SQLConnection> connection, String tenantId, String recordId, RecordType recordType, List<String> tags, PostgresClient postgresClient) {
+    CompletableFuture<Boolean> future = new CompletableFuture<>();
+    JsonArray parameters = new JsonArray();
+    String updatedValues = createInsertStatement(recordId, recordType, tags, parameters);
+    final String query = String.format(UPDATE_INSERT_STATEMENT_FOR_PROVIDER, getTableName(tenantId), updatedValues);
+    LOG.info("Do insert query = " + query);
+    postgresClient.execute(connection, query, parameters, reply -> {
+      if (reply.succeeded()) {
+        LOG.info("Successfully inserted entries.");
+        postgresClient.endTx(connection, done -> future.complete(Boolean.TRUE));
+      } else {
+        LOG.info("Failed to insert entries");
+        future.completeExceptionally(reply.cause());
+      }
+    });
+    return future;
+  }
+
+  private CompletableFuture<Boolean> unAssignTags(AsyncResult<SQLConnection> connection, String tenantId, String recordId,
+      RecordType recordType) {
+    CompletableFuture<Boolean> future = new CompletableFuture<>();
+    final String deleteQuery = String.format(DELETE_TAG_RECORD, getTableName(tenantId), recordId, recordType);
+    LOG.info("Do delete query = " + deleteQuery);
+
+    JsonArray parameters = createParameters(asList(recordId, recordType.getValue()));
+        if (connection != null) {
+          PostgresClient.getInstance(vertx, tenantId)
+            .execute(connection, deleteQuery, parameters, result -> {
+            if (result.succeeded()) {
+              LOG.info("Successfully deleted entries.");
+              future.complete(Boolean.TRUE);
+            } else {
+              LOG.info("Failed to delete entries." + result.cause());
+              future.completeExceptionally(result.cause());
+          }
+          });
+        } else {
+          PostgresClient.getInstance(vertx, tenantId).execute(deleteQuery, parameters, result -> {
+            if (result.succeeded()) {
+              LOG.info("Successfully deleted entries.");
+              future.complete(Boolean.TRUE);
+            } else {
+              LOG.info("Failed to delete entries." + result.cause());
+              future.completeExceptionally(result.cause());
+            }
+          });
+        }
+      return future;
+  }
+
+  private JsonArray createParameters(Iterable<?> queryParameters) {
+    JsonArray parameters = new JsonArray();
+
+    queryParameters.forEach(parameters::add);
+
+    return parameters;
+  }
+
+  private String createPlaceholders(JsonArray parameters) {
+    return StringUtils.join(Collections.nCopies(parameters.size(), "?"), ", ");
+  }
+
+  private String createInsertStatement(String recordId, RecordType recordType, List<String> tags, JsonArray params) {
+    tags.forEach(tag -> {
+      String id = UUID.randomUUID().toString();
+      params.add(id);
+      params.add(recordId);
+      params.add(recordType.getValue());
+      params.add(tag);
+    });
+    return String.join(",", Collections.nCopies(tags.size(),"(?,?,?,?)"));
+  }
+
+}

--- a/src/main/java/org/folio/tag/repository/TagRepositoryImpl.java
+++ b/src/main/java/org/folio/tag/repository/TagRepositoryImpl.java
@@ -2,6 +2,7 @@ package org.folio.tag.repository;
 
 import static java.util.Arrays.asList;
 
+import static org.folio.common.ListUtils.mapItems;
 import static org.folio.tag.repository.TagTableConstants.DELETE_TAG_RECORD;
 import static org.folio.tag.repository.TagTableConstants.ID_COLUMN;
 import static org.folio.tag.repository.TagTableConstants.RECORD_ID_COLUMN;
@@ -121,9 +122,7 @@ class TagRepositoryImpl implements TagRepository {
   }
 
   private List<Tag> readTags(ResultSet resultSet) {
-    return resultSet.getRows().stream()
-              .map(this::populateTag)
-              .collect(Collectors.toList());
+    return mapItems(resultSet.getRows(), this::populateTag);
   }
 
   private Tag populateTag(JsonObject row) {

--- a/src/main/java/org/folio/tag/repository/TagTableConstants.java
+++ b/src/main/java/org/folio/tag/repository/TagTableConstants.java
@@ -1,5 +1,6 @@
 package org.folio.tag.repository;
 
+@SuppressWarnings("squid:S1192")
 public class TagTableConstants {
   private TagTableConstants() {}
 
@@ -8,17 +9,25 @@ public class TagTableConstants {
   public static final String ID_COLUMN = "id";
   public static final String RECORD_ID_COLUMN = "record_id";
   public static final String RECORD_TYPE_COLUMN = "record_type";
+  public static final String TAG_FIELD_LIST = String.format("%s, %s, %s, %s",
+    ID_COLUMN, RECORD_ID_COLUMN, RECORD_TYPE_COLUMN, TAG_COLUMN);
 
-  public static final String SELECT_TAG_VALUES_BY_ID_AND_TYPE =
-    "SELECT " + TAG_COLUMN + " FROM %s "
-      + "WHERE " + RECORD_ID_COLUMN + "=? AND " + RECORD_TYPE_COLUMN + "=?";
+  static final String SELECT_ALL_TAGS =
+    "SELECT " + TAG_FIELD_LIST + " FROM %s ORDER BY " + TAG_COLUMN;
 
-  public static  final String UPDATE_INSERT_STATEMENT_FOR_PROVIDER =
-    "INSERT INTO %s (id, record_id, record_type, tag) VALUES " +
+  static final String SELECT_TAGS_BY_RECORD_ID_AND_RECORD_TYPE =
+    "SELECT " + TAG_FIELD_LIST + " FROM %s "
+      + "WHERE " + RECORD_ID_COLUMN + "=? AND " + RECORD_TYPE_COLUMN + "=? ORDER BY " + TAG_COLUMN;
+  
+  static final String SELECT_TAGS_BY_RECORD_TYPES =
+    "SELECT " + TAG_FIELD_LIST + " FROM %s "
+      + "WHERE " + RECORD_TYPE_COLUMN + " IN (%s) ORDER BY " + TAG_COLUMN;
+
+  static  final String UPDATE_INSERT_STATEMENT_FOR_PROVIDER =
+    "INSERT INTO %s (" + TAG_FIELD_LIST + ") VALUES " +
       "%s;";
 
-
-  public static final String DELETE_TAG_RECORD =
+  static final String DELETE_TAG_RECORD =
     "DELETE FROM %s WHERE " + RECORD_ID_COLUMN + "=? AND " + RECORD_TYPE_COLUMN + "=?";
 
 }

--- a/src/test/java/org/folio/rest/impl/EholdingsConfigurationTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsConfigurationTest.java
@@ -11,18 +11,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.hamcrest.Matchers.equalTo;
 
+import static org.folio.common.ListUtils.mapItems;
+
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
-import java.util.stream.Collectors;
-
-import org.folio.rest.jaxrs.model.Config;
-import org.folio.rest.jaxrs.model.Configs;
-import org.folio.rest.jaxrs.model.Configuration;
-import org.folio.rest.util.RestConstants;
-import org.folio.util.TestUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
@@ -30,10 +23,17 @@ import com.github.tomakehurst.wiremock.matching.AnythingPattern;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
-
 import io.restassured.RestAssured;
 import io.restassured.http.Header;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.folio.rest.jaxrs.model.Config;
+import org.folio.rest.jaxrs.model.Configs;
+import org.folio.rest.jaxrs.model.Configuration;
+import org.folio.rest.util.RestConstants;
+import org.folio.util.TestUtil;
 
 @RunWith(VertxUnitRunner.class)
 public class EholdingsConfigurationTest extends WireMockTestBase {
@@ -101,9 +101,7 @@ public class EholdingsConfigurationTest extends WireMockTestBase {
 
     String configsString = TestUtil.readFile("responses/kb-ebsco/configuration/get-configuration.json");
     Configs configs = mapper.readValue(configsString, Configs.class);
-    List<String> existingIds = configs.getConfigs().stream()
-      .map(Config::getId)
-      .collect(Collectors.toList());
+    List<String> existingIds = mapItems(configs.getConfigs(), Config::getId);
 
     mockConfigurationUpdate(configsString);
 

--- a/src/test/java/org/folio/rest/impl/EholdingsTagsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsTagsImplTest.java
@@ -1,0 +1,142 @@
+package org.folio.rest.impl;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyCollectionOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import static org.folio.rest.impl.TagsTestUtil.clearTags;
+import static org.folio.rest.impl.TagsTestUtil.insertTags;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.folio.rest.jaxrs.model.JsonapiError;
+import org.folio.rest.jaxrs.model.TagCollection;
+import org.folio.tag.RecordType;
+import org.folio.tag.Tag;
+
+@RunWith(VertxUnitRunner.class)
+public class EholdingsTagsImplTest extends WireMockTestBase {
+
+  private static final String PROVIDER_ID = "1111";
+  private static final String PACKAGE_ID = PROVIDER_ID + "-" + "3964";
+  private static final String TITLE_ID = "12345";
+  private static final String RESOURCE_ID = PACKAGE_ID + "-" + TITLE_ID;
+
+  private static final Tag PROVIDER_TAG = tag(PROVIDER_ID, RecordType.PROVIDER, "provider-tag");
+  private static final Tag PACKAGE_TAG = tag(PACKAGE_ID, RecordType.PACKAGE, "package-tag");
+  private static final Tag TITLE_TAG = tag(TITLE_ID, RecordType.TITLE, "title-tag");
+  private static final Tag RESOURCE_TAG = tag(RESOURCE_ID, RecordType.RESOURCE, "resource-tag");
+
+  private static final Tag[] ALL_TAGS = new Tag[] {PROVIDER_TAG, PACKAGE_TAG, TITLE_TAG, RESOURCE_TAG};
+
+  @Test
+  public void shouldReturnAllTagsSortedIfNotFilteredOnGet() {
+    insertTags(asList(ALL_TAGS), vertx);
+
+    try {
+      TagCollection col = getOkResponse("eholdings/tags").as(TagCollection.class);
+
+      assertNotNull(col);
+      assertEquals(sort(values(ALL_TAGS)), col.getData());
+      assertEquals(ALL_TAGS.length, col.getMeta().getTotalResults().intValue());
+    } finally {
+      clearTags(vertx);
+    }
+  }
+
+  @Test
+  public void shouldReturnEmptyCollectionIfNoTagsOnGet() {
+    TagCollection col = getOkResponse("eholdings/tags").as(TagCollection.class);
+
+    assertNotNull(col);
+    assertThat(col.getData(), is(emptyCollectionOf(String.class)));
+    assertEquals(0, col.getMeta().getTotalResults().intValue());
+  }
+
+  @Test
+  public void shouldFilterByRecordTypeOnGet() {
+    insertTags(asList(ALL_TAGS), vertx);
+
+    try {
+      TagCollection col = getOkResponse("eholdings/tags?filter[rectype]=provider").as(TagCollection.class);
+
+      assertNotNull(col);
+      assertEquals(values(PROVIDER_TAG), col.getData());
+      assertEquals(1, col.getMeta().getTotalResults().intValue());
+    } finally {
+      clearTags(vertx);
+    }
+  }
+
+  @Test
+  public void shouldFilterBySeveralRecordTypesOnGet() {
+    insertTags(asList(ALL_TAGS), vertx);
+
+    try {
+      TagCollection col = getOkResponse("eholdings/tags?filter[rectype]=provider&filter[rectype]=title")
+          .as(TagCollection.class);
+
+      assertNotNull(col);
+      assertEquals(sort(values(PROVIDER_TAG, TITLE_TAG)), col.getData());
+      assertEquals(2, col.getMeta().getTotalResults().intValue());
+    } finally {
+      clearTags(vertx);
+    }
+  }
+
+  @Test
+  public void shouldReturnEmptyCollectionIfFilteredOutOnGet() {
+    insertTags(asList(PROVIDER_TAG, PACKAGE_TAG), vertx);
+
+    try {
+      TagCollection col = getOkResponse("eholdings/tags?filter[rectype]=title")
+        .as(TagCollection.class);
+
+      assertNotNull(col);
+      assertThat(col.getData(), is(emptyCollectionOf(String.class)));
+      assertEquals(0, col.getMeta().getTotalResults().intValue());
+    } finally {
+      clearTags(vertx);
+    }
+  }
+
+  @Test
+  public void shouldFailOnInvalidRecordTypeOnGet() {
+    JsonapiError error = getResponseWithStatus("eholdings/tags?filter[rectype]=INVALID&filter[rectype]=title",
+        HttpStatus.SC_BAD_REQUEST).as(JsonapiError.class);
+
+    assertThat(error.getErrors().get(0).getTitle(), containsString("Invalid 'filter[rectype]' parameter value"));
+  }
+
+  private static List<String> sort(List<String> list) {
+    ArrayList<String> result = new ArrayList<>(list);
+    result.sort(String::compareTo);
+    return result;
+  }
+
+  private static List<String> values(Tag ... tags) {
+    List<String> result = new ArrayList<>(tags.length);
+    for (Tag tag : tags) {
+      result.add(tag.getValue());
+    }
+    return result;
+  }
+
+  private static Tag tag(String recordId, RecordType recordType, String value) {
+    return Tag.builder()
+              .recordId(recordId)
+              .recordType(recordType)
+              .value(value).build();
+  }
+
+}

--- a/src/test/java/org/folio/rest/impl/EholdingsTagsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsTagsImplTest.java
@@ -80,7 +80,7 @@ public class EholdingsTagsImplTest extends WireMockTestBase {
     try {
       TagCollection col = getOkResponse("eholdings/tags?filter[rectype]=provider").as(TagCollection.class);
 
-      TagCollection expected = buildTagCollection(filter(tags, byContent(PROVIDER_TAG)));
+      TagCollection expected = buildTagCollection(filter(tags, similarTo(PROVIDER_TAG)));
       assertEquals(expected, col);
     } finally {
       clearTags(vertx);
@@ -95,7 +95,7 @@ public class EholdingsTagsImplTest extends WireMockTestBase {
       TagCollection col = getOkResponse("eholdings/tags?filter[rectype]=provider&filter[rectype]=title")
           .as(TagCollection.class);
 
-      TagCollection expected = buildTagCollection(filter(tags, byContent(PROVIDER_TAG).or(byContent(TITLE_TAG))));
+      TagCollection expected = buildTagCollection(filter(tags, similarTo(PROVIDER_TAG).or(similarTo(TITLE_TAG))));
       assertEquals(expected, col);
     } finally {
       clearTags(vertx);
@@ -159,7 +159,7 @@ public class EholdingsTagsImplTest extends WireMockTestBase {
     }
   }
 
-  private Predicate<Tag> byContent(Tag expected) {
+  private Predicate<Tag> similarTo(Tag expected) {
     return tag -> expected.getValue().equals(tag.getValue()) &&
       expected.getRecordId().equals(tag.getRecordId()) &&
       expected.getRecordType().equals(tag.getRecordType());

--- a/src/test/java/org/folio/rest/impl/EholdingsTagsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsTagsImplTest.java
@@ -2,25 +2,33 @@ package org.folio.rest.impl;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.emptyCollectionOf;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
+import static org.folio.common.ListUtils.mapItems;
 import static org.folio.rest.impl.TagsTestUtil.clearTags;
 import static org.folio.rest.impl.TagsTestUtil.insertTags;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.http.HttpStatus;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.converter.Converter;
 
 import org.folio.rest.jaxrs.model.JsonapiError;
+import org.folio.rest.jaxrs.model.MetaTotalResults;
 import org.folio.rest.jaxrs.model.TagCollection;
+import org.folio.rest.jaxrs.model.TagCollectionItem;
+import org.folio.rest.util.RestConstants;
 import org.folio.tag.RecordType;
 import org.folio.tag.Tag;
 
@@ -37,18 +45,21 @@ public class EholdingsTagsImplTest extends WireMockTestBase {
   private static final Tag TITLE_TAG = tag(TITLE_ID, RecordType.TITLE, "title-tag");
   private static final Tag RESOURCE_TAG = tag(RESOURCE_ID, RecordType.RESOURCE, "resource-tag");
 
-  private static final Tag[] ALL_TAGS = new Tag[] {PROVIDER_TAG, PACKAGE_TAG, TITLE_TAG, RESOURCE_TAG};
+  private static final List<Tag> ALL_TAGS = asList(PROVIDER_TAG, PACKAGE_TAG, TITLE_TAG, RESOURCE_TAG);
+
+  @Autowired
+  private Converter<Tag, TagCollectionItem> tagConverter;
+
 
   @Test
   public void shouldReturnAllTagsSortedIfNotFilteredOnGet() {
-    insertTags(asList(ALL_TAGS), vertx);
+    List<Tag> tags = insertTags(ALL_TAGS, vertx);
 
     try {
       TagCollection col = getOkResponse("eholdings/tags").as(TagCollection.class);
 
-      assertNotNull(col);
-      assertEquals(sort(values(ALL_TAGS)), col.getData());
-      assertEquals(ALL_TAGS.length, col.getMeta().getTotalResults().intValue());
+      TagCollection expected = buildTagCollection(tags);
+      assertEquals(expected, col);
     } finally {
       clearTags(vertx);
     }
@@ -58,21 +69,19 @@ public class EholdingsTagsImplTest extends WireMockTestBase {
   public void shouldReturnEmptyCollectionIfNoTagsOnGet() {
     TagCollection col = getOkResponse("eholdings/tags").as(TagCollection.class);
 
-    assertNotNull(col);
-    assertThat(col.getData(), is(emptyCollectionOf(String.class)));
-    assertEquals(0, col.getMeta().getTotalResults().intValue());
+    TagCollection expected = buildTagCollection(Collections.emptyList());
+    assertEquals(expected, col);
   }
 
   @Test
   public void shouldFilterByRecordTypeOnGet() {
-    insertTags(asList(ALL_TAGS), vertx);
+    List<Tag> tags = insertTags(ALL_TAGS, vertx);
 
     try {
       TagCollection col = getOkResponse("eholdings/tags?filter[rectype]=provider").as(TagCollection.class);
 
-      assertNotNull(col);
-      assertEquals(values(PROVIDER_TAG), col.getData());
-      assertEquals(1, col.getMeta().getTotalResults().intValue());
+      TagCollection expected = buildTagCollection(filter(tags, byContent(PROVIDER_TAG)));
+      assertEquals(expected, col);
     } finally {
       clearTags(vertx);
     }
@@ -80,15 +89,14 @@ public class EholdingsTagsImplTest extends WireMockTestBase {
 
   @Test
   public void shouldFilterBySeveralRecordTypesOnGet() {
-    insertTags(asList(ALL_TAGS), vertx);
+    List<Tag> tags = insertTags(ALL_TAGS, vertx);
 
     try {
       TagCollection col = getOkResponse("eholdings/tags?filter[rectype]=provider&filter[rectype]=title")
           .as(TagCollection.class);
 
-      assertNotNull(col);
-      assertEquals(sort(values(PROVIDER_TAG, TITLE_TAG)), col.getData());
-      assertEquals(2, col.getMeta().getTotalResults().intValue());
+      TagCollection expected = buildTagCollection(filter(tags, byContent(PROVIDER_TAG).or(byContent(TITLE_TAG))));
+      assertEquals(expected, col);
     } finally {
       clearTags(vertx);
     }
@@ -102,9 +110,8 @@ public class EholdingsTagsImplTest extends WireMockTestBase {
       TagCollection col = getOkResponse("eholdings/tags?filter[rectype]=title")
         .as(TagCollection.class);
 
-      assertNotNull(col);
-      assertThat(col.getData(), is(emptyCollectionOf(String.class)));
-      assertEquals(0, col.getMeta().getTotalResults().intValue());
+      TagCollection expected = buildTagCollection(Collections.emptyList());
+      assertEquals(expected, col);
     } finally {
       clearTags(vertx);
     }
@@ -118,20 +125,6 @@ public class EholdingsTagsImplTest extends WireMockTestBase {
     assertThat(error.getErrors().get(0).getTitle(), containsString("Invalid 'filter[rectype]' parameter value"));
   }
 
-  private static List<String> sort(List<String> list) {
-    ArrayList<String> result = new ArrayList<>(list);
-    result.sort(String::compareTo);
-    return result;
-  }
-
-  private static List<String> values(Tag ... tags) {
-    List<String> result = new ArrayList<>(tags.length);
-    for (Tag tag : tags) {
-      result.add(tag.getValue());
-    }
-    return result;
-  }
-
   private static Tag tag(String recordId, RecordType recordType, String value) {
     return Tag.builder()
               .recordId(recordId)
@@ -139,4 +132,36 @@ public class EholdingsTagsImplTest extends WireMockTestBase {
               .value(value).build();
   }
 
+  private List<TagCollectionItem> toTagCollectionItems(List<Tag> tags) {
+    return mapItems(tags, tagConverter::convert);
+  }
+
+  private List<TagCollectionItem> sort(List<TagCollectionItem> items) {
+    ArrayList<TagCollectionItem> result = new ArrayList<>(items);
+    result.sort(Comparator.comparing(o -> o.getAttributes().getValue()));
+    return result;
+  }
+
+  private TagCollection buildTagCollection(List<Tag> tags) {
+    return new TagCollection()
+      .withData(sort(toTagCollectionItems(tags)))
+      .withMeta(new MetaTotalResults().withTotalResults(tags.size()))
+      .withJsonapi(RestConstants.JSONAPI);
+  }
+
+  private List<Tag> filter(List<Tag> tags, Predicate<Tag> filter) {
+    List<Tag> found = tags.stream().filter(filter).collect(Collectors.toList());
+
+    if (CollectionUtils.isEmpty(found)) {
+      throw new IllegalArgumentException("Cannot find any tag matching the filter predicate");
+    } else {
+      return found;
+    }
+  }
+
+  private Predicate<Tag> byContent(Tag expected) {
+    return tag -> expected.getValue().equals(tag.getValue()) &&
+      expected.getRecordId().equals(tag.getRecordId()) &&
+      expected.getRecordType().equals(tag.getRecordType());
+  }
 }

--- a/src/test/java/org/folio/rest/impl/IntegrationTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/IntegrationTestSuite.java
@@ -16,7 +16,8 @@ import org.junit.runners.Suite;
   EholdingsResourcesImplTest.class,
   EHoldingsRootProxyImplTest.class,
   EholdingsStatusTest.class,
-  EholdingsTitlesTest.class
+  EholdingsTitlesTest.class,
+  EholdingsTagsImplTest.class
 })
 @RunWith(Suite.class)
 public class IntegrationTestSuite {

--- a/src/test/java/org/folio/rest/impl/TagsTestUtil.java
+++ b/src/test/java/org/folio/rest/impl/TagsTestUtil.java
@@ -1,41 +1,60 @@
 package org.folio.rest.impl;
 
+import static org.apache.commons.lang3.StringUtils.join;
+
 import static org.folio.tag.repository.TagTableConstants.ID_COLUMN;
 import static org.folio.tag.repository.TagTableConstants.RECORD_ID_COLUMN;
 import static org.folio.tag.repository.TagTableConstants.RECORD_TYPE_COLUMN;
 import static org.folio.tag.repository.TagTableConstants.TABLE_NAME;
 import static org.folio.tag.repository.TagTableConstants.TAG_COLUMN;
+import static org.folio.tag.repository.TagTableConstants.TAG_FIELD_LIST;
 import static org.folio.util.TestUtil.STUB_TENANT;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
 
 import org.folio.rest.persist.PostgresClient;
 import org.folio.tag.RecordType;
+import org.folio.tag.Tag;
 
 public class TagsTestUtil {
+
   private TagsTestUtil() {
   }
 
   public static void insertTag(Vertx vertx, String recordId, final RecordType recordType, String value) {
     CompletableFuture<Void> future = new CompletableFuture<>();
     PostgresClient.getInstance(vertx).execute(
-      "INSERT INTO " + PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + TABLE_NAME +
-        "(" + ID_COLUMN + ", " +  RECORD_ID_COLUMN + ", " + RECORD_TYPE_COLUMN + ", " + TAG_COLUMN
+      "INSERT INTO " + tagTestTable() +
+        "(" + ID_COLUMN + ", " + RECORD_ID_COLUMN + ", " + RECORD_TYPE_COLUMN + ", " + TAG_COLUMN
         + ") VALUES('" +
         UUID.randomUUID().toString() + "', '" + recordId + "', '" + recordType.getValue() + "', '" + value + "')",
       event -> future.complete(null));
     future.join();
   }
 
+  public static void insertTags(List<Tag> tags, Vertx vertx) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+
+    String insertStatement = "INSERT INTO " + tagTestTable() +
+            "(" + TAG_FIELD_LIST + ") VALUES " + join(Collections.nCopies(tags.size(), "(?,?,?,?)"), ",");
+    JsonArray params = createParams(tags);
+
+    PostgresClient.getInstance(vertx).execute(insertStatement, params, event -> future.complete(null));
+
+    future.join();
+  }
+
   public static void clearTags(Vertx vertx) {
     CompletableFuture<Void> future = new CompletableFuture<>();
     PostgresClient.getInstance(vertx).execute(
-      "DELETE FROM " + PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + TABLE_NAME,
+      "DELETE FROM " + tagTestTable(),
       event -> future.complete(null));
     future.join();
   }
@@ -43,7 +62,7 @@ public class TagsTestUtil {
   public static List<String> getTags(Vertx vertx) {
     CompletableFuture<List<String>> future = new CompletableFuture<>();
     PostgresClient.getInstance(vertx).select(
-      "SELECT " + TAG_COLUMN + " FROM " + PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + TABLE_NAME,
+      "SELECT " + TAG_COLUMN + " FROM " + tagTestTable(),
       event -> future.complete(event.result().getRows().stream().map(row -> row.getString(TAG_COLUMN)).collect(Collectors.toList())));
     return future.join();
   }
@@ -51,9 +70,26 @@ public class TagsTestUtil {
   public static List<String> getTagsForRecordType(Vertx vertx, RecordType recordType) {
     CompletableFuture<List<String>> future = new CompletableFuture<>();
     PostgresClient.getInstance(vertx).select(
-      "SELECT " + TAG_COLUMN + " FROM " + PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + TABLE_NAME + " " +
+      "SELECT " + TAG_COLUMN + " FROM " + tagTestTable() + " " +
         "WHERE " + RECORD_TYPE_COLUMN + "= '" + recordType.getValue()+"'",
       event -> future.complete(event.result().getRows().stream().map(row -> row.getString(TAG_COLUMN)).collect(Collectors.toList())));
     return future.join();
+  }
+
+  private static String tagTestTable() {
+    return PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + TABLE_NAME;
+  }
+
+  private static JsonArray createParams(List<Tag> tags) {
+    JsonArray params = new JsonArray();
+
+    tags.forEach(tag -> {
+      params.add(UUID.randomUUID().toString());
+      params.add(tag.getRecordId());
+      params.add(tag.getRecordType().getValue());
+      params.add(tag.getValue());
+    });
+
+    return params;
   }
 }

--- a/src/test/java/org/folio/rest/impl/TagsTestUtil.java
+++ b/src/test/java/org/folio/rest/impl/TagsTestUtil.java
@@ -2,6 +2,7 @@ package org.folio.rest.impl;
 
 import static org.apache.commons.lang3.StringUtils.join;
 
+import static org.folio.common.ListUtils.mapItems;
 import static org.folio.tag.repository.TagTableConstants.ID_COLUMN;
 import static org.folio.tag.repository.TagTableConstants.RECORD_ID_COLUMN;
 import static org.folio.tag.repository.TagTableConstants.RECORD_TYPE_COLUMN;
@@ -14,7 +15,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
@@ -63,7 +63,7 @@ public class TagsTestUtil {
     CompletableFuture<List<String>> future = new CompletableFuture<>();
     PostgresClient.getInstance(vertx).select(
       "SELECT " + TAG_COLUMN + " FROM " + tagTestTable(),
-      event -> future.complete(event.result().getRows().stream().map(row -> row.getString(TAG_COLUMN)).collect(Collectors.toList())));
+      event -> future.complete(mapItems(event.result().getRows(), row -> row.getString(TAG_COLUMN))));
     return future.join();
   }
 
@@ -72,7 +72,7 @@ public class TagsTestUtil {
     PostgresClient.getInstance(vertx).select(
       "SELECT " + TAG_COLUMN + " FROM " + tagTestTable() + " " +
         "WHERE " + RECORD_TYPE_COLUMN + "= '" + recordType.getValue()+"'",
-      event -> future.complete(event.result().getRows().stream().map(row -> row.getString(TAG_COLUMN)).collect(Collectors.toList())));
+      event -> future.complete(mapItems(event.result().getRows(), row -> row.getString(TAG_COLUMN))));
     return future.join();
   }
 

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
   <Appenders>
     <Console name="CONSOLE" target="SYSTEM_OUT">
-      <PatternLayout pattern="%-5p %-20.20C{1} %m%n"/>
+      <PatternLayout pattern="%d %-5p [%t] %-20.20C{1} %m%n"/>
     </Console>
   </Appenders>
   <Loggers>


### PR DESCRIPTION
## Purpose
Per [MODKBEKBJ-186](https://issues.folio.org/browse/MODKBEKBJ-186) a new endpoint has been added to retrieve tags assigned to eholding records

## Approach

- describe new endpoint in RAML
- implement the endpoint according to generated interface
- add new methods to Tag Repository to retrieve all tags, tags assigned to records of specified type(s)

Responses:
-- with tags
![image](https://user-images.githubusercontent.com/42244720/54994502-10c8dd00-4fcd-11e9-8124-005db84041f5.png)
-- empty
![image](https://user-images.githubusercontent.com/42244720/54995317-20e1bc00-4fcf-11e9-90e5-79b0d40e2a69.png)

