### PR TITLE
Delete tags when custom package is deleted through PUT

### DIFF
--- a/src/main/java/org/folio/common/FutureUtils.java
+++ b/src/main/java/org/folio/common/FutureUtils.java
@@ -11,7 +11,7 @@ public class FutureUtils {
     CompletableFuture<T> f = new CompletableFuture<>();
 
     f.completeExceptionally(ex);
-    
+
     return f;
   }
 }

--- a/src/test/resources/requests/kb-ebsco/package/put-package-custom-not-selected.json
+++ b/src/test/resources/requests/kb-ebsco/package/put-package-custom-not-selected.json
@@ -5,7 +5,7 @@
       "isSelected": false,
       "name": "name of the ages forever and ever",
       "contentType": "Aggregated Full Text",
-      "allowKbToAddTitles": true,
+      "allowKbToAddTitles":  true,
       "visibilityData": {
         "isHidden": true,
         "reason": ""

--- a/src/test/resources/requests/kb-ebsco/package/put-package-custom-not-selected.json
+++ b/src/test/resources/requests/kb-ebsco/package/put-package-custom-not-selected.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "type": "packages",
+    "attributes": {
+      "isSelected": true,
+      "name": "name of the ages forever and ever",
+      "contentType": "Aggregated Full Text",
+      "allowKbToAddTitles": true,
+      "visibilityData": {
+        "isHidden": true,
+        "reason": ""
+      },
+      "customCoverage": {
+        "beginCoverage": "2003-01-01",
+        "endCoverage": "2004-01-01"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
Fix bug where package and tag data is not delete from local database if custom package is deleted on PUT request

## Approach
If getting package after update results in ResourceNotFoundException, then remove tag and package information from database.