### PR TITLE
MODKBEKBJ-311: Don't override loading status when TenantAPI is called second time

### DIFF
--- a/src/main/java/org/folio/repository/holdings/status/HoldingsStatusTableConstants.java
+++ b/src/main/java/org/folio/repository/holdings/status/HoldingsStatusTableConstants.java
@@ -7,7 +7,7 @@ public class HoldingsStatusTableConstants {
   public static final String JSONB_COLUMN = "jsonb";
   public static final String HOLDINGS_STATUS_FIELD_LIST = String.format("%s, %s", ID_COLUMN, JSONB_COLUMN);
   public static final String GET_HOLDINGS_STATUS = "SELECT " + HOLDINGS_STATUS_FIELD_LIST + " from %s;";
-  public static final String INSERT_LOADING_STATUS = "INSERT INTO %s (" + HOLDINGS_STATUS_FIELD_LIST + ") VALUES (%s);";
+  public static final String INSERT_LOADING_STATUS = "INSERT INTO %s (" + HOLDINGS_STATUS_FIELD_LIST + ") VALUES (%s) ON CONFLICT DO NOTHING;";
   public static final String UPDATE_LOADING_STATUS = "UPDATE %s SET " + JSONB_COLUMN + " = '%s'::jsonb;";
   public static final String UPDATE_IMPORTED_COUNT =
     "UPDATE %s SET jsonb = jsonb_set(jsonb_set(jsonb, " +

--- a/src/main/java/org/folio/rest/impl/TenantApiImpl.java
+++ b/src/main/java/org/folio/rest/impl/TenantApiImpl.java
@@ -12,8 +12,18 @@ import java.util.concurrent.CompletionStage;
 
 import javax.ws.rs.core.Response;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
 import org.folio.repository.holdings.status.HoldingsStatusRepository;
 import org.folio.repository.holdings.status.RetryStatus;
 import org.folio.repository.holdings.status.RetryStatusRepository;
@@ -22,15 +32,6 @@ import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.spring.SpringContextUtil;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 
 public class TenantApiImpl extends TenantAPI {
 
@@ -85,8 +86,7 @@ public class TenantApiImpl extends TenantAPI {
   }
 
   private CompletableFuture<Void> setStatusNotStarted(String tenantId) {
-    return holdingsStatusRepository.delete(tenantId)
-      .thenCompose(o -> holdingsStatusRepository.save(getStatusNotStarted(), tenantId));
+    return holdingsStatusRepository.save(getStatusNotStarted(), tenantId);
   }
 
   private Future<List<String>> setupTestData(Map<String, String> headers, Context context) {

--- a/src/main/resources/templates/db_scripts/create-holdings-status-table.sql
+++ b/src/main/resources/templates/db_scripts/create-holdings-status-table.sql
@@ -1,3 +1,3 @@
 ALTER TABLE holdings_status
 -- Add unique column with value true to ensure that only one row can be created in holdings_status
-ADD COLUMN IF NOT EXISTS lock BOOL UNIQUE DEFAULT TRUE CHECK (lock);
+ADD COLUMN IF NOT EXISTS lock BOOL NOT NULL UNIQUE DEFAULT TRUE CHECK (lock);

--- a/src/main/resources/templates/db_scripts/create-holdings-status-table.sql
+++ b/src/main/resources/templates/db_scripts/create-holdings-status-table.sql
@@ -1,0 +1,3 @@
+ALTER TABLE holdings_status
+-- Add unique column with value true to ensure that only one row can be created in holdings_status
+ADD COLUMN IF NOT EXISTS lock BOOL UNIQUE DEFAULT TRUE CHECK (lock);

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -38,8 +38,10 @@
     },
     {
       "tableName": "holdings_status",
+      "fromModuleVersion": "3.0.2",
       "withMetadata": false,
-      "withAuditing": false
+      "withAuditing": false,
+      "customSnippetPath": "create-holdings-status-table.sql"
     },
     {
       "tableName": "retry_status",

--- a/src/test/java/org/folio/rest/impl/LoadHoldingsStatusImplTest.java
+++ b/src/test/java/org/folio/rest/impl/LoadHoldingsStatusImplTest.java
@@ -61,6 +61,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.folio.repository.holdings.status.HoldingsStatusRepositoryImpl;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.HoldingsLoadingStatus;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.tools.PomReader;
 import org.folio.service.holdings.HoldingsService;
 import org.folio.util.HoldingsStatusUtil;
 import org.folio.util.KBTestUtil;
@@ -108,14 +110,20 @@ public class LoadHoldingsStatusImplTest extends WireMockTestBase {
     KBTestUtil.clearDataFromTable(vertx, HOLDINGS_STATUS_TABLE);
     HoldingsStatusUtil.insertStatus(vertx, getStatusCompleted(1000));
 
+
     Async async = context.async();
     TenantClient tenantClient = new TenantClient(host + ":" + port, STUB_TENANT, STUB_TOKEN);
     try {
-      tenantClient.postTenant(null, res2 -> async.complete());
+      TenantAttributes tenantAttributes = new TenantAttributes() ;
+      tenantAttributes.setModuleFrom("0.0.1");
+      tenantAttributes.setModuleTo(PomReader.INSTANCE.getVersion());
+      tenantClient.postTenant(tenantAttributes, res2 -> async.complete());
     } catch (Exception e) {
       e.printStackTrace();
     }
     async.awaitSuccess();
+
+
 
     final HoldingsLoadingStatus status = getWithOk(HOLDINGS_STATUS_ENDPOINT).body().as(HoldingsLoadingStatus.class);
     assertThat(status.getData().getAttributes().getStatus().getName().value(), equalToIgnoringWhiteSpace("Completed"));

--- a/src/test/java/org/folio/util/HoldingsStatusUtil.java
+++ b/src/test/java/org/folio/util/HoldingsStatusUtil.java
@@ -20,10 +20,14 @@ import org.folio.rest.persist.PostgresClient;
 public class HoldingsStatusUtil {
 
   public static HoldingsLoadingStatus insertStatusNotStarted(Vertx vertx) {
+    return insertStatus(vertx, getStatusNotStarted());
+  }
+
+  public static HoldingsLoadingStatus insertStatus(Vertx vertx, HoldingsLoadingStatus status) {
     CompletableFuture<HoldingsLoadingStatus> future = new CompletableFuture<>();
     PostgresClient.getInstance(vertx)
       .execute("INSERT INTO " + holdingsStatusTestTable() + " (" + ID_COLUMN + ", " + JSONB_COLUMN + " ) VALUES (?,?)",
-        new JsonArray(Arrays.asList(UUID.randomUUID().toString(), Json.encode(getStatusNotStarted()))),
+        new JsonArray(Arrays.asList(UUID.randomUUID().toString(), Json.encode(status))),
          event -> future.complete(null));
     return future.join();
   }


### PR DESCRIPTION
## Purpose
Don't override loading status when TenantAPI is called second time

## Approach
Add unique column to holdings_status to ensure that only one row can be
inserted.
Change INSERT statement to do nothing if status already exists
