### PR TITLE
MODKBEKBJ-271: Add check for empty collections in repositories

### DIFF
--- a/src/main/java/org/folio/repository/packages/PackageRepositoryImpl.java
+++ b/src/main/java/org/folio/repository/packages/PackageRepositoryImpl.java
@@ -32,6 +32,8 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.UpdateResult;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -98,6 +100,9 @@ public class PackageRepositoryImpl implements PackageRepository {
 
   @Override
   public CompletableFuture<List<DbPackage>> getPackagesByIds(List<PackageId> packageIds, String tenantId) {
+    if(CollectionUtils.isEmpty(packageIds)){
+      return CompletableFuture.completedFuture(Collections.emptyList());
+    }
     JsonArray parameters = new JsonArray();
     packageIds.forEach(packageId -> parameters.add(packageId.getProviderIdPart() + "-" + packageId.getPackageIdPart()));
 
@@ -114,6 +119,9 @@ public class PackageRepositoryImpl implements PackageRepository {
   }
 
   private CompletableFuture<List<DbPackage>> getPackageIdsByTagAndIdPrefix(List<String> tags, String prefix, int page, int count, String tenantId) {
+    if(CollectionUtils.isEmpty(tags)){
+      return CompletableFuture.completedFuture(Collections.emptyList());
+    }
     int offset = (page - 1) * count;
 
     JsonArray parameters = new JsonArray();

--- a/src/main/java/org/folio/repository/providers/ProviderRepositoryImpl.java
+++ b/src/main/java/org/folio/repository/providers/ProviderRepositoryImpl.java
@@ -23,6 +23,8 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.UpdateResult;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -71,6 +73,9 @@ public class ProviderRepositoryImpl implements ProviderRepository {
 
   @Override
   public CompletableFuture<List<Long>> getProviderIdsByTagName(List<String> tags, int page, int count, String tenantId) {
+    if(CollectionUtils.isEmpty(tags)){
+      return CompletableFuture.completedFuture(Collections.emptyList());
+    }
     int offset = (page - 1) * count;
 
     JsonArray parameters = new JsonArray();

--- a/src/main/java/org/folio/repository/resources/ResourceRepositoryImpl.java
+++ b/src/main/java/org/folio/repository/resources/ResourceRepositoryImpl.java
@@ -31,6 +31,8 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.UpdateResult;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -83,6 +85,9 @@ public class ResourceRepositoryImpl implements ResourceRepository {
 
   @Override
   public CompletableFuture<List<DbResource>> getResourcesByTagNameAndPackageId(List<String> tags, String resourceId, int page, int count, String tenantId) {
+    if(CollectionUtils.isEmpty(tags)){
+      return CompletableFuture.completedFuture(Collections.emptyList());
+    }
     int offset = (page - 1) * count;
 
     JsonArray parameters = new JsonArray();

--- a/src/main/java/org/folio/repository/tag/TagRepositoryImpl.java
+++ b/src/main/java/org/folio/repository/tag/TagRepositoryImpl.java
@@ -41,6 +41,7 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.ext.sql.UpdateResult;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -109,6 +110,9 @@ class TagRepositoryImpl implements TagRepository {
 
   @Override
   public CompletableFuture<List<Tag>> findByRecordByIds(String tenantId, List<String> recordIds, RecordType recordType) {
+    if(CollectionUtils.isEmpty(recordIds)){
+      return CompletableFuture.completedFuture(Collections.emptyList());
+    }
     Future<ResultSet> resultSetFuture = findByRecordIdsOfType(tenantId, recordIds, recordType);
 
     return mapResult(resultSetFuture, this::readTags);
@@ -117,6 +121,9 @@ class TagRepositoryImpl implements TagRepository {
   @Override
   public CompletableFuture<Map<String, List<Tag>>> findPerRecord(String tenantId, List<String> recordIds,
                                                                  RecordType recordType) {
+    if(CollectionUtils.isEmpty(recordIds)){
+      return CompletableFuture.completedFuture(Collections.emptyMap());
+    }
     Future<ResultSet> resultSetFuture = findByRecordIdsOfType(tenantId, recordIds, recordType);
 
     return mapResult(resultSetFuture, this::readTagsPerRecord)
@@ -130,6 +137,9 @@ class TagRepositoryImpl implements TagRepository {
 
   @Override
   public CompletableFuture<Integer> countRecordsByTagsAndPrefix(List<String> tags, String recordIdPrefix, String tenantId, RecordType recordType) {
+    if(CollectionUtils.isEmpty(tags)){
+      return CompletableFuture.completedFuture(0);
+    }
     JsonArray parameters = createParameters(tags);
     parameters.add(recordType.getValue());
     parameters.add(recordIdPrefix + "%");

--- a/src/main/java/org/folio/repository/titles/TitlesRepositoryImpl.java
+++ b/src/main/java/org/folio/repository/titles/TitlesRepositoryImpl.java
@@ -27,6 +27,8 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.UpdateResult;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -79,6 +81,9 @@ public class TitlesRepositoryImpl implements TitlesRepository {
 
   @Override
   public CompletableFuture<List<DbTitle>> getTitlesByResourceTags(List<String> tags, int page, int count, String tenantId) {
+    if(CollectionUtils.isEmpty(tags)){
+      return CompletableFuture.completedFuture(Collections.emptyList());
+    }
     int offset = (page - 1) * count;
 
     JsonArray parameters = new JsonArray();
@@ -101,6 +106,9 @@ public class TitlesRepositoryImpl implements TitlesRepository {
 
   @Override
   public CompletableFuture<Integer> countTitlesByResourceTags(List<String> tags, String tenantId) {
+    if(CollectionUtils.isEmpty(tags)){
+      return CompletableFuture.completedFuture(0);
+    }
     JsonArray parameters = new JsonArray();
     tags.forEach(parameters::add);
     final String query = String.format(COUNT_TITLES_BY_RESOURCE_TAGS, getTagsTableName(tenantId), createPlaceholders(tags.size()));

--- a/src/test/java/org/folio/repository/packages/PackageRepositoryImplTest.java
+++ b/src/test/java/org/folio/repository/packages/PackageRepositoryImplTest.java
@@ -1,0 +1,44 @@
+package org.folio.repository.packages;
+
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThat;
+
+import static org.folio.rest.impl.ProvidersTestData.STUB_VENDOR_ID;
+import static org.folio.util.TestUtil.STUB_TENANT;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import org.folio.spring.config.TestConfig;
+
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestConfig.class)
+public class PackageRepositoryImplTest {
+
+  @Autowired
+  PackageRepository repository;
+
+  @Test
+  public void shouldReturnEmptyListWhenIdListIsEmpty() {
+    List<DbPackage> packages = repository.getPackagesByIds(Collections.emptyList(), null).join();
+    assertThat(packages, empty());
+  }
+  @Test
+  public void shouldReturnEmptyListWhenTagListIsEmpty() {
+    List<DbPackage> packages = repository.getPackagesByTagName(Collections.emptyList(), 1, 25, STUB_TENANT).join();
+    assertThat(packages, empty());
+  }
+
+  @Test
+  public void shouldReturnEmptyListWhenTagListIsEmptyAndProviderIdIsPresent() {
+    List<DbPackage> packages = repository.getPackagesByTagNameAndProvider(Collections.emptyList(),STUB_VENDOR_ID,1, 25, null).join();
+    assertThat(packages, empty());
+  }
+}

--- a/src/test/java/org/folio/repository/providers/ProviderRepositoryImplTest.java
+++ b/src/test/java/org/folio/repository/providers/ProviderRepositoryImplTest.java
@@ -1,0 +1,31 @@
+package org.folio.repository.providers;
+
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThat;
+
+import static org.folio.util.TestUtil.STUB_TENANT;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import org.folio.spring.config.TestConfig;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestConfig.class)
+public class ProviderRepositoryImplTest {
+
+  @Autowired
+  ProviderRepository repository;
+
+  @Test
+  public void shouldReturnEmptyListWhenTagListIsEmpty() {
+    List<Long> providerIds = repository.getProviderIdsByTagName(Collections.emptyList(), 1, 25, STUB_TENANT).join();
+    assertThat(providerIds, empty());
+  }
+}

--- a/src/test/java/org/folio/repository/resources/ResourcesRepositoryImplTest.java
+++ b/src/test/java/org/folio/repository/resources/ResourcesRepositoryImplTest.java
@@ -1,0 +1,32 @@
+package org.folio.repository.resources;
+
+
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThat;
+
+import static org.folio.rest.impl.PackagesTestData.STUB_PACKAGE_ID;
+import static org.folio.util.TestUtil.STUB_TENANT;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import org.folio.spring.config.TestConfig;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestConfig.class)
+public class ResourcesRepositoryImplTest {
+  @Autowired
+  ResourceRepository repository;
+
+  @Test
+  public void shouldReturnEmptyListWhenTagListIsEmpty() {
+    List<DbResource> resources = repository.getResourcesByTagNameAndPackageId(Collections.emptyList(), STUB_PACKAGE_ID, 1, 25, STUB_TENANT).join();
+    assertThat(resources, empty());
+  }
+}

--- a/src/test/java/org/folio/repository/tag/TagRepositoryImplTest.java
+++ b/src/test/java/org/folio/repository/tag/TagRepositoryImplTest.java
@@ -1,0 +1,50 @@
+package org.folio.repository.tag;
+
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import static org.folio.util.TestUtil.STUB_TENANT;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import org.folio.repository.RecordType;
+import org.folio.spring.config.TestConfig;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestConfig.class)
+public class TagRepositoryImplTest {
+  @Autowired
+  TagRepository repository;
+  @Test
+  public void shouldReturnZeroWhenTagListIsEmptyOnCountRecordsByTags() {
+    int count = repository.countRecordsByTags(Collections.emptyList(), STUB_TENANT, RecordType.RESOURCE).join();
+    assertEquals(0, count);
+  }
+
+  @Test
+  public void shouldReturnZeroWhenTagListIsEmptyOnCountRecordsByTagsAndPrefix() {
+    int count = repository.countRecordsByTagsAndPrefix(Collections.emptyList(), "123-", STUB_TENANT, RecordType.RESOURCE).join();
+    assertEquals(0, count);
+  }
+
+  @Test
+  public void shouldReturnEmptyListWhenIdListIsEmptyOnFindByRecordByIds() {
+    List<Tag> tags = repository.findByRecordByIds(STUB_TENANT, Collections.emptyList(), RecordType.RESOURCE).join();
+    assertThat(tags, empty());
+  }
+
+  @Test
+  public void shouldReturnEmptyMapWhenIdListIsEmptyOnFindByRecordByIds() {
+    Map<String, List<Tag>> tags = repository.findPerRecord(STUB_TENANT, Collections.emptyList(), RecordType.RESOURCE).join();
+    assertThat(tags.keySet(), empty());
+  }
+}

--- a/src/test/java/org/folio/repository/titles/TitleRepositoryImplTest.java
+++ b/src/test/java/org/folio/repository/titles/TitleRepositoryImplTest.java
@@ -1,0 +1,38 @@
+package org.folio.repository.titles;
+
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import static org.folio.util.TestUtil.STUB_TENANT;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import org.folio.spring.config.TestConfig;
+import org.folio.tag.repository.titles.DbTitle;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestConfig.class)
+public class TitleRepositoryImplTest {
+  @Autowired
+  TitlesRepository repository;
+
+  @Test
+  public void shouldReturnZeroWhenTagListIsEmpty() {
+    int count = repository.countTitlesByResourceTags(Collections.emptyList(), STUB_TENANT).join();
+    assertEquals(0, count);
+  }
+
+  @Test
+  public void shouldReturnEmptyListWhenTagListIsEmpty() {
+    List<DbTitle> titles = repository.getTitlesByResourceTags(Collections.emptyList(), 1, 25, STUB_TENANT).join();
+    assertThat(titles, empty());
+  }
+}

--- a/src/test/java/org/folio/rest/impl/EholdingsPackagesTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsPackagesTest.java
@@ -58,8 +58,10 @@ import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+
 import io.restassured.RestAssured;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+
 import org.apache.http.HttpStatus;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -89,6 +91,7 @@ public class EholdingsPackagesTest extends WireMockTestBase {
   private static final String PACKAGE_STUB_FILE = "responses/rmapi/packages/get-package-by-id-response.json";
   private static final String CUSTOM_PACKAGE_STUB_FILE = "responses/rmapi/packages/get-custom-package-by-id-response.json";
   private static final String RESOURCES_BY_PACKAGE_ID_STUB_FILE = "responses/rmapi/resources/get-resources-by-package-id-response.json";
+  private static final String RESOURCES_BY_PACKAGE_ID_EMPTY_STUB_FILE = "responses/rmapi/resources/get-resources-by-package-id-response-empty.json";
   private static final String EXPECTED_PACKAGE_BY_ID_STUB_FILE = "responses/kb-ebsco/packages/expected-package-by-id.json";
   private static final String EXPECTED_RESOURCES_STUB_FILE = "responses/kb-ebsco/resources/expected-resources-by-package-id.json";
   private static final String EXPECTED_RESOURCES_WITH_TAGS_STUB_FILE = "responses/kb-ebsco/resources/expected-resources-by-package-id-with-tags.json";
@@ -709,6 +712,19 @@ public class EholdingsPackagesTest extends WireMockTestBase {
     String packageResourcesUrl = "/eholdings/packages/" + STUB_VENDOR_ID + "-" + STUB_PACKAGE_ID + "/resources?page=2";
     String query = "?searchfield=titlename&selection=all&resourcetype=all&searchtype=advanced&search=&offset=2&count=25&orderby=titlename";
     shouldReturnResourcesOnGetWithResources(packageResourcesUrl, query);
+  }
+
+  @Test
+  public void shouldReturnEmptyListWhenResourcesAreNotFound() throws IOException, URISyntaxException {
+    String packageResourcesUrl = "/eholdings/packages/" + STUB_VENDOR_ID + "-" + STUB_PACKAGE_ID + "/resources";
+
+    mockDefaultConfiguration(getWiremockUrl());
+
+    mockResourceById(RESOURCES_BY_PACKAGE_ID_EMPTY_STUB_FILE);
+
+    ResourceCollection actual = getWithStatus(packageResourcesUrl, 200).as(ResourceCollection.class);
+    assertThat(actual.getData(), empty());
+    assertEquals(0, (int) actual.getMeta().getTotalResults());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/EholdingsProvidersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsProvidersImplTest.java
@@ -60,11 +60,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.vertx.core.json.Json;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.junit.Test;
@@ -587,6 +589,21 @@ public class EholdingsProvidersImplTest extends WireMockTestBase {
     String expected = readFile("responses/kb-ebsco/packages/expected-package-collection-with-one-element.json");
 
     JSONAssert.assertEquals(expected, actual, false);
+  }
+
+  @Test
+  public void shouldReturnEmptyPackageListWhenNoProviderPackagesAreFound() throws IOException, URISyntaxException {
+    String rmapiProviderPackagesUrl = "/rm/rmaccounts.*" + STUB_CUSTOMER_ID + "/vendors/"
+      + STUB_VENDOR_ID + "/packages.*";
+    String providerPackagesUrl = "eholdings/providers/" + STUB_VENDOR_ID + "/packages";
+    String packageStubResponseFile = "responses/rmapi/packages/get-packages-by-provider-id-empty.json";
+
+    mockDefaultConfiguration(getWiremockUrl());
+    mockGet(new RegexPattern(rmapiProviderPackagesUrl), packageStubResponseFile);
+
+    PackageCollection packages = getWithOk(providerPackagesUrl).as(PackageCollection.class);
+    assertThat(packages.getData(), empty());
+    assertEquals(0, (int) packages.getMeta().getTotalResults());
   }
 
   @Test

--- a/src/test/resources/responses/rmapi/packages/get-packages-by-provider-id-empty.json
+++ b/src/test/resources/responses/rmapi/packages/get-packages-by-provider-id-empty.json
@@ -1,0 +1,4 @@
+{
+  "totalResults": 0,
+  "packagesList": []
+}

--- a/src/test/resources/responses/rmapi/resources/get-resources-by-package-id-response-empty.json
+++ b/src/test/resources/responses/rmapi/resources/get-resources-by-package-id-response-empty.json
@@ -1,0 +1,4 @@
+{
+  "totalResults": 0,
+  "titles": []
+}


### PR DESCRIPTION
## Purpose
Fix "Internal server error" in situations when list of results is empty,
currently in some situations Repository classes will try to construct SQL query using an empty list, and this leads to sql exception

## Approach
Add checks for cases when repository receives an empty collection as a parameter

#### TODOS and Open Questions
- [x] Add unit tests for this case
