### PR TITLE
MODKBEKBJ-227 - Modify ModuleDescriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -340,7 +340,12 @@
       ]
     }
   ],
-  "requires": [],
+  "requires": [
+    {
+      "id": "configuration",
+      "version": "2.0"
+    }
+  ],
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerArgs": {

--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,6 @@
       <version>2.8.11</version>
     </dependency>
     <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>mod-configuration-client</artifactId>
-      <version>${mod-configuration-client.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>
       <version>2.3</version>


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-227 we want to explicitly declare a dependency of mod-configuration interface called `configuration` and version 2.0

## Approach
* modified ModuleDescriptor requires section with mod-configuration interface
* removed mod-configuration-client dependency in pom file as it is provided by folio-holdingsiq-client library
<img width="770" alt="Screen Shot 2019-05-13 at 4 09 13 PM" src="https://user-images.githubusercontent.com/37537790/57623930-80a12000-7599-11e9-90b1-06a104ef8994.png">

