### PR TITLE
MODKBEKBJ-183: Fix bug with removing selected resource from holdings

### DIFF
--- a/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
@@ -238,6 +238,16 @@ public class EholdingsResourcesImpl implements EholdingsResources {
 
   private boolean resourceCanBeUpdated(ResourcePutRequest entity) {
     ResourcePutDataAttributes attributes = entity.getData().getAttributes();
-    return !Objects.isNull(attributes.getIsSelected()) && attributes.getIsSelected();
+    boolean isTitleCustom = !Objects.isNull(attributes.getIsTitleCustom()) && attributes.getIsTitleCustom();
+    boolean isSelected = !Objects.isNull(attributes.getIsSelected()) && attributes.getIsSelected();
+    if(!isSelected && !isTitleCustom){
+      try{
+        resourcePutBodyValidator.validate(entity, isTitleCustom);
+      }
+      catch (InputValidationException ex){
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/src/test/java/org/folio/rest/impl/EholdingsResourcesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsResourcesImplTest.java
@@ -382,16 +382,17 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
   }
 
   @Test
-  public void shouldUpdateOnlyTagsOnPutWhenResourceIsNotSelected() throws IOException, URISyntaxException {
+  public void shouldUpdateOnlyTagsOnPutWhenResourceIsNotSelectedAndUpdatedFieldsAreNotEmpty() throws IOException, URISyntaxException {
     try {
       String stubResponseFile = "responses/rmapi/resources/get-custom-resource-updated-response.json";
       ObjectMapper mapper = new ObjectMapper();
-      ResourcePutRequest request = mapper.readValue(readFile("requests/kb-ebsco/resource/put-custom-resource.json"),
+      ResourcePutRequest request = mapper.readValue(readFile("requests/kb-ebsco/resource/put-managed-resource.json"),
         ResourcePutRequest.class);
       List<String> tags = Arrays.asList(STUB_TAG, STUB_TAG2);
       request.getData().getAttributes().setTags(new Tags()
         .withTagList(tags));
       request.getData().getAttributes().setIsSelected(false);
+      request.getData().getAttributes().setCoverageStatement("coverage statement");
       updateResource(stubResponseFile, CUSTOM_RESOURCE_ENDPOINT, STUB_CUSTOM_RESOURCE_ID,
         mapper.writeValueAsString(request));
 


### PR DESCRIPTION
## Purpose
PR https://github.com/folio-org/mod-kb-ebsco-java/pull/116 introduced bug, in which resource can't be removed from holdings, because put request is not sent to RM API for unselected not custom resource.
Fix this bug by sending request to RM API in case if it is a valid update that will unselect resource
## Approach
Add special case to condition that skips sending put request to RM API