### PR TITLE
MODKBEKBJ-341 - Custom labels: update custom labels list

### DIFF
--- a/ramls/custom-labels.raml
+++ b/ramls/custom-labels.raml
@@ -94,14 +94,14 @@ types:
               example:
                 strict: false
                 value: !include examples/customLabels/cl_put_by_id_400_response.json
-        404:
-          description: Not Found
+        422:
+          description: Unprocessable Entity
           body:
             application/vnd.api+json:
               type: jsonapiError
               example:
                 strict: false
-                value: !include examples/customLabels/cl_get_put_delete_by_id_404_response.json
+                value: !include examples/customLabels/cl_put_by_id_422_response.json
     delete:
       description: Delete a Custom Label by Id
       responses:

--- a/ramls/examples/customLabels/cl_put_by_id_400_response.json
+++ b/ramls/examples/customLabels/cl_put_by_id_400_response.json
@@ -1,8 +1,6 @@
 {
   "errors": [{
-    "title": "Invalid Label id",
-    "detail": "Label Id can't be blank",
-    "source": {}
+    "title": "Invalid format for Custom Label id: 'a'"
   }],
   "jsonapi": {
     "version": "1.0"

--- a/ramls/examples/customLabels/cl_put_by_id_422_response.json
+++ b/ramls/examples/customLabels/cl_put_by_id_422_response.json
@@ -1,0 +1,9 @@
+{
+  "errors": [{
+      "title": "Invalid identifier id",
+      "detail": "Ids should be equal!  3 != 5"
+    }],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/types/customLabels/customLabelDataAttributes.json
+++ b/ramls/types/customLabels/customLabelDataAttributes.json
@@ -9,15 +9,12 @@
     "id": {
       "type": "integer",
       "description": "Label id",
-      "example": 1,
-      "minimum": 1,
-      "maximum": 5,
-      "exclusiveMaximum":true
+      "example": 1
     },
     "displayLabel": {
       "type": "string",
       "description": "Display Label Name",
-      "maxLength": 50
+      "example": "User defined field 1"
     },
     "displayOnFullTextFinder": {
       "type": "boolean",

--- a/src/main/java/org/folio/rest/converter/labels/CustomLabelPutRequestConverter.java
+++ b/src/main/java/org/folio/rest/converter/labels/CustomLabelPutRequestConverter.java
@@ -1,0 +1,29 @@
+package org.folio.rest.converter.labels;
+
+
+import static org.folio.rest.converter.labels.CustomLabelsItemConverter.CUSTOM_LABEL_TYPE;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import org.folio.rest.jaxrs.model.CustomLabel;
+import org.folio.rest.jaxrs.model.CustomLabelCollectionItem;
+import org.folio.rest.jaxrs.model.CustomLabelDataAttributes;
+import org.folio.rest.jaxrs.model.CustomLabelPutRequest;
+import org.folio.rest.util.RestConstants;
+
+@Component
+public class CustomLabelPutRequestConverter implements Converter<CustomLabelPutRequest, CustomLabel> {
+  @Override
+  public CustomLabel convert(CustomLabelPutRequest customLabelPutRequest) {
+    return new CustomLabel()
+      .withData(new CustomLabelCollectionItem()
+        .withType(CUSTOM_LABEL_TYPE)
+        .withAttributes(new CustomLabelDataAttributes()
+          .withId(customLabelPutRequest.getData().getAttributes().getId())
+          .withDisplayLabel(customLabelPutRequest.getData().getAttributes().getDisplayLabel())
+          .withDisplayOnFullTextFinder(customLabelPutRequest.getData().getAttributes().getDisplayOnFullTextFinder())
+          .withDisplayOnPublicationFinder(customLabelPutRequest.getData().getAttributes().getDisplayOnPublicationFinder())))
+      .withJsonapi(RestConstants.JSONAPI);
+  }
+}

--- a/src/main/java/org/folio/rest/converter/labels/CustomLabelPutRequestToRmApiConverter.java
+++ b/src/main/java/org/folio/rest/converter/labels/CustomLabelPutRequestToRmApiConverter.java
@@ -1,0 +1,19 @@
+package org.folio.rest.converter.labels;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import org.folio.rest.jaxrs.model.CustomLabelPutRequest;
+
+@Component
+public class CustomLabelPutRequestToRmApiConverter implements Converter<CustomLabelPutRequest, org.folio.holdingsiq.model.CustomLabel> {
+
+  @Override
+  public org.folio.holdingsiq.model.CustomLabel convert(CustomLabelPutRequest customLabelPutRequest) {
+    return org.folio.holdingsiq.model.CustomLabel.builder()
+      .id(customLabelPutRequest.getData().getAttributes().getId())
+      .displayLabel(customLabelPutRequest.getData().getAttributes().getDisplayLabel())
+      .displayOnFullTextFinder(customLabelPutRequest.getData().getAttributes().getDisplayOnFullTextFinder())
+      .displayOnPublicationFinder(customLabelPutRequest.getData().getAttributes().getDisplayOnPublicationFinder()).build();
+  }
+}

--- a/src/main/java/org/folio/rest/converter/labels/CustomLabelsItemConverter.java
+++ b/src/main/java/org/folio/rest/converter/labels/CustomLabelsItemConverter.java
@@ -11,7 +11,7 @@ import org.folio.rest.jaxrs.model.CustomLabelDataAttributes;
 @Component
 public class CustomLabelsItemConverter implements Converter<CustomLabel, CustomLabelCollectionItem> {
 
-  private static final String CUSTOM_LABEL_TYPE = "customLabel";
+  static final String CUSTOM_LABEL_TYPE = "customLabel";
 
   @Override
   public CustomLabelCollectionItem convert(@NonNull CustomLabel customLabel) {

--- a/src/main/java/org/folio/rest/impl/EholdingsCustomLabelsImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsCustomLabelsImpl.java
@@ -83,7 +83,7 @@ public class EholdingsCustomLabelsImpl implements EholdingsCustomLabels {
   }
 
   private CustomLabel getCustomLabelById(int fieldId, RootProxyCustomLabels rootProxyCustomLabels) {
-    final Integer index = findElementById(rootProxyCustomLabels.getLabelList(), fieldId);
+    final Integer index = findIndexById(rootProxyCustomLabels.getLabelList(), fieldId);
     if (fieldId <= 0 || Objects.isNull(index)){
       throw new NotFoundException();
     }
@@ -118,7 +118,7 @@ public class EholdingsCustomLabelsImpl implements EholdingsCustomLabels {
 
   private void updateCustomLabelsCollection(CustomLabel entity, RootProxyCustomLabels labels) {
     final List<CustomLabel> labelList = labels.getLabelList();
-    final Integer index = findElementById(labelList, entity.getId());
+    final Integer index = findIndexById(labelList, entity.getId());
 
     if(Objects.nonNull(index)){
       labelList.set(index, entity);
@@ -127,7 +127,7 @@ public class EholdingsCustomLabelsImpl implements EholdingsCustomLabels {
     }
   }
 
-  private Integer findElementById(List<CustomLabel> labelList, int id){
+  private Integer findIndexById(List<CustomLabel> labelList, int id){
 
     for (int index = 0; index < labelList.size(); index++) {
       final Integer customLabelId = labelList.get(index).getId();

--- a/src/main/java/org/folio/rest/validator/CustomLabelsPutBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/CustomLabelsPutBodyValidator.java
@@ -11,7 +11,9 @@ public class CustomLabelsPutBodyValidator {
 
   private static final String INVALID_REQUEST_BODY_TITLE = "Invalid request body";
   private static final String INVALID_REQUEST_BODY_DETAILS = "Json body must contain data.attributes";
+  private static final String MUST_BE_IN_RANGE = "Ids should be equal!  %d != %d";
   private static final int CUSTOM_LABEL_NAME_MAX_LENGTH = 50;
+  private String CUSTOM_LABEL_ID = "Custom Label id";
 
   public void validate(CustomLabelPutRequest request, int customLabelId) {
     if (request == null ||
@@ -21,10 +23,18 @@ public class CustomLabelsPutBodyValidator {
     }
     final CustomLabelDataAttributes attributes = request.getData().getAttributes();
     final Integer id = attributes.getId();
-    ValidatorUtil.checkInRange(1, 5, id, "Custom Label id");
-    ValidatorUtil.checkIsEqual(customLabelId, id);
+    ValidatorUtil.checkInRange(1, 5, id, CUSTOM_LABEL_ID);
+    checkIsEqual(customLabelId, id);
     ValidatorUtil.checkMaxLength("Custom Label Name", attributes.getDisplayLabel(), CUSTOM_LABEL_NAME_MAX_LENGTH);
     ValidatorUtil.checkIsNotNull("Full Text Finder", attributes.getDisplayOnFullTextFinder());
     ValidatorUtil.checkIsNotNull("Publication Finder", attributes.getDisplayOnPublicationFinder());
+  }
+
+  private void checkIsEqual(int customLabelId, Integer id) {
+    if(customLabelId != id) {
+      throw new InputValidationException(
+        String.format("Invalid %s", CUSTOM_LABEL_ID),
+        String.format(MUST_BE_IN_RANGE, customLabelId, id));
+    }
   }
 }

--- a/src/main/java/org/folio/rest/validator/CustomLabelsPutBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/CustomLabelsPutBodyValidator.java
@@ -1,0 +1,30 @@
+package org.folio.rest.validator;
+
+import org.springframework.stereotype.Component;
+
+import org.folio.rest.exception.InputValidationException;
+import org.folio.rest.jaxrs.model.CustomLabelDataAttributes;
+import org.folio.rest.jaxrs.model.CustomLabelPutRequest;
+
+@Component
+public class CustomLabelsPutBodyValidator {
+
+  private static final String INVALID_REQUEST_BODY_TITLE = "Invalid request body";
+  private static final String INVALID_REQUEST_BODY_DETAILS = "Json body must contain data.attributes";
+  private static final int CUSTOM_LABEL_NAME_MAX_LENGTH = 50;
+
+  public void validate(CustomLabelPutRequest request, int customLabelId) {
+    if (request == null ||
+      request.getData() == null ||
+      request.getData().getAttributes() == null) {
+      throw new InputValidationException(INVALID_REQUEST_BODY_TITLE, INVALID_REQUEST_BODY_DETAILS);
+    }
+    final CustomLabelDataAttributes attributes = request.getData().getAttributes();
+    final Integer id = attributes.getId();
+    ValidatorUtil.checkInRange(1, 5, id, "Custom Label id");
+    ValidatorUtil.checkIsEqual(customLabelId, id);
+    ValidatorUtil.checkMaxLength("Custom Label Name", attributes.getDisplayLabel(), CUSTOM_LABEL_NAME_MAX_LENGTH);
+    ValidatorUtil.checkIsNotNull("Full Text Finder", attributes.getDisplayOnFullTextFinder());
+    ValidatorUtil.checkIsNotNull("Publication Finder", attributes.getDisplayOnPublicationFinder());
+  }
+}

--- a/src/main/java/org/folio/rest/validator/CustomLabelsPutBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/CustomLabelsPutBodyValidator.java
@@ -11,9 +11,9 @@ public class CustomLabelsPutBodyValidator {
 
   private static final String INVALID_REQUEST_BODY_TITLE = "Invalid request body";
   private static final String INVALID_REQUEST_BODY_DETAILS = "Json body must contain data.attributes";
-  private static final String MUST_BE_IN_RANGE = "Ids should be equal!  %d != %d";
+  private static final String MUST_HAVE_EQUAL_IDS = "Ids should be equal!  %d != %d";
   private static final int CUSTOM_LABEL_NAME_MAX_LENGTH = 50;
-  private String CUSTOM_LABEL_ID = "Custom Label id";
+  private static final String CUSTOM_LABEL_ID = "Custom Label id";
 
   public void validate(CustomLabelPutRequest request, int customLabelId) {
     if (request == null ||
@@ -34,7 +34,7 @@ public class CustomLabelsPutBodyValidator {
     if(customLabelId != id) {
       throw new InputValidationException(
         String.format("Invalid %s", CUSTOM_LABEL_ID),
-        String.format(MUST_BE_IN_RANGE, customLabelId, id));
+        String.format(MUST_HAVE_EQUAL_IDS, customLabelId, id));
     }
   }
 }

--- a/src/main/java/org/folio/rest/validator/ValidatorUtil.java
+++ b/src/main/java/org/folio/rest/validator/ValidatorUtil.java
@@ -7,6 +7,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Objects;
 
+import org.apache.commons.lang.math.IntRange;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -27,6 +28,8 @@ public class ValidatorUtil {
   private static final String MUST_BE_VALID_URL = "%s has invalid format. Should start with https:// or http://";
   private static final String INVALID_DATES_ORDER = "Begin Coverage should be smaller than End Coverage";
   private static final String IDENTIFIER_ID = "identifier id";
+  private static final String INVALID_ID = "%s should be in range %d - %d";
+  private static final String NOT_EQUAL_ID = "Ids should be equal!  %d != %d";
 
   private ValidatorUtil() {
   }
@@ -146,5 +149,22 @@ public class ValidatorUtil {
     checkIsNotNull(paramName, identifier);
     checkIsNotNull(IDENTIFIER_ID, identifier.getId());
     checkMaxLength(paramName, identifier.getId(), 20);
+  }
+
+  public static void checkInRange(int minInclusive, int maxInclusive, Integer value, String paramName) {
+    IntRange myRange = new IntRange(minInclusive, maxInclusive);
+    if(!myRange.containsInteger(value)){
+      throw new InputValidationException(
+        String.format(INVALID_FIELD_FORMAT, paramName),
+        String.format(INVALID_ID, paramName, minInclusive, maxInclusive));
+    }
+  }
+
+  public static void checkIsEqual(int customLabelId, int id) {
+    if(customLabelId != id) {
+      throw new InputValidationException(
+        String.format(INVALID_FIELD_FORMAT, IDENTIFIER_ID),
+        String.format(NOT_EQUAL_ID, customLabelId, id));
+    }
   }
 }

--- a/src/main/java/org/folio/rest/validator/ValidatorUtil.java
+++ b/src/main/java/org/folio/rest/validator/ValidatorUtil.java
@@ -26,7 +26,7 @@ public class ValidatorUtil {
   private static final DateTimeFormatter DATE_PATTERN = DateTimeFormatter.ofPattern("yyyy-MM-dd");
   private static final String MUST_BE_VALID_URL = "%s has invalid format. Should start with https:// or http://";
   private static final String INVALID_DATES_ORDER = "Begin Coverage should be smaller than End Coverage";
-  private static final String INVALID_ID = "%s should be in range %d - %d";
+  private static final String MUST_BE_IN_RANGE = "%s should be in range %d - %d";
 
   private ValidatorUtil() {
   }
@@ -147,7 +147,7 @@ public class ValidatorUtil {
     if(!myRange.containsInteger(value)){
       throw new InputValidationException(
         String.format(INVALID_FIELD_FORMAT, paramName),
-        String.format(INVALID_ID, paramName, minInclusive, maxInclusive));
+        String.format(MUST_BE_IN_RANGE, paramName, minInclusive, maxInclusive));
     }
   }
 }

--- a/src/main/java/org/folio/rest/validator/ValidatorUtil.java
+++ b/src/main/java/org/folio/rest/validator/ValidatorUtil.java
@@ -12,7 +12,6 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.folio.rest.exception.InputValidationException;
-import org.folio.rest.jaxrs.model.Identifier;
 
 public class ValidatorUtil {
 
@@ -27,9 +26,7 @@ public class ValidatorUtil {
   private static final DateTimeFormatter DATE_PATTERN = DateTimeFormatter.ofPattern("yyyy-MM-dd");
   private static final String MUST_BE_VALID_URL = "%s has invalid format. Should start with https:// or http://";
   private static final String INVALID_DATES_ORDER = "Begin Coverage should be smaller than End Coverage";
-  private static final String IDENTIFIER_ID = "identifier id";
   private static final String INVALID_ID = "%s should be in range %d - %d";
-  private static final String NOT_EQUAL_ID = "Ids should be equal!  %d != %d";
 
   private ValidatorUtil() {
   }
@@ -145,26 +142,12 @@ public class ValidatorUtil {
     }
   }
 
-  public static void checkIdentifierValid(String paramName, Identifier identifier) {
-    checkIsNotNull(paramName, identifier);
-    checkIsNotNull(IDENTIFIER_ID, identifier.getId());
-    checkMaxLength(paramName, identifier.getId(), 20);
-  }
-
   public static void checkInRange(int minInclusive, int maxInclusive, Integer value, String paramName) {
     IntRange myRange = new IntRange(minInclusive, maxInclusive);
     if(!myRange.containsInteger(value)){
       throw new InputValidationException(
         String.format(INVALID_FIELD_FORMAT, paramName),
         String.format(INVALID_ID, paramName, minInclusive, maxInclusive));
-    }
-  }
-
-  public static void checkIsEqual(int customLabelId, int id) {
-    if(customLabelId != id) {
-      throw new InputValidationException(
-        String.format(INVALID_FIELD_FORMAT, IDENTIFIER_ID),
-        String.format(NOT_EQUAL_ID, customLabelId, id));
     }
   }
 }

--- a/src/test/java/org/folio/rest/converter/labels/CustomLabelPutRequestConverterTest.java
+++ b/src/test/java/org/folio/rest/converter/labels/CustomLabelPutRequestConverterTest.java
@@ -1,0 +1,42 @@
+package org.folio.rest.converter.labels;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.folio.test.util.TestUtil.getFile;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import org.folio.rest.jaxrs.model.CustomLabel;
+import org.folio.rest.jaxrs.model.CustomLabelPutRequest;
+import org.folio.rest.util.RestConstants;
+import org.folio.spring.config.TestConfig;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestConfig.class)
+public class CustomLabelPutRequestConverterTest {
+
+  @Autowired
+  private CustomLabelPutRequestConverter putRequestConverter;
+  @Test
+  public void shouldConvertToCustomLabel() throws URISyntaxException, IOException {
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    CustomLabelPutRequest putRequest = mapper.readValue(
+      getFile("requests/kb-ebsco/custom-labels/put-custom-label.json"), CustomLabelPutRequest.class);
+    final CustomLabel convertedLabel = putRequestConverter.convert(putRequest);
+    Integer customLabelId = 1;
+    assertEquals(customLabelId, convertedLabel.getData().getAttributes().getId());
+    assertEquals("customLabel", convertedLabel.getData().getType());
+    assertEquals(RestConstants.JSONAPI, convertedLabel.getJsonapi());
+  }
+
+}

--- a/src/test/java/org/folio/rest/converter/labels/CustomLabelPutRequestToRmApiConverterTest.java
+++ b/src/test/java/org/folio/rest/converter/labels/CustomLabelPutRequestToRmApiConverterTest.java
@@ -1,0 +1,42 @@
+package org.folio.rest.converter.labels;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static org.folio.test.util.TestUtil.getFile;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import org.folio.holdingsiq.model.CustomLabel;
+import org.folio.rest.jaxrs.model.CustomLabelPutRequest;
+import org.folio.spring.config.TestConfig;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestConfig.class)
+public class CustomLabelPutRequestToRmApiConverterTest {
+  @Autowired
+  private CustomLabelPutRequestToRmApiConverter converter;
+  @Test
+  public void shouldConvertToCustomLabel() throws URISyntaxException, IOException {
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    CustomLabelPutRequest putRequest = mapper.readValue(
+      getFile("requests/kb-ebsco/custom-labels/put-custom-label.json"), CustomLabelPutRequest.class);
+    final CustomLabel convertedLabel = converter.convert(putRequest);
+    Integer customLabelId = 1;
+    assertEquals(customLabelId, convertedLabel.getId());
+    assertEquals("test label 1 updated", convertedLabel.getDisplayLabel());
+    assertFalse(convertedLabel.getDisplayOnFullTextFinder());
+    assertTrue(convertedLabel.getDisplayOnPublicationFinder());
+  }
+}

--- a/src/test/java/org/folio/rest/validator/CustomLabelsPutBodyValidatorTest.java
+++ b/src/test/java/org/folio/rest/validator/CustomLabelsPutBodyValidatorTest.java
@@ -1,0 +1,137 @@
+package org.folio.rest.validator;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.folio.rest.exception.InputValidationException;
+import org.folio.rest.jaxrs.model.CustomLabelCollectionItem;
+import org.folio.rest.jaxrs.model.CustomLabelDataAttributes;
+import org.folio.rest.jaxrs.model.CustomLabelPutRequest;
+
+public class CustomLabelsPutBodyValidatorTest {
+
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+  private CustomLabelsPutBodyValidator validator = new CustomLabelsPutBodyValidator();
+
+  @Test(expected = InputValidationException.class)
+  public void shouldThrowExceptionWhenNoPutBody(){
+    CustomLabelPutRequest putRequest = null;
+    validator.validate(putRequest, 1);
+  }
+
+  @Test(expected = InputValidationException.class)
+  public void shouldThrowExceptionWhenEmptyBody(){
+    CustomLabelPutRequest putRequest = new CustomLabelPutRequest();
+    validator.validate(putRequest, 1);
+  }
+
+  @Test(expected = InputValidationException.class)
+  public void shouldThrowExceptionWhenNoPutData(){
+    CustomLabelPutRequest putRequest = new CustomLabelPutRequest()
+      .withData(null);
+    validator.validate(putRequest, 1);
+  }
+
+  @Test(expected = InputValidationException.class)
+  public void shouldThrowExceptionWhenEmptyPutData(){
+    CustomLabelPutRequest putRequest = new CustomLabelPutRequest()
+      .withData(new CustomLabelCollectionItem());
+    validator.validate(putRequest, 1);
+  }
+
+  @Test(expected = InputValidationException.class)
+  public void shouldThrowExceptionWhenInvalidId(){
+    CustomLabelPutRequest putRequest = new CustomLabelPutRequest()
+      .withData(new CustomLabelCollectionItem()
+        .withAttributes(new CustomLabelDataAttributes()
+          .withId(6)
+        )
+      );
+    validator.validate(putRequest, 1);
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenNotEqualId() {
+    expectedEx.expect(InputValidationException.class);
+    expectedEx.expectMessage("Invalid identifier id");
+    CustomLabelPutRequest putRequest = new CustomLabelPutRequest()
+      .withData(new CustomLabelCollectionItem()
+        .withAttributes(new CustomLabelDataAttributes()
+          .withId(3)
+        )
+      );
+    validator.validate(putRequest, 1);
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenIdIsNull(){
+    expectedEx.expect(InputValidationException.class);
+    expectedEx.expectMessage("Invalid Custom Label id");
+    CustomLabelPutRequest putRequest = new CustomLabelPutRequest()
+      .withData(new CustomLabelCollectionItem()
+        .withAttributes(new CustomLabelDataAttributes()
+          .withId(null)
+        )
+      );
+    validator.validate(putRequest, 1);
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenNameIsTooLong() {
+    expectedEx.expect(InputValidationException.class);
+    expectedEx.expectMessage("Invalid Custom Label Name");
+    final CustomLabelPutRequest request = new CustomLabelPutRequest()
+      .withData(new CustomLabelCollectionItem()
+        .withAttributes(new CustomLabelDataAttributes()
+          .withId(1)
+          .withDisplayLabel(RandomStringUtils.randomAlphanumeric(51)))
+      );
+    validator.validate(request, 1);
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenPublicationFinderIsNull() {
+    expectedEx.expect(InputValidationException.class);
+    expectedEx.expectMessage("Invalid Publication Finder");
+    final CustomLabelPutRequest request = new CustomLabelPutRequest()
+      .withData(new CustomLabelCollectionItem()
+        .withAttributes(new CustomLabelDataAttributes()
+          .withDisplayLabel(RandomStringUtils.randomAlphanumeric(40))
+          .withId(1)
+          .withDisplayOnFullTextFinder(false)
+          .withDisplayOnPublicationFinder(null))
+      );
+    validator.validate(request, 1);
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenFullTextFinderIsNull() {
+    expectedEx.expect(InputValidationException.class);
+    expectedEx.expectMessage("Invalid Full Text Finder");
+    final CustomLabelPutRequest request = new CustomLabelPutRequest()
+      .withData(new CustomLabelCollectionItem()
+        .withAttributes(new CustomLabelDataAttributes()
+          .withDisplayLabel(RandomStringUtils.randomAlphanumeric(40))
+          .withId(1)
+          .withDisplayOnFullTextFinder(null)
+          .withDisplayOnPublicationFinder(false))
+      );
+    validator.validate(request, 1);
+  }
+
+  @Test
+  public void shouldNotFallWhenPutBodyRequestIsValid() {
+    final CustomLabelPutRequest request = new CustomLabelPutRequest()
+      .withData(new CustomLabelCollectionItem()
+        .withAttributes(new CustomLabelDataAttributes()
+          .withDisplayLabel(RandomStringUtils.randomAlphanumeric(40))
+          .withId(1)
+          .withDisplayOnFullTextFinder(false)
+          .withDisplayOnPublicationFinder(false))
+      );
+    validator.validate(request, 1);
+  }
+}

--- a/src/test/java/org/folio/rest/validator/CustomLabelsPutBodyValidatorTest.java
+++ b/src/test/java/org/folio/rest/validator/CustomLabelsPutBodyValidatorTest.java
@@ -56,7 +56,7 @@ public class CustomLabelsPutBodyValidatorTest {
   @Test
   public void shouldThrowExceptionWhenNotEqualId() {
     expectedEx.expect(InputValidationException.class);
-    expectedEx.expectMessage("Invalid identifier id");
+    expectedEx.expectMessage("Invalid Custom Label id");
     CustomLabelPutRequest putRequest = new CustomLabelPutRequest()
       .withData(new CustomLabelCollectionItem()
         .withAttributes(new CustomLabelDataAttributes()

--- a/src/test/resources/requests/kb-ebsco/custom-labels/put-custom-label-id-five.json
+++ b/src/test/resources/requests/kb-ebsco/custom-labels/put-custom-label-id-five.json
@@ -2,10 +2,10 @@
   "data": {
     "type": "customLabel",
     "attributes": {
-      "id": 1,
-      "displayLabel": "test label 1 updated",
+      "id": 5,
+      "displayLabel": "test label 5 updated",
       "displayOnFullTextFinder": false,
-      "displayOnPublicationFinder": true
+      "displayOnPublicationFinder": false
     }
   }
 }

--- a/src/test/resources/requests/kb-ebsco/custom-labels/put-custom-label-invalid-id.json
+++ b/src/test/resources/requests/kb-ebsco/custom-labels/put-custom-label-invalid-id.json
@@ -2,7 +2,7 @@
   "data": {
     "type": "customLabel",
     "attributes": {
-      "id": 1,
+      "id": 6,
       "displayLabel": "test label 1 updated",
       "displayOnFullTextFinder": false,
       "displayOnPublicationFinder": true

--- a/src/test/resources/requests/kb-ebsco/custom-labels/put-custom-label-invalid-name.json
+++ b/src/test/resources/requests/kb-ebsco/custom-labels/put-custom-label-invalid-name.json
@@ -3,7 +3,7 @@
     "type": "customLabel",
     "attributes": {
       "id": 1,
-      "displayLabel": "test label 1 updated",
+      "displayLabel": "Lorem ipsum dolor sit amet, consectetuer adipiscin",
       "displayOnFullTextFinder": false,
       "displayOnPublicationFinder": true
     }

--- a/src/test/resources/requests/rmapi/custom-labels/put-custom-labels-two-elements.json
+++ b/src/test/resources/requests/rmapi/custom-labels/put-custom-labels-two-elements.json
@@ -1,0 +1,21 @@
+{
+  "proxy": {
+    "id": "Test-Proxy-ID-123",
+    "inherited": null
+  },
+  "vendorId": "19",
+  "labels": [
+    {
+      "id": 1,
+      "displayLabel": "test label 1",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": true
+    },
+    {
+      "id": 5,
+      "displayLabel": "test label 5 updated",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": false
+    }
+  ]
+}

--- a/src/test/resources/responses/kb-ebsco/custom-labels/get-custom-label-single-element-id-five.json
+++ b/src/test/resources/responses/kb-ebsco/custom-labels/get-custom-label-single-element-id-five.json
@@ -2,10 +2,13 @@
   "data": {
     "type": "customLabel",
     "attributes": {
-      "id": 1,
-      "displayLabel": "test label 1 updated",
+      "id": 5,
+      "displayLabel": "test label 5",
       "displayOnFullTextFinder": false,
       "displayOnPublicationFinder": true
     }
+  },
+  "jsonapi": {
+    "version": "1.0"
   }
 }

--- a/src/test/resources/responses/kb-ebsco/custom-labels/get-custom-labels-list-updated.json
+++ b/src/test/resources/responses/kb-ebsco/custom-labels/get-custom-labels-list-updated.json
@@ -1,0 +1,55 @@
+{
+  "data": [
+    {
+      "type": "customLabel",
+      "attributes": {
+        "id": 1,
+        "displayLabel": "test label 1 updated",
+        "displayOnFullTextFinder": false,
+        "displayOnPublicationFinder": true
+      }
+    },
+    {
+      "type": "customLabel",
+      "attributes": {
+        "id": 2,
+        "displayLabel": "label 2",
+        "displayOnFullTextFinder": true,
+        "displayOnPublicationFinder": true
+      }
+    },
+    {
+      "type": "customLabel",
+      "attributes": {
+        "id": 3,
+        "displayLabel": "label 3",
+        "displayOnFullTextFinder": false,
+        "displayOnPublicationFinder": true
+      }
+    },
+    {
+      "type": "customLabel",
+      "attributes": {
+        "id": 4,
+        "displayLabel": "label 4",
+        "displayOnFullTextFinder": true,
+        "displayOnPublicationFinder": false
+      }
+    },
+    {
+      "type": "customLabel",
+      "attributes": {
+        "id": 5,
+        "displayLabel": "label 5",
+        "displayOnFullTextFinder": false,
+        "displayOnPublicationFinder": false
+      }
+    }
+  ],
+  "meta": {
+    "totalResults": 5
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/src/test/resources/responses/rmapi/custom-labels/get-custom-labels-two-elements.json
+++ b/src/test/resources/responses/rmapi/custom-labels/get-custom-labels-two-elements.json
@@ -1,0 +1,28 @@
+{
+  "proxy": {
+    "id": "Test-Proxy-ID-123"
+  },
+  "vendorId": 19,
+  "ftfTokens": [
+    {
+      "key": "CCC.Password",
+      "shouldShowOneResourcePerLinkSource": true,
+      "targetID": "19",
+      "token": 1
+    }
+  ],
+  "labels": [
+    {
+      "id": 1,
+      "displayLabel": "test label 1",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": true
+    },
+    {
+      "id": 5,
+      "displayLabel": "test label 5",
+      "displayOnFullTextFinder": false,
+      "displayOnPublicationFinder": true
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
Due to https://issues.folio.org/browse/MODKBEKBJ-341 we want to add the ability to update custom labels by id

## Approach
* updated raml and json example files
* added implementation for PUT /custom-labels/{id}
* added validator for put custom field body
* added converters
* added/updated tests

The returned value of PUT /custom-labels{id} is converted put body with updated values. It was done because of the known but not resolved issue https://corptools.ebsco-gss.net/serviceissues/?si=491744 from RM API side.
