### PR TITLE
MODKBEKBJ-285 - Implement GET /loadHoldings/status

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -152,14 +152,19 @@
           "permissionsRequired": ["kb-ebsco.tags.collection.get"]
         },
         {
+          "methods": ["GET"],
+          "pathPattern": "/eholdings/tags/summary",
+          "permissionsRequired": ["kb-ebsco.unique.tags.collection.get"]
+        },
+        {
           "methods": ["POST"],
           "pathPattern": "/loadHoldings",
           "permissionsRequired": ["kb-ebsco.holdings.load.post"]
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/eholdings/tags/summary",
-          "permissionsRequired": ["kb-ebsco.unique.tags.collection.get"]
+          "pathPattern": "/loadHoldings/status",
+          "permissionsRequired": ["kb-ebsco.holdings.load.status.get"]
         }
       ]
     },
@@ -368,7 +373,12 @@
     {
       "permissionName": "kb-ebsco.holdings.load.post",
       "displayName": "permission to run load of holdings",
-      "description": "one-time run load of holdings"
+      "description": "One-time run load of holdings"
+    },
+    {
+      "permissionName": "kb-ebsco.holdings.load.status.get",
+      "displayName": "get current status of holdings loading",
+      "description": "Get current status of holdings loading"
     },
     {
       "permissionName": "kb-ebsco.all",
@@ -404,7 +414,8 @@
         "kb-ebsco.root-proxy.get",
         "kb-ebsco.root-proxy.put",
         "kb-ebsco.tags.collection.get",
-        "kb-ebsco.unique.tags.collection.get"
+        "kb-ebsco.unique.tags.collection.get",
+        "kb-ebsco.holdings.load.status.get"
       ]
     }
   ],

--- a/ramls/eholdings.raml
+++ b/ramls/eholdings.raml
@@ -14,6 +14,7 @@ types:
   configurationPutRequest: !include types/configuration/configurationPutRequest.json
   jsonapiError: !include types/jsonapiError.json
   configurationStatus: !include types/status/status.json
+  holdingsLoadingStatus: !include types/loadHoldings/loadingHoldingsStatus.json
 
 /eholdings/configuration:
   displayName: Configuration
@@ -105,3 +106,29 @@ types:
     responses:
       204:
         description: No Content
+      500:
+        description: "Internal server error"
+        body:
+          text/plain:
+            example: "Internal server error, contact administrator"
+  /status:
+    displayName: Get current status of load holdings job.
+    get:
+      description: Get current status of load holdings job.
+      headers:
+        Content-Type:
+          example: application/json
+      responses:
+        200:
+          body:
+            application/json:
+              description: Get current status of load holdings job.
+              type: holdingsLoadingStatus
+              example:
+                strict: false
+                value: !include examples/loadHoldings/loading_completed_200_response.json
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error, contact administrator"

--- a/ramls/examples/loadHoldings/loading_completed_200_response.json
+++ b/ramls/examples/loadHoldings/loading_completed_200_response.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "type": "status",
+    "attributes": {
+      "started": "1999-12-31 14:59:59",
+      "finished": "1999-12-31 16:30:47",
+      "totalCount": 1234,
+      "status": {
+        "name": "Completed"
+      }
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/examples/loadHoldings/loading_failed_200_response.json
+++ b/ramls/examples/loadHoldings/loading_failed_200_response.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "type" : "status",
+    "attributes": {
+      "status": {
+        "name": "Failed"
+      },
+      "errors": [
+        {
+          "title": "Invalid APIKEY",
+          "detail": "Kb api credentials are invalid"
+        }
+      ]
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/examples/loadHoldings/loading_in_progress_200_response.json
+++ b/ramls/examples/loadHoldings/loading_in_progress_200_response.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "type": "status",
+    "attributes": {
+      "started": "1999-12-31 14:59:59",
+      "status": {
+        "name": "In Progress",
+        "detail": "Populating staging area"
+      }
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/examples/loadHoldings/loading_not_started_200_response.json
+++ b/ramls/examples/loadHoldings/loading_not_started_200_response.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "type": "status",
+    "attributes": {
+      "status": {
+        "name": "Not Started"
+      }
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/examples/loadHoldings/loading_started_200_response.json
+++ b/ramls/examples/loadHoldings/loading_started_200_response.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "type": "status",
+    "attributes": {
+      "started": "1999-12-31 14:59:59",
+      "status": {
+        "name": "Started"
+      }
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/types/loadHoldings/loadingHoldingsStatus.json
+++ b/ramls/types/loadHoldings/loadingHoldingsStatus.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Holdings Loading Status Schema",
+  "description": "Holdings Loading Status Schema",
+  "javaType": "org.folio.rest.jaxrs.model.HoldingsLoadingStatus",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "data": {
+      "type": "object",
+      "description": "Status data",
+      "$ref": "statusData.json"
+    },
+    "jsonapi": {
+      "type": "object",
+      "description": "version of json api",
+      "$ref": "../jsonapi.json"
+    }
+  },
+  "required": [
+    "data",
+    "jsonapi"
+  ]
+}

--- a/ramls/types/loadHoldings/statusAttributes.json
+++ b/ramls/types/loadHoldings/statusAttributes.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Load Status Attributes Schema",
+  "description": "Load Status Attributes Schema",
+  "javaType": "org.folio.rest.jaxrs.model.LoadStatusAttributes",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "started": {
+      "type": "string",
+      "description": "Holdings loading started time",
+      "example": "1999-12-31 14:59:59"
+    },
+    "finished": {
+      "type": "string",
+      "description": "Holdings loading finished time",
+      "example": "1999-12-31 16:30:47"
+    },
+    "totalCount": {
+      "type": "integer",
+      "description": "Total number of holdings",
+      "example": 1234
+    },
+    "importedCount": {
+      "type": "integer",
+      "description": "Imported number of holdings",
+      "example": 1000
+    },
+    "status": {
+      "type": "object",
+      "$ref" : "statusInformation.json",
+      "description": "Current Status Information"
+    },
+    "errors": {
+      "type": "array",
+      "description": "Error Response List",
+      "items": {
+        "type": "object",
+        "$ref": "../jsonapiErrorResponse.json"
+      }
+    }
+  },
+  "required": [
+    "status"
+  ]
+}

--- a/ramls/types/loadHoldings/statusData.json
+++ b/ramls/types/loadHoldings/statusData.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Load Status Data Schema",
+  "description": "Load Status Data Schema",
+  "javaType": "org.folio.rest.jaxrs.model.LoadStatusData",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "Type information"
+    },
+    "attributes": {
+      "type": "object",
+      "description": "Status Attributes",
+      "$ref": "statusAttributes.json"
+    }
+  },
+  "required": [
+    "type",
+    "attributes"
+  ]
+}

--- a/ramls/types/loadHoldings/statusInformation.json
+++ b/ramls/types/loadHoldings/statusInformation.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Load Status Details Schema",
+  "description": "Load Status Schema",
+  "javaType": "org.folio.rest.jaxrs.model.LoadStatusInformation",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "$ref" : "statusNameEnum.json",
+      "description": "Current Status of holdings loading"
+    },
+    "detail": {
+      "type": "string",
+      "$ref" : "statusNameDetailEnum.json",
+      "description": "Current Status detail name of holdings loading"
+    }
+  },
+  "required": [
+    "name"
+  ]
+}

--- a/ramls/types/loadHoldings/statusNameDetailEnum.json
+++ b/ramls/types/loadHoldings/statusNameDetailEnum.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Load Status Name Detail Schema",
+  "description": "Load Status Name Detail Schema",
+  "javaType": "org.folio.rest.jaxrs.model.LoadStatusNameDetailEnum",
+  "type": "string",
+  "additionalProperties": false,
+  "enum": [
+    "Populating staging area",
+    "Loading holdings"
+  ]
+}

--- a/ramls/types/loadHoldings/statusNameEnum.json
+++ b/ramls/types/loadHoldings/statusNameEnum.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Load Status Name Schema",
+  "description": "Load Status Name Schema",
+  "javaType": "org.folio.rest.jaxrs.model.LoadStatusNameEnum",
+  "type": "string",
+  "additionalProperties": false,
+  "enum": [
+    "Not Started",
+    "Started",
+    "In Progress",
+    "Completed",
+    "Failed"
+  ]
+}

--- a/src/main/java/org/folio/repository/DbUtil.java
+++ b/src/main/java/org/folio/repository/DbUtil.java
@@ -1,11 +1,12 @@
 package org.folio.repository;
 
+import static org.folio.repository.holdings.HoldingsTableConstants.HOLDINGS_TABLE;
+import static org.folio.repository.holdings.status.HoldingsStatusTableConstants.HOLDINGS_STATUS_TABLE;
 import static org.folio.repository.packages.PackageTableConstants.PACKAGES_TABLE_NAME;
 import static org.folio.repository.providers.ProviderTableConstants.PROVIDERS_TABLE_NAME;
 import static org.folio.repository.resources.ResourceTableConstants.RESOURCES_TABLE_NAME;
 import static org.folio.repository.tag.TagTableConstants.TAGS_TABLE_NAME;
 import static org.folio.repository.titles.TitlesTableConstants.TITLES_TABLE_NAME;
-import static org.folio.tag.repository.resources.HoldingsTableConstants.HOLDINGS_TABLE;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -99,6 +100,10 @@ public class DbUtil {
 
   public static String getHoldingsTableName(String tenantId) {
     return getTableName(tenantId, HOLDINGS_TABLE);
+  }
+
+  public static String getHoldingsStatusTableName(String tenantId) {
+    return getTableName(tenantId, HOLDINGS_STATUS_TABLE);
   }
 
   public static <T> Optional<T> mapColumn(JsonObject row, String columnName, Class<T> tClass){

--- a/src/main/java/org/folio/repository/holdings/HoldingsRepositoryImpl.java
+++ b/src/main/java/org/folio/repository/holdings/HoldingsRepositoryImpl.java
@@ -7,9 +7,9 @@ import static org.folio.common.ListUtils.mapItems;
 import static org.folio.repository.DbUtil.executeInTransaction;
 import static org.folio.repository.DbUtil.getHoldingsTableName;
 import static org.folio.repository.DbUtil.mapColumn;
-import static org.folio.tag.repository.resources.HoldingsTableConstants.GET_HOLDINGS_BY_IDS;
-import static org.folio.tag.repository.resources.HoldingsTableConstants.INSERT_OR_UPDATE_HOLDINGS_STATEMENT;
-import static org.folio.tag.repository.resources.HoldingsTableConstants.REMOVE_FROM_HOLDINGS;
+import static org.folio.repository.holdings.HoldingsTableConstants.GET_HOLDINGS_BY_IDS;
+import static org.folio.repository.holdings.HoldingsTableConstants.INSERT_OR_UPDATE_HOLDINGS_STATEMENT;
+import static org.folio.repository.holdings.HoldingsTableConstants.REMOVE_FROM_HOLDINGS;
 
 import java.time.Instant;
 import java.util.List;
@@ -18,7 +18,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
-
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -29,7 +28,6 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.ext.sql.UpdateResult;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/org/folio/repository/holdings/HoldingsTableConstants.java
+++ b/src/main/java/org/folio/repository/holdings/HoldingsTableConstants.java
@@ -1,4 +1,4 @@
-package org.folio.tag.repository.resources;
+package org.folio.repository.holdings;
 
 public class HoldingsTableConstants {
   public static final String HOLDINGS_TABLE = "holdings";
@@ -13,6 +13,8 @@ public class HoldingsTableConstants {
   public static final String REMOVE_FROM_HOLDINGS = "DELETE FROM %s WHERE " + UPDATED_AT_COLUMN + " != timestamp with time zone '%s';";
 
   public static final String GET_HOLDINGS_BY_IDS = "SELECT * from %s WHERE id IN (%s);";
+
+  public static final String GET_HOLDINGS_COUNT = "SELECT COUNT(*) from %s";
 
   private HoldingsTableConstants() { }
 }

--- a/src/main/java/org/folio/repository/holdings/status/HoldingsLoadingStatusFactory.java
+++ b/src/main/java/org/folio/repository/holdings/status/HoldingsLoadingStatusFactory.java
@@ -1,0 +1,87 @@
+package org.folio.repository.holdings.status;
+
+import static org.folio.rest.util.RestConstants.JSONAPI;
+import static org.folio.rest.util.RestConstants.STATUS_RECTYPE;
+
+import java.util.List;
+
+import org.folio.rest.jaxrs.model.HoldingsLoadingStatus;
+import org.folio.rest.jaxrs.model.JsonapiErrorResponse;
+import org.folio.rest.jaxrs.model.LoadStatusAttributes;
+import org.folio.rest.jaxrs.model.LoadStatusData;
+import org.folio.rest.jaxrs.model.LoadStatusInformation;
+import org.folio.rest.jaxrs.model.LoadStatusNameDetailEnum;
+import org.folio.rest.jaxrs.model.LoadStatusNameEnum;
+
+public class HoldingsLoadingStatusFactory {
+
+  private HoldingsLoadingStatusFactory() {
+  }
+
+  public static HoldingsLoadingStatus getStatusNotStarted() {
+    return new HoldingsLoadingStatus()
+      .withData(new LoadStatusData()
+        .withType(STATUS_RECTYPE)
+        .withAttributes(new LoadStatusAttributes()
+          .withStatus(new LoadStatusInformation()
+            .withName(LoadStatusNameEnum.NOT_STARTED))))
+      .withJsonapi(JSONAPI);
+  }
+
+  public static HoldingsLoadingStatus getStatusStarted() {
+    return new HoldingsLoadingStatus()
+      .withData(new LoadStatusData()
+        .withType(STATUS_RECTYPE)
+        .withAttributes(new LoadStatusAttributes()
+          .withStatus(new LoadStatusInformation()
+            .withName(LoadStatusNameEnum.STARTED))))
+      .withJsonapi(JSONAPI);
+  }
+
+  public static HoldingsLoadingStatus getStatusPopulatingStagingArea() {
+    return new HoldingsLoadingStatus()
+      .withData(new LoadStatusData()
+        .withType(STATUS_RECTYPE)
+        .withAttributes(new LoadStatusAttributes()
+          .withStatus(new LoadStatusInformation()
+            .withName(LoadStatusNameEnum.IN_PROGRESS)
+            .withDetail(LoadStatusNameDetailEnum.POPULATING_STAGING_AREA))
+          .withErrors(null)))
+      .withJsonapi(JSONAPI);
+  }
+
+  public static HoldingsLoadingStatus getStatusLoadingHoldings(int totalCount, int importedCount) {
+    return new HoldingsLoadingStatus()
+      .withData(new LoadStatusData()
+        .withType(STATUS_RECTYPE)
+        .withAttributes(new LoadStatusAttributes()
+          .withStatus(new LoadStatusInformation()
+            .withName(LoadStatusNameEnum.IN_PROGRESS)
+            .withDetail(LoadStatusNameDetailEnum.LOADING_HOLDINGS))
+          .withTotalCount(totalCount)
+          .withImportedCount(importedCount)))
+      .withJsonapi(JSONAPI);
+  }
+
+  public static HoldingsLoadingStatus getStatusCompleted(int totalCount) {
+    return new HoldingsLoadingStatus()
+      .withData(new LoadStatusData()
+        .withType(STATUS_RECTYPE)
+        .withAttributes(new LoadStatusAttributes()
+          .withStatus(new LoadStatusInformation()
+            .withName(LoadStatusNameEnum.COMPLETED))
+          .withTotalCount(totalCount)))
+      .withJsonapi(JSONAPI);
+  }
+
+  public static HoldingsLoadingStatus getLoadStatusFailed(List<JsonapiErrorResponse> errors) {
+    return new HoldingsLoadingStatus()
+      .withData(new LoadStatusData()
+        .withType(STATUS_RECTYPE)
+        .withAttributes(new LoadStatusAttributes()
+          .withStatus(new LoadStatusInformation()
+            .withName(LoadStatusNameEnum.FAILED))
+          .withErrors(errors)))
+      .withJsonapi(JSONAPI);
+  }
+}

--- a/src/main/java/org/folio/repository/holdings/status/HoldingsStatusRepository.java
+++ b/src/main/java/org/folio/repository/holdings/status/HoldingsStatusRepository.java
@@ -1,0 +1,16 @@
+package org.folio.repository.holdings.status;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.rest.jaxrs.model.HoldingsLoadingStatus;
+
+public interface HoldingsStatusRepository {
+
+  CompletableFuture<HoldingsLoadingStatus> get(String tenantId);
+
+  CompletableFuture<Void> save(HoldingsLoadingStatus status, String tenantId);
+
+  CompletableFuture<Void> update(HoldingsLoadingStatus status, String tenantId);
+
+  CompletableFuture<Void> delete(String tenantId);
+}

--- a/src/main/java/org/folio/repository/holdings/status/HoldingsStatusRepositoryImpl.java
+++ b/src/main/java/org/folio/repository/holdings/status/HoldingsStatusRepositoryImpl.java
@@ -1,0 +1,88 @@
+package org.folio.repository.holdings.status;
+
+import static org.folio.common.FutureUtils.mapResult;
+import static org.folio.common.FutureUtils.mapVertxFuture;
+import static org.folio.common.ListUtils.createPlaceholders;
+import static org.folio.repository.DbUtil.getHoldingsStatusTableName;
+import static org.folio.repository.DbUtil.mapColumn;
+import static org.folio.repository.holdings.status.HoldingsStatusTableConstants.DELETE_LOADING_STATUS;
+import static org.folio.repository.holdings.status.HoldingsStatusTableConstants.GET_HOLDINGS_STATUS;
+import static org.folio.repository.holdings.status.HoldingsStatusTableConstants.INSERT_LOADING_STATUS;
+import static org.folio.repository.holdings.status.HoldingsStatusTableConstants.UPDATE_LOADING_STATUS;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.sql.UpdateResult;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.folio.rest.jaxrs.model.HoldingsLoadingStatus;
+import org.folio.rest.persist.PostgresClient;
+
+@Component
+public class HoldingsStatusRepositoryImpl implements HoldingsStatusRepository {
+  private static final Logger LOG = LoggerFactory.getLogger(HoldingsStatusRepositoryImpl.class);
+
+  private Vertx vertx;
+
+  @Autowired
+  public HoldingsStatusRepositoryImpl(Vertx vertx) {
+    this.vertx = vertx;
+  }
+
+  @Override
+  public CompletableFuture<HoldingsLoadingStatus> get(String tenantId) {
+
+    final String query = String.format(GET_HOLDINGS_STATUS, getHoldingsStatusTableName(tenantId));
+    PostgresClient postgresClient = PostgresClient.getInstance(vertx, tenantId);
+    LOG.info("Select holdings loading status = " + query);
+    Future<ResultSet> future = Future.future();
+    postgresClient.select(query, future);
+    return mapResult(future, this::mapStatus);
+  }
+
+  @Override
+  public CompletableFuture<Void> save(HoldingsLoadingStatus status, String tenantId) {
+
+    final String query = String.format(INSERT_LOADING_STATUS, getHoldingsStatusTableName(tenantId), createPlaceholders(2));
+    JsonArray parameters = new JsonArray().add(UUID.randomUUID().toString()).add(Json.encode(status));
+    LOG.info("Do insert query = " + query);
+    Future<UpdateResult> future = Future.future();
+    PostgresClient postgresClient = PostgresClient.getInstance(vertx, tenantId);
+    postgresClient.execute(query, parameters, future);
+    return mapVertxFuture(future).thenApply(result -> null);
+  }
+
+  @Override
+  public CompletableFuture<Void> update(HoldingsLoadingStatus status, String tenantId) {
+
+    final String query = String.format(UPDATE_LOADING_STATUS, getHoldingsStatusTableName(tenantId), Json.encode(status));
+    LOG.info("Do update query = " + query);
+    Future<UpdateResult> future = Future.future();
+    PostgresClient postgresClient = PostgresClient.getInstance(vertx, tenantId);
+    postgresClient.execute(query, future);
+    return mapVertxFuture(future).thenApply(result -> null);
+  }
+
+  @Override
+  public CompletableFuture<Void> delete(String tenantId) {
+    final String query = String.format(DELETE_LOADING_STATUS, getHoldingsStatusTableName(tenantId));
+    LOG.info("Do delete query = " + query);
+    Future<UpdateResult> future = Future.future();
+    PostgresClient postgresClient = PostgresClient.getInstance(vertx, tenantId);
+    postgresClient.execute(query, future);
+    return mapVertxFuture(future).thenApply(result -> null);
+  }
+
+  private HoldingsLoadingStatus mapStatus(ResultSet resultSet) {
+    return mapColumn(resultSet.getRows().get(0), "jsonb", HoldingsLoadingStatus.class).orElse(null);
+  }
+}

--- a/src/main/java/org/folio/repository/holdings/status/HoldingsStatusTableConstants.java
+++ b/src/main/java/org/folio/repository/holdings/status/HoldingsStatusTableConstants.java
@@ -1,0 +1,15 @@
+package org.folio.repository.holdings.status;
+
+public class HoldingsStatusTableConstants {
+
+  public static final String HOLDINGS_STATUS_TABLE = "holdings_status";
+  public static final String ID_COLUMN = "id";
+  public static final String JSONB_COLUMN = "jsonb";
+  public static final String GET_HOLDINGS_STATUS = "SELECT * from %s;";
+  public static final String HOLDINGS_STATUS_FIELD_LIST = String.format("%s, %s", ID_COLUMN, JSONB_COLUMN);
+  public static final String INSERT_LOADING_STATUS = "INSERT INTO %s (" + HOLDINGS_STATUS_FIELD_LIST + ") VALUES (%s);";
+  public static final String UPDATE_LOADING_STATUS = "UPDATE %s SET " + JSONB_COLUMN + " = '%s'::jsonb;";
+  public static final String DELETE_LOADING_STATUS = "DELETE FROM %s;";
+
+  private HoldingsStatusTableConstants() { }
+}

--- a/src/main/java/org/folio/repository/titles/DbTitle.java
+++ b/src/main/java/org/folio/repository/titles/DbTitle.java
@@ -1,11 +1,11 @@
-package org.folio.tag.repository.titles;
-
-import org.folio.holdingsiq.model.Title;
-import org.springframework.lang.NonNull;
-import org.springframework.lang.Nullable;
+package org.folio.repository.titles;
 
 import lombok.Builder;
 import lombok.Value;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+import org.folio.holdingsiq.model.Title;
 
 @Value
 @Builder

--- a/src/main/java/org/folio/repository/titles/TitlesRepository.java
+++ b/src/main/java/org/folio/repository/titles/TitlesRepository.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.holdingsiq.model.Title;
-import org.folio.tag.repository.titles.DbTitle;
 
 public interface TitlesRepository {
 

--- a/src/main/java/org/folio/repository/titles/TitlesRepositoryImpl.java
+++ b/src/main/java/org/folio/repository/titles/TitlesRepositoryImpl.java
@@ -27,7 +27,6 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.UpdateResult;
-
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -36,7 +35,6 @@ import org.folio.holdingsiq.model.Title;
 import org.folio.repository.holdings.HoldingInfoInDB;
 import org.folio.repository.resources.ResourceTableConstants;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.tag.repository.titles.DbTitle;
 
 @Component
 public class TitlesRepositoryImpl implements TitlesRepository {

--- a/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
@@ -15,7 +15,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +32,7 @@ import org.folio.holdingsiq.service.validator.TitleParametersValidator;
 import org.folio.repository.RecordType;
 import org.folio.repository.tag.Tag;
 import org.folio.repository.tag.TagRepository;
+import org.folio.repository.titles.DbTitle;
 import org.folio.repository.titles.TitlesRepository;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.aspect.HandleValidationErrors;
@@ -53,7 +53,6 @@ import org.folio.rest.validator.TitlesPostAttributesValidator;
 import org.folio.rest.validator.TitlesPostBodyValidator;
 import org.folio.rmapi.result.TitleResult;
 import org.folio.spring.SpringContextUtil;
-import org.folio.tag.repository.titles.DbTitle;
 
 public class EholdingsTitlesImpl implements EholdingsTitles {
   private static final String GET_TITLE_NOT_FOUND_MESSAGE = "Title not found";

--- a/src/main/java/org/folio/rest/impl/TenantApiImpl.java
+++ b/src/main/java/org/folio/rest/impl/TenantApiImpl.java
@@ -1,23 +1,33 @@
 package org.folio.rest.impl;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
-import org.folio.rest.annotations.Validate;
-import org.folio.rest.jaxrs.model.TenantAttributes;
-import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.tools.utils.TenantTool;
-import javax.ws.rs.core.Response;
+import static org.folio.repository.holdings.status.HoldingsLoadingStatusFactory.getStatusNotStarted;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import javax.ws.rs.core.Response;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.folio.repository.holdings.status.HoldingsStatusRepository;
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.TenantTool;
+import org.folio.spring.SpringContextUtil;
 
 public class TenantApiImpl extends TenantAPI {
 
@@ -28,17 +38,44 @@ public class TenantApiImpl extends TenantAPI {
   private static final String TEST_MODE = "test.mode";
   private final Logger logger = LoggerFactory.getLogger(TenantApiImpl.class);
 
+  @Autowired
+  private HoldingsStatusRepository holdingsStatusRepository;
+
+  public TenantApiImpl() {
+    super();
+    SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
+  }
+
   @Validate
   @Override
   public void postTenant(TenantAttributes entity, Map<String, String> headers, Handler<AsyncResult<Response>> handlers,
                          Context context) {
-    super.postTenant(entity, headers, result -> {
-      if (result.failed()) {
-        handlers.handle(result);
-      } else {
-        setupTestData(headers, context).setHandler(event -> handlers.handle(result));
-      }
-    }, context);
+
+    Future<Response> future = Future.future();
+    super.postTenant(entity, headers, future, context);
+
+    future.compose(response -> setupTestData(headers, context).map(response))
+      .compose(response -> setLoadingStatus(headers).map(response))
+      .setHandler(handlers);
+  }
+
+
+
+  private Future<Void> setLoadingStatus(Map<String, String> headers) {
+
+    Future<Void> future = Future.future();
+    setStatusNotStarted(TenantTool.tenantId(headers))
+      .thenAccept(future::complete)
+      .exceptionally(e -> {
+        future.fail(e.getCause());
+        return null;
+      });
+    return future;
+  }
+
+  private CompletableFuture<Void> setStatusNotStarted(String tenantId) {
+    return holdingsStatusRepository.delete(tenantId)
+      .thenCompose(o -> holdingsStatusRepository.save(getStatusNotStarted(), tenantId));
   }
 
   private Future<List<String>> setupTestData(Map<String, String> headers, Context context) {
@@ -61,7 +98,7 @@ public class TenantApiImpl extends TenantAPI {
         return Future.succeededFuture();
       }
 
-      String tenantId = TenantTool.calculateTenantId(headers.get(OKAPI_TENANT_HEADER));
+      String tenantId = TenantTool.tenantId(headers);
       String moduleName = PostgresClient.getModuleName();
 
       sqlScript = sqlScript.replace(TENANT_PLACEHOLDER, tenantId).replace(MODULE_PLACEHOLDER, moduleName);

--- a/src/main/java/org/folio/rest/util/RestConstants.java
+++ b/src/main/java/org/folio/rest/util/RestConstants.java
@@ -22,6 +22,7 @@ public final class RestConstants {
   public static final String PACKAGE_RECTYPE = "package";
   public static final String TITLE_RECTYPE = "title";
   public static final String RESOURCE_RECTYPE = "resource";
+  public static final String STATUS_RECTYPE = "status";
 
   public static final Map<String, String> FILTER_SELECTED_MAPPING =
     ImmutableMap.of(

--- a/src/main/java/org/folio/service/holdings/HoldingsService.java
+++ b/src/main/java/org/folio/service/holdings/HoldingsService.java
@@ -8,7 +8,8 @@ import org.folio.repository.resources.ResourceInfoInDB;
 import org.folio.rest.util.template.RMAPITemplateContext;
 
 public interface HoldingsService {
-  CompletableFuture<Void> loadHoldings(RMAPITemplateContext context, String tenantId);
+
+  CompletableFuture<Void> loadHoldings(RMAPITemplateContext context);
 
   CompletableFuture<List<HoldingInfoInDB>> getHoldingsByIds(List<ResourceInfoInDB> resourcesResult, String tenant);
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -47,6 +47,20 @@
       "withMetadata": false,
       "withAuditing": false,
       "customSnippetPath": "create-holdings-table.sql"
+    },
+    {
+      "tableName": "holdings_status",
+      "pkColumnName": "id",
+      "generateId": false,
+      "withMetadata": false,
+      "withAuditing": false
+    }
+  ],
+  "scripts": [
+    {
+    "run": "after",
+    "snippet": "CREATE OR REPLACE FUNCTION update_started_date_before_insertion()    RETURNS TRIGGER  AS $$   DECLARE      started text;      finished text;      status text;   BEGIN     status = NEW.jsonb->'data'->'attributes'->'status'->>'name';       IF status = 'Started' THEN       started = '\"' || CURRENT_TIMESTAMP(2) || '\"';       NEW.jsonb = jsonb_set(NEW.jsonb, '{data,attributes,started}' ,  started::jsonb);     end IF;       IF status = 'Completed' THEN         finished = '\"' || CURRENT_TIMESTAMP(2) || '\"';       NEW.jsonb = jsonb_set(NEW.jsonb, '{data,attributes,finished}' ,  finished::jsonb);     end IF;       IF status = 'In Progress' OR status = 'Completed' THEN         started = to_json(OLD.jsonb->'data'->'attributes'->>'started');       NEW.jsonb = jsonb_set(NEW.jsonb, '{data,attributes,started}' ,  started::jsonb);       ELSE NEW.jsonb = NEW.jsonb;     end IF;   RETURN NEW;   END;  $$  language 'plpgsql';    DROP TRIGGER IF EXISTS  update_started_date_before_insertion_trigger ON holdings_status CASCADE;    CREATE TRIGGER  update_started_date_before_insertion_trigger BEFORE UPDATE ON holdings_status  FOR EACH ROW EXECUTE PROCEDURE update_started_date_before_insertion();",
+    "fromModuleVersion": "1.0"
     }
   ]
 }

--- a/src/main/resources/templates/db_scripts/update_started_date_before_insertion.sql
+++ b/src/main/resources/templates/db_scripts/update_started_date_before_insertion.sql
@@ -1,0 +1,41 @@
+-- Custom script to add an additional column startedDate for holdings_status table.
+-- Changes in this file will not result in an update of the function.
+-- To change the function, update this script and copy it to the appropriate scripts.snippet field of the schema.json
+
+CREATE OR REPLACE FUNCTION update_started_date_before_insertion()
+  RETURNS TRIGGER
+AS $$
+ DECLARE
+    started text;
+    finished text;
+    status text;
+ BEGIN
+   status = NEW.jsonb->'data'->'attributes'->'status'->>'name';
+
+   IF status = 'Started' THEN
+     started = '"' || CURRENT_TIMESTAMP(2) || '"';
+     NEW.jsonb = jsonb_set(NEW.jsonb, '{data,attributes,started}' ,  started::jsonb);
+   end IF;
+
+   IF status = 'Completed' THEN
+
+     finished = '"' || CURRENT_TIMESTAMP(2) || '"';
+     NEW.jsonb = jsonb_set(NEW.jsonb, '{data,attributes,finished}' ,  finished::jsonb);
+   end IF;
+
+   IF status = 'In Progress' OR status = 'Completed' THEN
+
+     started = to_json(OLD.jsonb->'data'->'attributes'->>'started');
+     NEW.jsonb = jsonb_set(NEW.jsonb, '{data,attributes,started}' ,  started::jsonb);
+
+   ELSE NEW.jsonb = NEW.jsonb;
+   end IF;
+ RETURN NEW;
+ END;
+$$
+language 'plpgsql';
+
+DROP TRIGGER IF EXISTS  update_started_date_before_insertion_trigger ON holdings_status CASCADE;
+
+CREATE TRIGGER  update_started_date_before_insertion_trigger BEFORE UPDATE ON holdings_status
+FOR EACH ROW EXECUTE PROCEDURE update_started_date_before_insertion();

--- a/src/test/java/org/folio/repository/titles/TitleRepositoryImplTest.java
+++ b/src/test/java/org/folio/repository/titles/TitleRepositoryImplTest.java
@@ -16,7 +16,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import org.folio.spring.config.TestConfig;
-import org.folio.tag.repository.titles.DbTitle;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = TestConfig.class)

--- a/src/test/java/org/folio/rest/impl/EholdingsTitlesTest.java
+++ b/src/test/java/org/folio/rest/impl/EholdingsTitlesTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import static org.folio.repository.holdings.HoldingsTableConstants.HOLDINGS_TABLE;
 import static org.folio.repository.titles.TitlesTableConstants.TITLES_TABLE_NAME;
 import static org.folio.rest.impl.PackagesTestData.STUB_PACKAGE_ID;
 import static org.folio.rest.impl.ProvidersTestData.STUB_VENDOR_ID;
@@ -36,7 +37,6 @@ import static org.folio.rest.impl.TitlesTestData.STUB_CUSTOM_TITLE_ID;
 import static org.folio.rest.impl.TitlesTestData.STUB_CUSTOM_TITLE_NAME;
 import static org.folio.rest.impl.TitlesTestData.STUB_TITLE_ID;
 import static org.folio.rest.impl.TitlesTestData.STUB_TITLE_NAME;
-import static org.folio.tag.repository.resources.HoldingsTableConstants.HOLDINGS_TABLE;
 import static org.folio.util.TestUtil.mockDefaultConfiguration;
 import static org.folio.util.TestUtil.mockGet;
 import static org.folio.util.TestUtil.readFile;
@@ -55,13 +55,11 @@ import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
-
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.vertx.core.json.Json;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;

--- a/src/test/java/org/folio/rest/impl/IntegrationTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/IntegrationTestSuite.java
@@ -18,7 +18,8 @@ import org.junit.runners.Suite;
   EholdingsStatusTest.class,
   EholdingsTitlesTest.class,
   EholdingsTagsImplTest.class,
-  LoadHoldingsImplTest.class
+  LoadHoldingsImplTest.class,
+  LoadHoldingsStatusImplTest.class
 })
 @RunWith(Suite.class)
 public class IntegrationTestSuite {

--- a/src/test/java/org/folio/rest/impl/LoadHoldingsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/LoadHoldingsImplTest.java
@@ -8,6 +8,7 @@ import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+import static org.folio.repository.holdings.status.HoldingsStatusTableConstants.HOLDINGS_STATUS_TABLE;
 import static org.folio.util.TestUtil.mockDefaultConfiguration;
 import static org.folio.util.TestUtil.mockGet;
 import static org.folio.util.TestUtil.readFile;
@@ -22,79 +23,88 @@ import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
-
 import io.vertx.core.json.Json;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.folio.repository.holdings.HoldingInfoInDB;
+import org.folio.util.HoldingsStatusUtil;
 import org.folio.util.HoldingsTestUtil;
+import org.folio.util.TestUtil;
 
 @RunWith(VertxUnitRunner.class)
 public class LoadHoldingsImplTest extends WireMockTestBase {
 
-  private static final String HOLDINGS_STATUS_ENDPOINT = "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/holdings/status";
-  private static final String HOLDINGS_POST_HOLDINGS_ENDPOINT = "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/holdings";
-  private static final String HOLDINGS_GET_ENDPOINT = "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/holdings";
-  private static final String LOAD_HOLDINGS_ENDPOINT = "loadHoldings";
+  static final String HOLDINGS_STATUS_ENDPOINT = "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/holdings/status";
+  static final String HOLDINGS_POST_HOLDINGS_ENDPOINT = "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/holdings";
+  static final String HOLDINGS_GET_ENDPOINT = "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/holdings";
+  static final String LOAD_HOLDINGS_ENDPOINT = "loadHoldings";
   private static final String GET_HOLDINGS_SCENARIO = "Get holdings";
   private static final String COMPLETED_STATE = "Completed state";
 
   @Test
   public void shouldSaveHoldings() throws IOException, URISyntaxException {
+    try {
+      mockDefaultConfiguration(getWiremockUrl());
 
-    mockDefaultConfiguration(getWiremockUrl());
+      mockGet(new EqualToPattern(HOLDINGS_STATUS_ENDPOINT), "responses/rmapi/holdings/status/get-status-completed.json");
 
-    mockGet(new EqualToPattern(HOLDINGS_STATUS_ENDPOINT), "responses/rmapi/holdings/status/get-status-completed.json");
+      stubFor(
+        post(new UrlPathPattern(new EqualToPattern(HOLDINGS_POST_HOLDINGS_ENDPOINT), false))
+          .willReturn(new ResponseDefinitionBuilder()
+            .withBody("")
+            .withStatus(202)));
 
-    stubFor(
-      post(new UrlPathPattern(new EqualToPattern(HOLDINGS_POST_HOLDINGS_ENDPOINT), false))
-        .willReturn(new ResponseDefinitionBuilder()
-          .withBody("")
-          .withStatus(202)));
+      mockGet(new RegexPattern(HOLDINGS_GET_ENDPOINT), "responses/rmapi/holdings/holdings/get-holdings.json");
 
-    mockGet(new RegexPattern(HOLDINGS_GET_ENDPOINT), "responses/rmapi/holdings/holdings/get-holdings.json");
+      postWithStatus(LOAD_HOLDINGS_ENDPOINT, "", SC_NO_CONTENT);
 
-    postWithStatus(LOAD_HOLDINGS_ENDPOINT, "", SC_NO_CONTENT);
-
-    final List<HoldingInfoInDB> holdingsList = HoldingsTestUtil.getHoldings(vertx);
-    assertThat(holdingsList.size(), Matchers.notNullValue());
-
+      final List<HoldingInfoInDB> holdingsList = HoldingsTestUtil.getHoldings(vertx);
+      assertThat(holdingsList.size(), Matchers.notNullValue());
+    } finally {
+      TestUtil.clearDataFromTable(vertx, HOLDINGS_STATUS_TABLE);
+      HoldingsStatusUtil.insertStatusNotStarted(vertx);
+    }
   }
 
   @Test
   public void shouldWaitForCompleteStatusAndLoadHoldings() throws IOException, URISyntaxException {
-    mockDefaultConfiguration(getWiremockUrl());
+    try {
+      mockDefaultConfiguration(getWiremockUrl());
 
-    stubFor(get(new UrlPathPattern(new RegexPattern(HOLDINGS_STATUS_ENDPOINT), true))
-      .inScenario(GET_HOLDINGS_SCENARIO)
-      .whenScenarioStateIs(STARTED)
-      .willReturn(new ResponseDefinitionBuilder()
-        .withBody(readFile("responses/rmapi/holdings/status/get-status-in-progress.json")))
-      .willSetStateTo(COMPLETED_STATE));
+      stubFor(get(new UrlPathPattern(new RegexPattern(HOLDINGS_STATUS_ENDPOINT), true)).inScenario(GET_HOLDINGS_SCENARIO)
+        .whenScenarioStateIs(STARTED)
+        .willReturn(new ResponseDefinitionBuilder()
+          .withBody(readFile(
+              "responses/rmapi/holdings/status/get-status-in-progress.json")))
+        .willSetStateTo(COMPLETED_STATE));
 
-    stubFor(get(new UrlPathPattern(new RegexPattern(HOLDINGS_STATUS_ENDPOINT), true))
-      .inScenario(GET_HOLDINGS_SCENARIO)
-      .whenScenarioStateIs(COMPLETED_STATE)
-      .willReturn(new ResponseDefinitionBuilder()
-        .withBody(readFile("responses/rmapi/holdings/status/get-status-completed.json"))));
+      stubFor(get(new UrlPathPattern(new RegexPattern(HOLDINGS_STATUS_ENDPOINT), true)).inScenario(GET_HOLDINGS_SCENARIO)
+        .whenScenarioStateIs(COMPLETED_STATE)
+        .willReturn(new ResponseDefinitionBuilder()
+          .withBody(readFile("responses/rmapi/holdings/status/get-status-completed.json"))));
 
-    mockGet(new RegexPattern(HOLDINGS_GET_ENDPOINT), "responses/rmapi/holdings/holdings/get-holdings.json");
+      mockGet(new RegexPattern(HOLDINGS_GET_ENDPOINT), "responses/rmapi/holdings/holdings/get-holdings.json");
 
-    postWithStatus(LOAD_HOLDINGS_ENDPOINT, "", SC_NO_CONTENT);
+      postWithStatus(LOAD_HOLDINGS_ENDPOINT, "", SC_NO_CONTENT);
 
-    final List<HoldingInfoInDB> holdingsList = HoldingsTestUtil.getHoldings(vertx);
-    assertThat(holdingsList.size(), equalTo(2));
+      final List<HoldingInfoInDB> holdingsList = HoldingsTestUtil.getHoldings(vertx);
+      assertThat(holdingsList.size(), equalTo(2));
+    } finally {
+      TestUtil.clearDataFromTable(vertx, HOLDINGS_STATUS_TABLE);
+      HoldingsStatusUtil.insertStatusNotStarted(vertx);
+    }
   }
 
   @Test
   public void shouldSaveHoldingsAndClearOldEntries() throws IOException, URISyntaxException {
+    try {
+
       mockDefaultConfiguration(getWiremockUrl());
       HoldingsTestUtil.addHolding(vertx, Json.decodeValue(readFile("responses/kb-ebsco/holdings/custom-holding.json"),
-          HoldingInfoInDB.class), Instant.now().minus(Duration.ofDays(2)));
+        HoldingInfoInDB.class), Instant.now().minus(Duration.ofDays(2)));
 
       mockGet(new EqualToPattern(HOLDINGS_STATUS_ENDPOINT), "responses/rmapi/holdings/status/get-status-completed.json");
 
@@ -109,6 +119,9 @@ public class LoadHoldingsImplTest extends WireMockTestBase {
 
       final List<HoldingInfoInDB> holdingsList = HoldingsTestUtil.getHoldings(vertx);
       assertThat(holdingsList.size(), equalTo(2));
+    } finally {
+      TestUtil.clearDataFromTable(vertx, HOLDINGS_STATUS_TABLE);
+      HoldingsStatusUtil.insertStatusNotStarted(vertx);
+    }
   }
-
 }

--- a/src/test/java/org/folio/rest/impl/LoadHoldingsStatusImplTest.java
+++ b/src/test/java/org/folio/rest/impl/LoadHoldingsStatusImplTest.java
@@ -1,0 +1,110 @@
+package org.folio.rest.impl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static java.time.ZonedDateTime.parse;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.apache.http.HttpStatus.SC_NO_CONTENT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+
+import static org.folio.repository.holdings.status.HoldingsStatusTableConstants.HOLDINGS_STATUS_TABLE;
+import static org.folio.rest.impl.LoadHoldingsImplTest.HOLDINGS_GET_ENDPOINT;
+import static org.folio.rest.impl.LoadHoldingsImplTest.HOLDINGS_POST_HOLDINGS_ENDPOINT;
+import static org.folio.rest.impl.LoadHoldingsImplTest.LOAD_HOLDINGS_ENDPOINT;
+import static org.folio.util.TestUtil.mockDefaultConfiguration;
+import static org.folio.util.TestUtil.mockEmptyConfiguration;
+import static org.folio.util.TestUtil.mockGet;
+import static org.folio.util.TestUtil.readFile;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+import io.vertx.core.json.Json;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.folio.repository.holdings.HoldingInfoInDB;
+import org.folio.rest.jaxrs.model.HoldingsLoadingStatus;
+import org.folio.util.HoldingsStatusUtil;
+import org.folio.util.HoldingsTestUtil;
+import org.folio.util.TestUtil;
+
+@RunWith(VertxUnitRunner.class)
+public class LoadHoldingsStatusImplTest extends WireMockTestBase {
+
+  public static final String HOLDINGS_STATUS_ENDPOINT = LOAD_HOLDINGS_ENDPOINT + "/status";
+
+  @Test
+  public void shouldReturnStatusNotStarted() throws IOException, URISyntaxException {
+    mockDefaultConfiguration(getWiremockUrl());
+    final HoldingsLoadingStatus status = getWithOk(HOLDINGS_STATUS_ENDPOINT).body().as(HoldingsLoadingStatus.class);
+    assertThat(status.getData().getAttributes().getStatus().getName().value(), equalToIgnoringWhiteSpace("Not Started"));
+  }
+
+  @Test
+  public void shouldReturnStatusCompleted() throws IOException, URISyntaxException {
+    try {
+      mockDefaultConfiguration(getWiremockUrl());
+
+      HoldingsTestUtil.addHolding(vertx, Json.decodeValue(readFile("responses/kb-ebsco/holdings/custom-holding.json"),
+        HoldingInfoInDB.class), Instant.now().minus(Duration.ofDays(2)));
+
+      mockGet(new EqualToPattern(LoadHoldingsImplTest.HOLDINGS_STATUS_ENDPOINT), "responses/rmapi/holdings/status/get-status-completed.json");
+
+      stubFor(post(new UrlPathPattern(new EqualToPattern(HOLDINGS_POST_HOLDINGS_ENDPOINT), false))
+        .willReturn(new ResponseDefinitionBuilder()
+          .withBody("")
+          .withStatus(202)));
+
+      mockGet(new RegexPattern(HOLDINGS_GET_ENDPOINT), "responses/rmapi/holdings/holdings/get-holdings.json");
+
+      postWithStatus(LOAD_HOLDINGS_ENDPOINT, "", SC_NO_CONTENT);
+      final HoldingsLoadingStatus status = getWithOk(HOLDINGS_STATUS_ENDPOINT).body().as(HoldingsLoadingStatus.class);
+
+      assertThat(status.getData().getType(), equalTo("status"));
+      assertThat(status.getData().getAttributes().getTotalCount(), equalTo(2));
+      assertThat(status.getData().getAttributes().getStatus().getName().value(), equalToIgnoringCase("Completed"));
+      DateTimeFormatter f = getFormatter();
+
+      org.junit.Assert.assertTrue(parse(status.getData().getAttributes().getStarted().replace(" ", "T"), f)
+        .isBefore(parse(status.getData().getAttributes().getFinished().replace(" ", "T"), f)));
+    } finally {
+      TestUtil.clearDataFromTable(vertx, HOLDINGS_STATUS_TABLE);
+      HoldingsStatusUtil.insertStatusNotStarted(vertx);
+    }
+  }
+
+  @Test
+  public void shouldReturnErrorWhenNoConfiguration() throws IOException, URISyntaxException {
+    try {
+      mockEmptyConfiguration(getWiremockUrl());
+      postWithStatus(LOAD_HOLDINGS_ENDPOINT, "", SC_INTERNAL_SERVER_ERROR);
+      final HoldingsLoadingStatus status = getWithOk(HOLDINGS_STATUS_ENDPOINT).body().as(HoldingsLoadingStatus.class);
+      assertThat(status.getData().getAttributes().getStatus().getName().value(), equalToIgnoringCase("Failed"));
+
+    } finally {
+      TestUtil.clearDataFromTable(vertx, HOLDINGS_STATUS_TABLE);
+      HoldingsStatusUtil.insertStatusNotStarted(vertx);
+    }
+  }
+
+  private DateTimeFormatter getFormatter() {
+    return new DateTimeFormatterBuilder()
+      .parseCaseInsensitive()
+      .append(ISO_LOCAL_DATE_TIME)
+      .appendOffset("+HH", "Z").toFormatter();
+  }
+}

--- a/src/test/java/org/folio/util/HoldingsStatusUtil.java
+++ b/src/test/java/org/folio/util/HoldingsStatusUtil.java
@@ -1,0 +1,33 @@
+package org.folio.util;
+
+import static org.folio.repository.holdings.HoldingsTableConstants.JSONB_COLUMN;
+import static org.folio.repository.holdings.status.HoldingsLoadingStatusFactory.getStatusNotStarted;
+import static org.folio.repository.holdings.status.HoldingsStatusTableConstants.HOLDINGS_STATUS_TABLE;
+import static org.folio.repository.holdings.status.HoldingsStatusTableConstants.ID_COLUMN;
+import static org.folio.util.TestUtil.STUB_TENANT;
+
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+
+import org.folio.rest.jaxrs.model.HoldingsLoadingStatus;
+import org.folio.rest.persist.PostgresClient;
+
+public class HoldingsStatusUtil {
+
+  public static HoldingsLoadingStatus insertStatusNotStarted(Vertx vertx) {
+    CompletableFuture<HoldingsLoadingStatus> future = new CompletableFuture<>();
+    PostgresClient.getInstance(vertx)
+      .execute("INSERT INTO " + holdingsStatusTestTable() + " (" + ID_COLUMN + ", " + JSONB_COLUMN + " ) VALUES (?,?)",
+        new JsonArray(Arrays.asList(UUID.randomUUID().toString(), Json.encode(getStatusNotStarted()))),
+         event -> future.complete(null));
+    return future.join();
+  }
+  private static String holdingsStatusTestTable() {
+    return PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + HOLDINGS_STATUS_TABLE;
+  }
+}

--- a/src/test/java/org/folio/util/HoldingsTestUtil.java
+++ b/src/test/java/org/folio/util/HoldingsTestUtil.java
@@ -1,9 +1,9 @@
 package org.folio.util;
 
-import static org.folio.tag.repository.resources.HoldingsTableConstants.HOLDINGS_TABLE;
-import static org.folio.tag.repository.resources.HoldingsTableConstants.ID_COLUMN;
-import static org.folio.tag.repository.resources.HoldingsTableConstants.JSONB_COLUMN;
-import static org.folio.tag.repository.resources.HoldingsTableConstants.UPDATED_AT_COLUMN;
+import static org.folio.repository.holdings.HoldingsTableConstants.HOLDINGS_TABLE;
+import static org.folio.repository.holdings.HoldingsTableConstants.ID_COLUMN;
+import static org.folio.repository.holdings.HoldingsTableConstants.JSONB_COLUMN;
+import static org.folio.repository.holdings.HoldingsTableConstants.UPDATED_AT_COLUMN;
 import static org.folio.util.TestUtil.STUB_TENANT;
 import static org.folio.util.TestUtil.readFile;
 
@@ -16,7 +16,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;


### PR DESCRIPTION
## Purpose
Due to https://issues.folio.org/browse/MODKBEKBJ-285 we want to have the ability to track loading status during holdings loading.

## Approach
* added new endpoint definition to descriptor and raml files
* added database trigger to have started date equal during all holdings loading stages
* added implementation form GET /loadHoldings/status endpoint
* added tests

