### PR TITLE
MODKBEKBJ-283 - Remove update of package tags from package endpoints

### DIFF
--- a/ramls/types/packages/packagePostDataAttributes.json
+++ b/ramls/types/packages/packagePostDataAttributes.json
@@ -20,11 +20,6 @@
       "type": "object",
       "description": "Custom Coverage",
       "$ref": "../coverage.json"
-    },
-    "tags": {
-      "type": "object",
-      "description": "Package tags",
-      "$ref": "../../raml-util/schemas/tags.schema"
     }
   },
   "required": [

--- a/ramls/types/packages/packagePutData.json
+++ b/ramls/types/packages/packagePutData.json
@@ -21,7 +21,7 @@
     "attributes": {
       "description": "Data type attributes",
       "type": "object",
-      "$ref": "packageDataAttributes.json"
+      "$ref": "packagePutDataAttributes.json"
     }
   },
   "required": [

--- a/ramls/types/packages/packagePutDataAttributes.json
+++ b/ramls/types/packages/packagePutDataAttributes.json
@@ -2,61 +2,55 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Package Put Data attributes schema",
   "description": "Package Put Data attributes schema",
-  "type": "object",
   "javaType": "org.folio.rest.jaxrs.model.PackagePutDataAttributes",
+  "type": "object",
   "additionalProperties": false,
   "properties": {
-    "name": {
-      "type": "string",
-      "description": "Package name",
-      "example": "Advanced Placement Psychology Collection"
-    },
     "contentType": {
       "type": "string",
-      "description": "Package type",
-      "enum": [
-        "Aggregated Full Text",
-        "Abstract and Index",
-        "E-Book",
-        "E-Journal",
-        "Print",
-        "Online Reference",
-        "Unknown"],
-      "example": "E-Journal"
+      "description": "Content Type of Package",
+      "$ref" : "contentTypeEnum.json",
+      "example": "Online Reference"
     },
     "customCoverage": {
       "type": "object",
       "description": "Custom Coverage",
       "$ref": "../coverage.json"
     },
-    "isSelected": {
+    "isCustom": {
       "type": "boolean",
-      "description": "Selection of the managed or custom package to be updated. Note that selection can be updated for BOTH CUSTOM AND MANAGED PACKAGES. For custom packages, if this is set to false, it deletes the package.",
+      "description": "Whether this package is custom or not",
       "example": false
     },
-    "allowKbToAddTitles": {
+    "isSelected": {
       "type": "boolean",
-      "description": "Automatically allow KB to add titles for a managed package. Note that this attribute can be updated ONLY FOR A MANAGED PACKAGE.",
-      "example": true
+      "description": "Whether this package is selected or not",
+      "example": false
+    },
+    "name": {
+      "type": "string",
+      "description": "Package name",
+      "example": "Shenbao"
     },
     "visibilityData": {
       "type": "object",
       "description": "Visibility data",
       "$ref": "../visibilityData.json"
     },
+    "allowKbToAddTitles": {
+      "type": "boolean",
+      "description": "Allow KB to add titles",
+      "example": true
+    },
     "packageToken": {
       "type": "object",
-      "description": "Tokens are variables in content URLs that identify the customer. The token is text within the URL that needs to be replaced with an institute-specific value.",
-      "$ref": "../tokenPut.json"
+      "description": "Package Token",
+      "$ref": "../token.json"
     },
     "proxy": {
       "type": "object",
       "description": "Proxy",
-      "$ref": "../proxyPut.json"
+      "$ref": "../proxy.json"
     }
-  },
-  "required": [
-    "name",
-    "contentType"
-  ]
+  }
 }

--- a/src/main/java/org/folio/rest/converter/packages/PackageRequestConverter.java
+++ b/src/main/java/org/folio/rest/converter/packages/PackageRequestConverter.java
@@ -7,14 +7,14 @@ import org.springframework.stereotype.Component;
 import org.folio.holdingsiq.model.CoverageDates;
 import org.folio.holdingsiq.model.PackagePut;
 import org.folio.holdingsiq.model.TokenInfo;
-import org.folio.rest.jaxrs.model.PackageDataAttributes;
+import org.folio.rest.jaxrs.model.PackagePutDataAttributes;
 import org.folio.rest.jaxrs.model.PackagePutRequest;
 
 @Component
 public class PackageRequestConverter {
 
   public PackagePut convertToRMAPICustomPackagePutRequest(PackagePutRequest request) {
-    PackageDataAttributes attributes = request.getData().getAttributes();
+    PackagePutDataAttributes attributes = request.getData().getAttributes();
     PackagePut.PackagePutBuilder builder = convertCommonAttributesToPackagePutRequest(attributes);
     builder.packageName(attributes.getName());
     Integer contentType = contentTypeToRMAPICode.get(attributes.getContentType());
@@ -23,7 +23,7 @@ public class PackageRequestConverter {
   }
 
   public PackagePut convertToRMAPIPackagePutRequest(PackagePutRequest request) {
-    PackageDataAttributes attributes = request.getData().getAttributes();
+    PackagePutDataAttributes attributes = request.getData().getAttributes();
     PackagePut.PackagePutBuilder builder = convertCommonAttributesToPackagePutRequest(attributes);
     builder.allowEbscoToAddTitles(attributes.getAllowKbToAddTitles());
     if (attributes.getPackageToken() != null) {
@@ -35,7 +35,7 @@ public class PackageRequestConverter {
     return builder.build();
   }
 
-  private PackagePut.PackagePutBuilder convertCommonAttributesToPackagePutRequest(PackageDataAttributes attributes) {
+  private PackagePut.PackagePutBuilder convertCommonAttributesToPackagePutRequest(PackagePutDataAttributes attributes) {
     PackagePut.PackagePutBuilder builder = PackagePut.builder();
 
     builder.isSelected(attributes.getIsSelected());

--- a/src/main/java/org/folio/rest/validator/CustomPackagePutBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/CustomPackagePutBodyValidator.java
@@ -1,10 +1,11 @@
 package org.folio.rest.validator;
 
+import org.springframework.stereotype.Component;
+
 import org.folio.rest.exception.InputValidationException;
 import org.folio.rest.jaxrs.model.ContentType;
-import org.folio.rest.jaxrs.model.PackageDataAttributes;
+import org.folio.rest.jaxrs.model.PackagePutDataAttributes;
 import org.folio.rest.jaxrs.model.PackagePutRequest;
-import org.springframework.stereotype.Component;
 
 @Component
 public class CustomPackagePutBodyValidator
@@ -18,7 +19,7 @@ public class CustomPackagePutBodyValidator
       request.getData().getAttributes() == null) {
       throw new InputValidationException(INVALID_REQUEST_BODY_TITLE, INVALID_REQUEST_BODY_DETAILS);
     }
-    PackageDataAttributes attributes = request.getData().getAttributes();
+    PackagePutDataAttributes attributes = request.getData().getAttributes();
     String name = attributes.getName();
     ContentType contentType = attributes.getContentType();
 

--- a/src/main/java/org/folio/rest/validator/PackagePutBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/PackagePutBodyValidator.java
@@ -1,9 +1,10 @@
 package org.folio.rest.validator;
 
-import org.folio.rest.exception.InputValidationException;
-import org.folio.rest.jaxrs.model.PackageDataAttributes;
-import org.folio.rest.jaxrs.model.PackagePutRequest;
 import org.springframework.stereotype.Component;
+
+import org.folio.rest.exception.InputValidationException;
+import org.folio.rest.jaxrs.model.PackagePutDataAttributes;
+import org.folio.rest.jaxrs.model.PackagePutRequest;
 
 @Component
 public class PackagePutBodyValidator {
@@ -18,7 +19,7 @@ public class PackagePutBodyValidator {
       request.getData().getAttributes() == null) {
       throw new InputValidationException(INVALID_REQUEST_BODY_TITLE, INVALID_REQUEST_BODY_DETAILS);
     }
-    PackageDataAttributes attributes = request.getData().getAttributes();
+    PackagePutDataAttributes attributes = request.getData().getAttributes();
     Boolean isSelected = attributes.getIsSelected();
     Boolean allowKbToAddTitles = attributes.getAllowKbToAddTitles();
 

--- a/src/main/java/org/folio/rmapi/result/PackageResult.java
+++ b/src/main/java/org/folio/rmapi/result/PackageResult.java
@@ -21,13 +21,6 @@ public class PackageResult {
     this.titles = titles;
   }
 
-  public PackageResult(PackageByIdData packageData, VendorById vendor, Titles titles, Tags tags) {
-    this.packageData = packageData;
-    this.vendor = vendor;
-    this.titles = titles;
-    this.tags = tags;
-  }
-
   public PackageByIdData getPackageData() {
     return packageData;
   }

--- a/src/test/java/org/folio/rest/converter/packages/PackageRequestConverterTest.java
+++ b/src/test/java/org/folio/rest/converter/packages/PackageRequestConverterTest.java
@@ -13,7 +13,7 @@ import org.folio.holdingsiq.model.PackagePut;
 import org.folio.rest.impl.PackagesTestData;
 import org.folio.rest.jaxrs.model.ContentType;
 import org.folio.rest.jaxrs.model.Coverage;
-import org.folio.rest.jaxrs.model.PackageDataAttributes;
+import org.folio.rest.jaxrs.model.PackagePutDataAttributes;
 import org.folio.rest.jaxrs.model.VisibilityData;
 import org.folio.spring.config.TestConfig;
 
@@ -26,7 +26,7 @@ public class PackageRequestConverterTest {
   @Test
   public void shouldCreateRequestToSelectPackage() {
     PackagePut packagePut = packagesConverter.convertToRMAPIPackagePutRequest(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withIsSelected(true)));
     assertTrue(packagePut.getIsSelected());
   }
@@ -34,7 +34,7 @@ public class PackageRequestConverterTest {
   @Test
   public void shouldCreateRequestToHidePackage() {
     PackagePut packagePut = packagesConverter.convertToRMAPIPackagePutRequest(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withIsSelected(true)
         .withVisibilityData(new VisibilityData()
           .withIsHidden(true))));
@@ -44,7 +44,7 @@ public class PackageRequestConverterTest {
   @Test
   public void shouldCreateRequestToAllowKbAddTitlesToPackage() {
     PackagePut packagePut = packagesConverter.convertToRMAPIPackagePutRequest(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withIsSelected(true)
         .withAllowKbToAddTitles(true)));
     assertTrue(packagePut.getAllowEbscoToAddTitles());
@@ -53,7 +53,7 @@ public class PackageRequestConverterTest {
   @Test
   public void shouldCreateRequestToAddCustomCoverage() {
     PackagePut packagePut = packagesConverter.convertToRMAPIPackagePutRequest(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withIsSelected(true)
         .withCustomCoverage(new Coverage()
           .withBeginCoverage("2000-10-10")
@@ -65,7 +65,7 @@ public class PackageRequestConverterTest {
   @Test
   public void shouldCreateRequestToChangeCustomPackageName() {
     PackagePut packagePut = packagesConverter.convertToRMAPICustomPackagePutRequest(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withName("new package name")));
     assertEquals("new package name", packagePut.getPackageName());
   }
@@ -73,7 +73,7 @@ public class PackageRequestConverterTest {
   @Test
   public void shouldCreateRequestToChangeCustomPackageCoverageDates() {
     PackagePut packagePut = packagesConverter.convertToRMAPICustomPackagePutRequest(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withCustomCoverage(new Coverage()
           .withBeginCoverage("2003-01-01")
           .withEndCoverage("2004-01-01"))));
@@ -85,7 +85,7 @@ public class PackageRequestConverterTest {
   @Test
   public void shouldCreateRequestToChangeCustomPackageCoverageDatesToEmpty() {
     PackagePut packagePut = packagesConverter.convertToRMAPICustomPackagePutRequest(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withCustomCoverage(new Coverage()
           .withBeginCoverage("")
           .withEndCoverage(""))));
@@ -96,7 +96,7 @@ public class PackageRequestConverterTest {
   @Test
   public void shouldCreateRequestToChangeCustomPackageContentType() {
     PackagePut packagePut = packagesConverter.convertToRMAPICustomPackagePutRequest(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withContentType(ContentType.AGGREGATED_FULL_TEXT)));
     Integer aggregatedFullTextContentTypeCode = 1;
     assertEquals(aggregatedFullTextContentTypeCode, packagePut.getContentType());
@@ -105,7 +105,7 @@ public class PackageRequestConverterTest {
   @Test
   public void shouldCreateRequestToChangeCustomPackageVisibility() {
     PackagePut packagePut = packagesConverter.convertToRMAPICustomPackagePutRequest(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withVisibilityData(new VisibilityData()
           .withIsHidden(true))));
     assertTrue(packagePut.getIsHidden());

--- a/src/test/java/org/folio/rest/impl/PackagesTestData.java
+++ b/src/test/java/org/folio/rest/impl/PackagesTestData.java
@@ -4,8 +4,8 @@ import static org.folio.rest.impl.ProvidersTestData.STUB_VENDOR_ID;
 import static org.folio.rest.impl.ProvidersTestData.STUB_VENDOR_ID_2;
 import static org.folio.rest.impl.ProvidersTestData.STUB_VENDOR_ID_3;
 
-import org.folio.rest.jaxrs.model.PackageDataAttributes;
 import org.folio.rest.jaxrs.model.PackagePutData;
+import org.folio.rest.jaxrs.model.PackagePutDataAttributes;
 import org.folio.rest.jaxrs.model.PackagePutRequest;
 
 public class PackagesTestData {
@@ -26,7 +26,7 @@ public class PackagesTestData {
   public static final String FULL_PACKAGE_ID_4 = STUB_VENDOR_ID + "-" + STUB_PACKAGE_ID_2;
   public static final String FULL_PACKAGE_ID_5 = STUB_VENDOR_ID + "-" + STUB_PACKAGE_ID_3;
 
-  public static PackagePutRequest getPackagePutRequest(PackageDataAttributes attributes) {
+  public static PackagePutRequest getPackagePutRequest(PackagePutDataAttributes attributes) {
     return new PackagePutRequest()
       .withData(new PackagePutData()
         .withType(PackagePutData.Type.PACKAGES)

--- a/src/test/java/org/folio/rest/validator/CustomPackagePutBodyValidatorTest.java
+++ b/src/test/java/org/folio/rest/validator/CustomPackagePutBodyValidatorTest.java
@@ -2,14 +2,15 @@ package org.folio.rest.validator;
 
 import static org.hamcrest.Matchers.containsString;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import org.folio.rest.exception.InputValidationException;
 import org.folio.rest.impl.PackagesTestData;
 import org.folio.rest.jaxrs.model.ContentType;
 import org.folio.rest.jaxrs.model.Coverage;
-import org.folio.rest.jaxrs.model.PackageDataAttributes;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.folio.rest.jaxrs.model.PackagePutDataAttributes;
 
 public class CustomPackagePutBodyValidatorTest {
 
@@ -23,7 +24,7 @@ public class CustomPackagePutBodyValidatorTest {
     expectedEx.expect(InputValidationException.class);
     expectedEx.expectMessage(containsString("beginCoverage"));
     validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withIsSelected(true)
         .withContentType(ContentType.E_BOOK)
         .withName("package name")
@@ -36,7 +37,7 @@ public class CustomPackagePutBodyValidatorTest {
     expectedEx.expect(InputValidationException.class);
     expectedEx.expectMessage(containsString("name"));
     validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withContentType(ContentType.E_BOOK)
         .withName("")));
   }
@@ -46,7 +47,7 @@ public class CustomPackagePutBodyValidatorTest {
     expectedEx.expect(InputValidationException.class);
     expectedEx.expectMessage(containsString("contentType"));
     validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withName("package name")));
   }
 }

--- a/src/test/java/org/folio/rest/validator/PackagePutBodyValidatorTest.java
+++ b/src/test/java/org/folio/rest/validator/PackagePutBodyValidatorTest.java
@@ -3,15 +3,16 @@ package org.folio.rest.validator;
 import static org.hamcrest.Matchers.containsString;
 
 import org.apache.commons.lang3.StringUtils;
-import org.folio.rest.exception.InputValidationException;
-import org.folio.rest.impl.PackagesTestData;
-import org.folio.rest.jaxrs.model.Coverage;
-import org.folio.rest.jaxrs.model.PackageDataAttributes;
-import org.folio.rest.jaxrs.model.Token;
-import org.folio.rest.jaxrs.model.VisibilityData;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import org.folio.rest.exception.InputValidationException;
+import org.folio.rest.impl.PackagesTestData;
+import org.folio.rest.jaxrs.model.Coverage;
+import org.folio.rest.jaxrs.model.PackagePutDataAttributes;
+import org.folio.rest.jaxrs.model.Token;
+import org.folio.rest.jaxrs.model.VisibilityData;
 
 public class PackagePutBodyValidatorTest {
 
@@ -23,7 +24,7 @@ public class PackagePutBodyValidatorTest {
   @Test
   public void shouldValidateWhenPackageIsSelected() {
     validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withIsSelected(true)
         .withCustomCoverage(new Coverage())
         .withAllowKbToAddTitles(true)
@@ -37,7 +38,7 @@ public class PackagePutBodyValidatorTest {
     expectedEx.expect(InputValidationException.class);
     expectedEx.expectMessage(containsString("isHidden"));
     validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
       .withIsSelected(false)
       .withVisibilityData(new VisibilityData()
         .withIsHidden(true))));
@@ -48,7 +49,7 @@ public class PackagePutBodyValidatorTest {
     expectedEx.expect(InputValidationException.class);
     expectedEx.expectMessage(containsString("beginCoverage"));
     validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withIsSelected(false)
         .withCustomCoverage(new Coverage()
           .withBeginCoverage("2000-01-01"))));
@@ -59,7 +60,7 @@ public class PackagePutBodyValidatorTest {
     expectedEx.expect(InputValidationException.class);
     expectedEx.expectMessage(containsString("allowKbToAddTitles"));
     validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withIsSelected(false)
         .withAllowKbToAddTitles(true)));
   }
@@ -69,7 +70,7 @@ public class PackagePutBodyValidatorTest {
     expectedEx.expect(InputValidationException.class);
     expectedEx.expectMessage(containsString("value"));
     validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withIsSelected(false)
         .withPackageToken(new Token().withValue("tokenValue"))));
   }
@@ -79,7 +80,7 @@ public class PackagePutBodyValidatorTest {
     expectedEx.expect(InputValidationException.class);
     expectedEx.expectMessage(containsString("value"));
     validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withIsSelected(true)
         .withPackageToken(new Token().withValue(StringUtils.repeat("tokenvalue",200)))));
   }
@@ -89,7 +90,7 @@ public class PackagePutBodyValidatorTest {
     expectedEx.expect(InputValidationException.class);
     expectedEx.expectMessage(containsString("beginCoverage"));
     validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withIsSelected(true)
         .withCustomCoverage(new Coverage()
           .withBeginCoverage("abcd-ab-ab"))));
@@ -98,7 +99,7 @@ public class PackagePutBodyValidatorTest {
   @Test
   public void shouldValidateWhenPackageIsSelectedAndCoverageDateIsEmpty() {
     validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackageDataAttributes()
+      new PackagePutDataAttributes()
         .withIsSelected(true)
         .withCustomCoverage(new Coverage()
           .withBeginCoverage(""))));

--- a/src/test/resources/requests/kb-ebsco/package/post-package-request.json
+++ b/src/test/resources/requests/kb-ebsco/package/post-package-request.json
@@ -7,9 +7,6 @@
       "customCoverage": {
         "beginCoverage": "2017-12-23",
         "endCoverage": "2018-03-30"
-      },
-      "tags": {
-        "tagList": []
       }
     }
   }

--- a/src/test/resources/requests/kb-ebsco/package/put-package-custom-multiple-attributes
+++ b/src/test/resources/requests/kb-ebsco/package/put-package-custom-multiple-attributes
@@ -10,11 +10,6 @@
       "isCustom": true,
       "isSelected": true,
       "name": "name of the ages forever and ever",
-      "packageType": "Custom",
-      "providerId": 3964,
-      "providerName": "API DEV GOVERNMENT CUSTOMER",
-      "selectedCount": 0,
-      "titleCount": 0,
       "visibilityData": {
         "isHidden": true,
         "reason": ""

--- a/src/test/resources/requests/kb-ebsco/package/put-package-selected.json
+++ b/src/test/resources/requests/kb-ebsco/package/put-package-selected.json
@@ -10,11 +10,6 @@
       "isCustom": true,
       "isSelected": true,
       "name": "name of the ages forever and ever",
-      "packageType": "Custom",
-      "providerId": 123356,
-      "providerName": "API DEV GOVERNMENT CUSTOMER",
-      "selectedCount": 0,
-      "titleCount": 0,
       "visibilityData": {
         "isHidden": false,
         "reason": ""


### PR DESCRIPTION
## Purpose
updates for https://issues.folio.org/browse/MODKBEKBJ-283

## Approach
After discussion with UI team decided not to remove "tags" from the schemas for POST and PUT package methods as those values for tags are used for the sequential call to update package tags.

* removed tags update for POST /packages
* removed tags update for PUT /packages/{id}
* updated/removed redundant tests
