### PR TITLE
Release 2.2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+## v2.2.0 2019-03-22
+ * MODKBEKBJ-162- Tags: assign/unassign tags to Package record
+ * MODKBEKBJ-163 - Tags: assign/unassign tags to Title record
+ * MODKBEKBJ-165 - Tags: assign/unassign tags to Resource record
+ * MODKBEKBJ-168 - Error when removing managed titles from holdings
+ * MODKBEKBJ-174- Remove title from holdings - Error converting value \"Streaming Video\"
+ * MODKBEKBJ-176 - Bug on adding resource to holdings
+ * MODKBEKBJ-177- Add a method to modify title
+ * MODKBEKBJ-181 - Investigate Newman error messages reason during collection run
+ * MODKBEKBJ-182 - Tags: assign/unassign tags on provider when no package is selected 
+ * MODKBEKBJ-183 - Tags: assign/unassign tags on resources regardless of isSelected value
+ * MODKBEKBJ-194 - Custom Coverages are not returned in descending order
+ * MODKBEKBJ-196 - Tags: assign/unassign tags on title regardless of whether it is managed or custom
+ * MODKBEKBJ-197 - Tags: assign/unassign tags on package regardless of isSelected value
+ * MODKBEKBJ-198 - DB upgrade fails
+ * MODKBEKBJ-200 - Invalid filter for packages does not return ValidationException
+
 ## v2.0.3 2019-02-08
  * MODKBEKBJ-168 - Error when removing managed titles from holdings
  * MODKBEKBJ-161 - Tags: assign/unassign tags to Provider record

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-kb-ebsco-java</artifactId>
-  <version>2.2.0</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>EBSCO KB Broker</name>
@@ -515,7 +515,7 @@
     <url>https://github.com/folio-org/mod-kb-ebsco-java</url>
     <connection>scm:git:git://github.com/folio-org/mod-kb-ebsco-java</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-kb-ebsco-java.git</developerConnection>
-    <tag>v2.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-kb-ebsco-java</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.2.0</version>
   <packaging>jar</packaging>
 
   <name>EBSCO KB Broker</name>
@@ -515,7 +515,7 @@
     <url>https://github.com/folio-org/mod-kb-ebsco-java</url>
     <connection>scm:git:git://github.com/folio-org/mod-kb-ebsco-java</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-kb-ebsco-java.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.2.0</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
## Purpose
Create Q1 release which includes the following changes since v2.0.3
 * https://issues.folio.org/browse/MODKBEKBJ-162- Tags: assign/unassign tags to Package record
 * https://issues.folio.org/browse/MODKBEKBJ-163 - Tags: assign/unassign tags to Title record
 * https://issues.folio.org/browse/MODKBEKBJ-165 - Tags: assign/unassign tags to Resource record
 * https://issues.folio.org/browse/MODKBEKBJ-168 - Error when removing managed titles from holdings
 * https://issues.folio.org/browse/MODKBEKBJ-174- Remove title from holdings - Error converting value \"Streaming Video\"
 * https://issues.folio.org/browse/MODKBEKBJ-176 - Bug on adding resource to holdings
 * https://issues.folio.org/browse/MODKBEKBJ-177- Add a method to modify title
 * https://issues.folio.org/browse/MODKBEKBJ-198 - DB upgrade fails
 * https://issues.folio.org/browse/MODKBEKBJ-181 - Investigate Newman error messages reason during collection run
 * https://issues.folio.org/browse/MODKBEKBJ-182 - Tags: assign/unassign tags on provider when no package is selected 
 * https://issues.folio.org/browse/MODKBEKBJ-183 - Tags: assign/unassign tags on resources regardless of isSelected value
 * https://issues.folio.org/browse/MODKBEKBJ-194 - Custom Coverages are not returned in descending order
 * https://issues.folio.org/browse/MODKBEKBJ-196 - Tags: assign/unassign tags on title regardless of whether it is managed or custom
 * https://issues.folio.org/browse/MODKBEKBJ-197 - Tags: assign/unassign tags on package regardless of isSelected value
 * https://issues.folio.org/browse/MODKBEKBJ-200 - Invalid filter for packages does not return ValidationException

Note release version was updated to v2.2.0 to avoid potential conflicts with an earlier tag (see the following as reference)
https://github.com/folio-org/mod-kb-ebsco-java/pull/126

## Approach
Follow release procedure for mvn module - https://dev.folio.org/guidelines/release-procedures/