### PR TITLE
MODKBEKBJ-324: Add timeout to loading process

### DIFF
--- a/ramls/eholdings.raml
+++ b/ramls/eholdings.raml
@@ -106,6 +106,11 @@ types:
     responses:
       204:
         description: No Content
+      409:
+        description: "Process of loading holdings is already running"
+        body:
+          text/plain:
+            example: "Process of loading holdings is already running"
       500:
         description: "Internal server error"
         body:

--- a/ramls/types/loadHoldings/loadHoldingsStatusAttributes.json
+++ b/ramls/types/loadHoldings/loadHoldingsStatusAttributes.json
@@ -11,6 +11,11 @@
       "description": "Holdings loading started time",
       "example": "1999-12-31 14:59:59"
     },
+    "updated": {
+      "type": "string",
+      "description": "Time of last update to status",
+      "example": "1999-12-31 16:01:03"
+    },
     "finished": {
       "type": "string",
       "description": "Holdings loading finished time",

--- a/src/main/java/org/folio/common/VertxIdProvider.java
+++ b/src/main/java/org/folio/common/VertxIdProvider.java
@@ -9,24 +9,24 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
- * Assigns UUID to specified Vertx instance if id isn't assigned already.
- * Same Vertx instance will always have the same id, even if there are multiple instances of VertxIdService.
+ * Assigns UUID to specified Vertx instance if id isn't assigned already, and returns it from getVertxId().
+ * Same Vertx instance will always have the same id, even if there are multiple instances of VertxIdProvider.
  */
 @Component
-public class VertxIdService {
+public class VertxIdProvider {
   public static final String VERTX_ID_MAP = "vertxIdMap";
   public static final String VERTX_ID_KEY = "vertxId";
   private Vertx vertx;
 
   @Autowired
-  public VertxIdService(Vertx vertx) {
+  public VertxIdProvider(Vertx vertx) {
     this.vertx = vertx;
     LocalMap<Object, Object> map = vertx.sharedData().getLocalMap(VERTX_ID_MAP);
-    map.computeIfAbsent(VERTX_ID_KEY, key -> UUID.randomUUID());
+    map.computeIfAbsent(VERTX_ID_KEY, key -> UUID.randomUUID().toString());
   }
 
-  public UUID getVertxId(){
-    return (UUID) vertx.sharedData().getLocalMap(VERTX_ID_MAP).get(VERTX_ID_KEY);
+  public String  getVertxId(){
+    return (String) vertx.sharedData().getLocalMap(VERTX_ID_MAP).get(VERTX_ID_KEY);
   }
 }
 

--- a/src/main/java/org/folio/common/VertxIdService.java
+++ b/src/main/java/org/folio/common/VertxIdService.java
@@ -1,0 +1,32 @@
+package org.folio.common;
+
+import java.util.UUID;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.LocalMap;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Assigns UUID to specified Vertx instance if id isn't assigned already.
+ * Same Vertx instance will always have the same id, even if there are multiple instances of VertxIdService.
+ */
+@Component
+public class VertxIdService {
+  public static final String VERTX_ID_MAP = "vertxIdMap";
+  public static final String VERTX_ID_KEY = "vertxId";
+  private Vertx vertx;
+
+  @Autowired
+  public VertxIdService(Vertx vertx) {
+    this.vertx = vertx;
+    LocalMap<Object, Object> map = vertx.sharedData().getLocalMap(VERTX_ID_MAP);
+    map.computeIfAbsent(VERTX_ID_KEY, key -> UUID.randomUUID());
+  }
+
+  public UUID getVertxId(){
+    return (UUID) vertx.sharedData().getLocalMap(VERTX_ID_MAP).get(VERTX_ID_KEY);
+  }
+}
+

--- a/src/main/java/org/folio/repository/holdings/status/HoldingsLoadingStatusFactory.java
+++ b/src/main/java/org/folio/repository/holdings/status/HoldingsLoadingStatusFactory.java
@@ -27,7 +27,9 @@ public class HoldingsLoadingStatusFactory {
         .withType(STATUS_RECTYPE)
         .withAttributes(new LoadStatusAttributes()
           .withStatus(new LoadStatusInformation()
-            .withName(LoadStatusNameEnum.NOT_STARTED))))
+            .withName(LoadStatusNameEnum.NOT_STARTED))
+          .withUpdated(getTimeNow())
+        ))
       .withJsonapi(JSONAPI);
   }
 
@@ -36,10 +38,11 @@ public class HoldingsLoadingStatusFactory {
       .withData(new LoadStatusData()
         .withType(STATUS_RECTYPE)
         .withAttributes(new LoadStatusAttributes()
-          .withStarted(POSTGRES_TIMESTAMP_FORMATTER.format(Instant.now().atZone(ZoneId.systemDefault())))
+          .withStarted(getTimeNow())
           .withStatus(new LoadStatusInformation()
             .withName(LoadStatusNameEnum.IN_PROGRESS)
             .withDetail(LoadStatusNameDetailEnum.POPULATING_STAGING_AREA))
+          .withUpdated(getTimeNow())
           .withErrors(null)))
       .withJsonapi(JSONAPI);
   }
@@ -52,6 +55,7 @@ public class HoldingsLoadingStatusFactory {
           .withStatus(new LoadStatusInformation()
             .withName(LoadStatusNameEnum.IN_PROGRESS)
             .withDetail(LoadStatusNameDetailEnum.LOADING_HOLDINGS))
+          .withUpdated(getTimeNow())
           .withTotalCount(totalCount)
           .withImportedCount(importedCount)
           .withTotalPages(totalPages)
@@ -68,7 +72,8 @@ public class HoldingsLoadingStatusFactory {
           .withStatus(new LoadStatusInformation()
             .withName(LoadStatusNameEnum.COMPLETED))
           .withTotalCount(totalCount)
-          .withFinished(POSTGRES_TIMESTAMP_FORMATTER.format(Instant.now().atZone(ZoneId.systemDefault())))))
+          .withUpdated(getTimeNow())
+          .withFinished(getTimeNow())))
       .withJsonapi(JSONAPI);
   }
 
@@ -79,7 +84,12 @@ public class HoldingsLoadingStatusFactory {
         .withAttributes(new LoadStatusAttributes()
           .withStatus(new LoadStatusInformation()
             .withName(LoadStatusNameEnum.FAILED))
+          .withUpdated(getTimeNow())
           .withErrors(errors)))
       .withJsonapi(JSONAPI);
+  }
+
+  private static String getTimeNow() {
+    return POSTGRES_TIMESTAMP_FORMATTER.format(Instant.now().atZone(ZoneId.systemDefault()));
   }
 }

--- a/src/main/java/org/folio/repository/holdings/status/HoldingsStatusTableConstants.java
+++ b/src/main/java/org/folio/repository/holdings/status/HoldingsStatusTableConstants.java
@@ -5,17 +5,19 @@ public class HoldingsStatusTableConstants {
   public static final String HOLDINGS_STATUS_TABLE = "holdings_status";
   public static final String ID_COLUMN = "id";
   public static final String JSONB_COLUMN = "jsonb";
-  public static final String HOLDINGS_STATUS_FIELD_LIST = String.format("%s, %s", ID_COLUMN, JSONB_COLUMN);
+  public static final String PROCESS_ID_COLUMN = "process_id";
+  public static final String HOLDINGS_STATUS_FIELD_LIST = String.format("%s, %s, %s", ID_COLUMN, JSONB_COLUMN, PROCESS_ID_COLUMN);
   public static final String GET_HOLDINGS_STATUS = "SELECT " + HOLDINGS_STATUS_FIELD_LIST + " from %s;";
   public static final String INSERT_LOADING_STATUS = "INSERT INTO %s (" + HOLDINGS_STATUS_FIELD_LIST + ") VALUES (%s) ON CONFLICT DO NOTHING;";
-  public static final String UPDATE_LOADING_STATUS = "UPDATE %s SET " + JSONB_COLUMN + " = '%s'::jsonb;";
+  public static final String UPDATE_LOADING_STATUS = "UPDATE %s SET " + JSONB_COLUMN + " = '%s'::jsonb WHERE process_id=?";
   public static final String UPDATE_IMPORTED_COUNT =
     "UPDATE %s SET jsonb = jsonb_set(jsonb_set(jsonb, " +
       "'{data,attributes,importedCount}', ((jsonb->'data'->'attributes'->>'importedCount')::int + %s)::text::jsonb, false), " +
       "'{data,attributes,importedPages}', ((jsonb->'data'->'attributes'->>'importedPages')::int + %s)::text::jsonb, false) " +
       "WHERE " +
       "jsonb->'data'->'attributes'->>'importedCount' IS NOT NULL AND " +
-      "jsonb->'data'->'attributes'->>'importedPages' IS NOT NULL ";
+      "jsonb->'data'->'attributes'->>'importedPages' IS NOT NULL AND " +
+      "process_id=?";
   public static final String DELETE_LOADING_STATUS = "DELETE FROM %s;";
 
   private HoldingsStatusTableConstants() { }

--- a/src/main/java/org/folio/rest/impl/LoadHoldingsImpl.java
+++ b/src/main/java/org/folio/rest/impl/LoadHoldingsImpl.java
@@ -6,6 +6,15 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.ws.rs.core.Response;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
 import org.folio.repository.holdings.status.HoldingsStatusRepository;
 import org.folio.rest.jaxrs.model.HoldingsLoadingStatus;
 import org.folio.rest.jaxrs.resource.LoadHoldings;
@@ -14,14 +23,6 @@ import org.folio.rest.util.template.RMAPITemplate;
 import org.folio.rest.util.template.RMAPITemplateFactory;
 import org.folio.service.holdings.HoldingsService;
 import org.folio.spring.SpringContextUtil;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 
 public class LoadHoldingsImpl implements LoadHoldings {
 
@@ -47,7 +48,7 @@ public class LoadHoldingsImpl implements LoadHoldings {
       holdingsService.loadHoldings(context);
       return CompletableFuture.completedFuture(null);
     })
-      .execute();
+    .execute();
   }
 
   @Override

--- a/src/main/java/org/folio/service/holdings/HoldingsService.java
+++ b/src/main/java/org/folio/service/holdings/HoldingsService.java
@@ -3,17 +3,17 @@ package org.folio.service.holdings;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.ProxyGen;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Vertx;
+
 import org.folio.repository.holdings.HoldingInfoInDB;
 import org.folio.repository.resources.ResourceInfoInDB;
 import org.folio.rest.util.template.RMAPITemplateContext;
 import org.folio.service.holdings.message.LoadFailedMessage;
 import org.folio.service.holdings.message.SnapshotCreatedMessage;
 import org.folio.service.holdings.message.SnapshotFailedMessage;
-
-import io.vertx.codegen.annotations.GenIgnore;
-import io.vertx.codegen.annotations.ProxyGen;
-import io.vertx.codegen.annotations.VertxGen;
-import io.vertx.core.Vertx;
 
 @ProxyGen
 @VertxGen
@@ -23,8 +23,14 @@ public interface HoldingsService {
     return new HoldingsServiceVertxEBProxy(vertx, address);
   }
 
+  /**
+   * Starts the process of loading holdings
+   * @param context RMAPITemplateContext
+   * @return future that will be completed when process is started successfully, if process failed to start then future
+   * will be failed.
+   */
   @GenIgnore
-  default void loadHoldings(RMAPITemplateContext context) {
+  default CompletableFuture<Void> loadHoldings(RMAPITemplateContext context) {
     //Default implementation is necessary for automatically generated vertx proxy
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/org/folio/service/holdings/exception/ProcessInProgressException.java
+++ b/src/main/java/org/folio/service/holdings/exception/ProcessInProgressException.java
@@ -1,0 +1,9 @@
+package org.folio.service.holdings.exception;
+
+public class ProcessInProgressException extends RuntimeException {
+  private static final long serialVersionUID = -94932377914823017L;
+
+  public ProcessInProgressException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -36,7 +36,8 @@ import org.folio.rmapi.cache.VendorCacheKey;
   "org.folio.rest.validator",
   "org.folio.rest.util.template",
   "org.folio.repository",
-  "org.folio.service"})
+  "org.folio.service",
+  "org.folio.common"})
 public class ApplicationConfig {
   @Bean
   public PropertySourcesPlaceholderConfigurer placeholderConfigurer() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,4 @@ holdings.snapshot.retry.delay=10800000
 holdings.snapshot.refresh.period=86400000
 holdings.load.retry.delay=10800000
 holdings.load.retry.count=3
+holdings.timeout=3600000

--- a/src/main/resources/templates/db_scripts/create-holdings-status-table.sql
+++ b/src/main/resources/templates/db_scripts/create-holdings-status-table.sql
@@ -1,3 +1,8 @@
 ALTER TABLE holdings_status
 -- Add unique column with value true to ensure that only one row can be created in holdings_status
 ADD COLUMN IF NOT EXISTS lock BOOL NOT NULL UNIQUE DEFAULT TRUE CHECK (lock);
+
+ALTER TABLE holdings_status
+ADD COLUMN IF NOT EXISTS process_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000';
+ALTER TABLE holdings_status
+ALTER COLUMN process_id DROP DEFAULT;

--- a/src/test/java/org/folio/rest/impl/LoadHoldingsStatusImplTest.java
+++ b/src/test/java/org/folio/rest/impl/LoadHoldingsStatusImplTest.java
@@ -29,6 +29,7 @@ import static org.folio.test.util.TestUtil.STUB_TOKEN;
 import static org.folio.test.util.TestUtil.mockGet;
 import static org.folio.test.util.TestUtil.mockResponseList;
 import static org.folio.test.util.TestUtil.readFile;
+import static org.folio.util.HoldingsStatusUtil.PROCESS_ID;
 import static org.folio.util.KBTestUtil.interceptAndContinue;
 import static org.folio.util.KBTestUtil.interceptAndStop;
 import static org.folio.util.KBTestUtil.mockDefaultConfiguration;
@@ -42,11 +43,13 @@ import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.DeliveryContext;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -107,7 +110,7 @@ public class LoadHoldingsStatusImplTest extends WireMockTestBase {
   public void shouldNotOverrideStatusOnSecondCallToTenantAPI(TestContext context) throws IOException, URISyntaxException {
     mockDefaultConfiguration(getWiremockUrl());
     KBTestUtil.clearDataFromTable(vertx, HOLDINGS_STATUS_TABLE);
-    HoldingsStatusUtil.insertStatus(vertx, getStatusCompleted(1000));
+    HoldingsStatusUtil.insertStatus(vertx, getStatusCompleted(1000), PROCESS_ID);
 
 
     Async async = context.async();

--- a/src/test/java/org/folio/util/HoldingsStatusUtil.java
+++ b/src/test/java/org/folio/util/HoldingsStatusUtil.java
@@ -4,6 +4,7 @@ import static org.folio.repository.holdings.HoldingsTableConstants.JSONB_COLUMN;
 import static org.folio.repository.holdings.status.HoldingsLoadingStatusFactory.getStatusNotStarted;
 import static org.folio.repository.holdings.status.HoldingsStatusTableConstants.HOLDINGS_STATUS_TABLE;
 import static org.folio.repository.holdings.status.HoldingsStatusTableConstants.ID_COLUMN;
+import static org.folio.repository.holdings.status.HoldingsStatusTableConstants.PROCESS_ID_COLUMN;
 import static org.folio.test.util.TestUtil.STUB_TENANT;
 
 import java.util.Arrays;
@@ -19,15 +20,16 @@ import org.folio.rest.persist.PostgresClient;
 
 public class HoldingsStatusUtil {
 
+  public static String PROCESS_ID = "926223cc-bd21-4fe2-af75-b8e82cfecad3";
   public static HoldingsLoadingStatus insertStatusNotStarted(Vertx vertx) {
-    return insertStatus(vertx, getStatusNotStarted());
+    return insertStatus(vertx, getStatusNotStarted(), PROCESS_ID );
   }
 
-  public static HoldingsLoadingStatus insertStatus(Vertx vertx, HoldingsLoadingStatus status) {
+  public static HoldingsLoadingStatus insertStatus(Vertx vertx, HoldingsLoadingStatus status, String processId) {
     CompletableFuture<HoldingsLoadingStatus> future = new CompletableFuture<>();
     PostgresClient.getInstance(vertx)
-      .execute("INSERT INTO " + holdingsStatusTestTable() + " (" + ID_COLUMN + ", " + JSONB_COLUMN + " ) VALUES (?,?)",
-        new JsonArray(Arrays.asList(UUID.randomUUID().toString(), Json.encode(status))),
+      .execute("INSERT INTO " + holdingsStatusTestTable() + " (" + ID_COLUMN + ", " + JSONB_COLUMN + ", " + PROCESS_ID_COLUMN + " ) VALUES (?,?,?)",
+        new JsonArray(Arrays.asList(UUID.randomUUID().toString(), Json.encode(status), processId)),
          event -> future.complete(null));
     return future.join();
   }

--- a/src/test/resources/test-application.properties
+++ b/src/test/resources/test-application.properties
@@ -14,3 +14,4 @@ holdings.page.retry.count=2
 holdings.page.retry.delay=1
 holdings.load.retry.delay=1
 holdings.load.retry.count=2
+holdings.timeout=60000


### PR DESCRIPTION
## Purpose
Add timeout to loading process

## Approach
Add "updated" attribute to loading status
Add "process_id" column to holdings_status table
process_id contains UUID of current Vert.x instance
Make it so that only process with correct process id can change status
If status was last updated more than 1 hour ago then another process
can safely reset it.
