### PR TITLE
Prep for release 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-kb-ebsco-java</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>EBSCO KB Broker</name>


### PR DESCRIPTION
## Purpose
Update version to V2.2.0 in prep for Q1 release

Version 2.1.0 release was closed (per below PR) so as to include some bug fixes
 https://github.com/folio-org/mod-kb-ebsco-java/pull/126

Update release to v2.2.0 to avoid issues with any Jenkins remnants created related for v2.1.0

Below issues to be included in Q1 release
https://github.com/folio-org/mod-kb-ebsco-java/pull/127
https://github.com/folio-org/mod-kb-ebsco-java/pull/125