### PR TITLE
MODKBEKBJ-287 Remove update of resource tags from resource endpoints

### DIFF
--- a/ramls/types/resources/resourcePutDataAttributes.json
+++ b/ramls/types/resources/resourcePutDataAttributes.json
@@ -114,11 +114,6 @@
       "type": "object",
       "description": "Proxy.  Note that this attribute can be updated both for CUSTOM AND MANAGED RESOURCES.",
       "$ref": "../proxy.json"
-    },
-    "tags": {
-      "type": "object",
-      "description": "Resource tags",
-      "$ref": "../../raml-util/schemas/tags.schema"
     }
   }
 }

--- a/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
@@ -156,12 +156,7 @@ public class EholdingsResourcesImpl implements EholdingsResources {
     templateFactory.createTemplate(okapiHeaders, asyncResultHandler)
       .requestAction(context ->
         processResourceUpdate(entity, parsedResourceId, context)
-          .thenCompose(resourceResult ->
-            updateResourceTags(resourceId, resourceResult.getTitleName(), entity.getData().getAttributes().getTags(),
-              context.getOkapiData().getTenant())
-          .thenApply(o -> new ResourceResult(resourceResult,null,null,false,
-            entity.getData().getAttributes().getTags())))
-      )
+          .thenApply(resourceResult -> new ResourceResult(resourceResult, null, null, false)))
       .addErrorMapper(InputValidationException.class, exception ->
         EholdingsResources.PutEholdingsResourcesByResourceIdResponse.respond422WithApplicationVndApiJson(
           ErrorUtil.createError(exception.getMessage(), exception.getMessageDetail())))

--- a/src/main/java/org/folio/rmapi/result/ResourceResult.java
+++ b/src/main/java/org/folio/rmapi/result/ResourceResult.java
@@ -19,14 +19,6 @@ public class ResourceResult {
     this.includeTitle = includeTitle;
   }
 
-  public ResourceResult(Title title, VendorById vendor, PackageByIdData packageData, boolean includeTitle, Tags tags) {
-    this.title = title;
-    this.vendor = vendor;
-    this.packageData = packageData;
-    this.includeTitle = includeTitle;
-    this.tags = tags;
-  }
-
   public Title getTitle() {
     return title;
   }


### PR DESCRIPTION
## Purpose
Remove code that updates tags https://issues.folio.org/browse/MODKBEKBJ-287

## Approach
* removed tags update for PUT /resources/{id}
* updated/removed redundant tests
