### PR TITLE
MODKBEKBJ-197 Fix removal of managed package from holdings

### DIFF
--- a/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
@@ -284,7 +284,16 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
   }
 
   private boolean isPackageUpdateable(PackagePutRequest entity) {
-    PackageDataAttributes attributes = entity.getData().getAttributes();
-    return !Objects.isNull(attributes.getIsSelected()) && attributes.getIsSelected();
+    PackageDataAttributes packageData = entity.getData().getAttributes();
+    if (!Objects.isNull(packageData.getIsCustom()) && !packageData.getIsCustom() &&
+        !Objects.isNull(packageData.getIsSelected()) && !packageData.getIsSelected()) {
+      try {
+        packagePutBodyValidator.validate(entity);
+      }
+      catch (InputValidationException ex){
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/src/test/resources/requests/kb-ebsco/package/put-package-not-selected-non-empty-fields.json
+++ b/src/test/resources/requests/kb-ebsco/package/put-package-not-selected-non-empty-fields.json
@@ -7,6 +7,7 @@
         "endCoverage": "2004-01-01"
       },
       "isSelected": false,
+      "isCustom":false,
       "allowKbToAddTitles": true,
       "visibilityData": {
         "isHidden": true,


### PR DESCRIPTION
## Purpose
PR https://github.com/folio-org/mod-kb-ebsco-java/pull/119 introduced bug, in which package can't be removed from holdings, because put request is not sent to RM API for unselected managed packages.
Fix this bug by sending request to RM API in case if it is a valid update that will unselect package
## Approach
Add special case to condition that skips sending put request to RM API