### PR TITLE
MODKBEKBJ-306: Correctly process "None" status on loading holdings

### DIFF
--- a/src/main/java/org/folio/repository/holdings/LoadStatus.java
+++ b/src/main/java/org/folio/repository/holdings/LoadStatus.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 
 public enum LoadStatus {
 
-  COMPLETED("Completed"), IN_PROGRESS("In progress"), FAILED("Failed");
+  COMPLETED("Completed"), IN_PROGRESS("In progress"), FAILED("Failed"), NONE("None");
 
   private String value;
 

--- a/src/test/java/org/folio/rest/impl/IntegrationTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/IntegrationTestSuite.java
@@ -21,7 +21,8 @@ import org.folio.test.util.TestSetUpHelper;
   EholdingsTitlesTest.class,
   EholdingsTagsImplTest.class,
   LoadHoldingsImplTest.class,
-  LoadHoldingsStatusImplTest.class
+  LoadHoldingsStatusImplTest.class,
+  LoadServiceFacadeImplTest.class
 })
 @RunWith(Suite.class)
 public class IntegrationTestSuite {

--- a/src/test/java/org/folio/rest/impl/LoadHoldingsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/LoadHoldingsImplTest.java
@@ -139,18 +139,19 @@ public class LoadHoldingsImplTest extends WireMockTestBase {
   @Test
   public void shouldRetryCreationOfSnapshotWhenItFails(TestContext context) throws IOException, URISyntaxException {
     mockDefaultConfiguration(getWiremockUrl());
-    mockGet(new EqualToPattern(HOLDINGS_STATUS_ENDPOINT), "responses/rmapi/holdings/status/get-status-completed.json");
+
     stubFor(
       post(new UrlPathPattern(new EqualToPattern(HOLDINGS_POST_HOLDINGS_ENDPOINT), false))
         .willReturn(new ResponseDefinitionBuilder()
           .withBody("")
           .withStatus(202)));
-    mockResponseList(new UrlPathPattern(new EqualToPattern(HOLDINGS_GET_ENDPOINT), false),
-      new ResponseDefinitionBuilder().withStatus(500),
-      new ResponseDefinitionBuilder()
-        .withBody("")
-        .withStatus(202)
-    );
+    ResponseDefinitionBuilder failedResponse = new ResponseDefinitionBuilder().withStatus(500);
+    ResponseDefinitionBuilder successfulResponse = new ResponseDefinitionBuilder()
+      .withBody(readFile("responses/rmapi/holdings/status/get-status-completed.json"));
+    mockResponseList(new UrlPathPattern(new EqualToPattern(HOLDINGS_STATUS_ENDPOINT), false),
+      failedResponse,
+      successfulResponse,
+      successfulResponse);
 
     Async async = context.async();
     interceptor = interceptAndStop(HOLDINGS_SERVICE_ADDRESS, SNAPSHOT_CREATED_ACTION, message -> async.complete());

--- a/src/test/java/org/folio/rest/impl/LoadServiceFacadeImplTest.java
+++ b/src/test/java/org/folio/rest/impl/LoadServiceFacadeImplTest.java
@@ -1,0 +1,93 @@
+package org.folio.rest.impl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.junit.Assert.assertTrue;
+
+import static org.folio.service.holdings.HoldingConstants.HOLDINGS_SERVICE_ADDRESS;
+import static org.folio.service.holdings.HoldingConstants.SNAPSHOT_CREATED_ACTION;
+import static org.folio.test.util.TestUtil.STUB_TENANT;
+import static org.folio.test.util.TestUtil.mockResponseList;
+import static org.folio.test.util.TestUtil.readFile;
+import static org.folio.util.KBTestUtil.interceptAndStop;
+import static org.folio.util.KBTestUtil.mockDefaultConfiguration;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.SendContext;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.folio.holdingsiq.model.Configuration;
+import org.folio.service.holdings.ConfigurationMessage;
+import org.folio.service.holdings.LoadServiceFacade;
+
+@RunWith(VertxUnitRunner.class)
+public class LoadServiceFacadeImplTest extends WireMockTestBase {
+
+  static final String HOLDINGS_STATUS_ENDPOINT = "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/holdings/status";
+  static final String HOLDINGS_POST_HOLDINGS_ENDPOINT = "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/holdings";
+  private static final int TIMEOUT = 180000;
+
+  @Autowired
+  LoadServiceFacade loadServiceFacade;
+
+  private Configuration stubConfiguration;
+
+  private Handler<SendContext> interceptor;
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    stubConfiguration = Configuration.builder()
+      .apiKey(STUB_API_KEY)
+      .customerId(STUB_CUSTOMER_ID)
+      .url(getWiremockUrl())
+      .build();
+  }
+
+  @After
+  public void tearDown() {
+    if (interceptor != null) {
+      vertx.eventBus().removeInterceptor(interceptor);
+    }
+  }
+
+  @Test
+  public void shouldCreateSnapshotOnInitialStatusNone(TestContext context) throws IOException, URISyntaxException {
+    mockDefaultConfiguration(getWiremockUrl());
+
+    Async async = context.async();
+
+    mockResponseList(new UrlPathPattern(new EqualToPattern(HOLDINGS_STATUS_ENDPOINT),false),
+      new ResponseDefinitionBuilder().withBody(readFile("responses/rmapi/holdings/status/get-status-none.json")),
+      new ResponseDefinitionBuilder().withBody(readFile("responses/rmapi/holdings/status/get-status-completed.json"))
+    );
+    stubFor(post(new UrlPathPattern(new EqualToPattern(HOLDINGS_POST_HOLDINGS_ENDPOINT), false))
+      .willReturn(new ResponseDefinitionBuilder()
+        .withBody("")
+        .withStatus(202)));
+
+    interceptor = interceptAndStop(HOLDINGS_SERVICE_ADDRESS, SNAPSHOT_CREATED_ACTION,
+      message -> async.complete());
+    vertx.eventBus().addInterceptor(interceptor);
+
+    loadServiceFacade.createSnapshot(new ConfigurationMessage(stubConfiguration, STUB_TENANT));
+
+    async.await(TIMEOUT);
+    assertTrue(async.isSucceeded());
+  }
+}

--- a/src/test/java/org/folio/rest/impl/WireMockTestBase.java
+++ b/src/test/java/org/folio/rest/impl/WireMockTestBase.java
@@ -16,6 +16,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.unit.TestContext;
 
 import org.apache.http.protocol.HTTP;
 import org.junit.Before;
@@ -64,8 +65,9 @@ public abstract class WireMockTestBase extends TestBase {
   private VertxCache<TitleCacheKey, Title> titleCache;
 
   @BeforeClass
-  public static void setUpClassWithProperties(){
+  public static void setUpClass(TestContext context){
     configProperties.put("spring.configuration", "org.folio.spring.config.TestConfig");
+    TestBase.setUpClass(context);
   }
 
   @Before

--- a/src/test/resources/responses/rmapi/holdings/status/get-status-none.json
+++ b/src/test/resources/responses/rmapi/holdings/status/get-status-none.json
@@ -1,0 +1,5 @@
+{
+  "status": "None",
+  "created": null,
+  "totalCount": 0
+}


### PR DESCRIPTION
Jira: MODKBEKBJ-306


## Purpose
Correctly process "None" status on loading holdings

## Approach
Add None status

Additionally:
Fix an issue in WireMockTestBase to make it use TestConfig
Fix an issue in LoadHoldingsImplTest where HOLDINGS_GET_ENDPOINT returned
an error instead of HOLDINGS_STATUS_ENDPOINT