### PR TITLE
MODKBEKBJ-346: Fix bug where resource is not removed if request has userDefinedFields

### DIFF
--- a/src/main/java/org/folio/repository/holdings/ReportStatus.java
+++ b/src/main/java/org/folio/repository/holdings/ReportStatus.java
@@ -19,6 +19,6 @@ public enum ReportStatus {
     return Arrays.stream(values())
       .filter(statusValue -> statusValue.value.equalsIgnoreCase(value))
       .findFirst()
-      .orElseThrow(() -> new IllegalArgumentException("DeltaReportStatus with value " + value + " doesn't exist"));
+      .orElseThrow(() -> new IllegalArgumentException("ReportStatus with value " + value + " doesn't exist"));
   }
 }

--- a/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
@@ -46,7 +46,6 @@ import org.folio.rest.exception.InputValidationException;
 import org.folio.rest.jaxrs.model.Resource;
 import org.folio.rest.jaxrs.model.ResourcePostDataAttributes;
 import org.folio.rest.jaxrs.model.ResourcePostRequest;
-import org.folio.rest.jaxrs.model.ResourcePutDataAttributes;
 import org.folio.rest.jaxrs.model.ResourcePutRequest;
 import org.folio.rest.jaxrs.model.ResourceTags;
 import org.folio.rest.jaxrs.model.ResourceTagsDataAttributes;
@@ -273,10 +272,6 @@ public class EholdingsResourcesImpl implements EholdingsResources {
   }
 
   private CompletableFuture<Title> processResourceUpdate(ResourcePutRequest entity, ResourceId parsedResourceId, RMAPITemplateContext context) {
-    if(!resourceCanBeUpdated(entity)){
-      //Return current state of resource without updating it
-      return context.getResourcesService().retrieveResource(parsedResourceId);
-    }
     return context.getResourcesService().retrieveResource(parsedResourceId)
       .thenCompose(title -> {
         ResourcePut resourcePutBody;
@@ -290,20 +285,5 @@ public class EholdingsResourcesImpl implements EholdingsResources {
         return context.getResourcesService().updateResource(parsedResourceId, resourcePutBody);
       })
       .thenCompose(o -> context.getResourcesService().retrieveResource(parsedResourceId));
-  }
-
-  private boolean resourceCanBeUpdated(ResourcePutRequest entity) {
-    ResourcePutDataAttributes attributes = entity.getData().getAttributes();
-    boolean isTitleCustom = !Objects.isNull(attributes.getIsTitleCustom()) && attributes.getIsTitleCustom();
-    boolean isSelected = !Objects.isNull(attributes.getIsSelected()) && attributes.getIsSelected();
-    if(!isSelected && !isTitleCustom){
-      try{
-        resourcePutBodyValidator.validate(entity, isTitleCustom);
-      }
-      catch (InputValidationException ex){
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/src/main/java/org/folio/rest/validator/ResourcePutBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/ResourcePutBodyValidator.java
@@ -85,11 +85,11 @@ public class ResourcePutBodyValidator {
       (!Strings.isEmpty(cvgStmt) || !Objects.isNull(embargoUnit) ||
       (!Objects.isNull(isHidden) && isHidden) ||
       (!Objects.isNull(customCoverages) && !customCoverages.isEmpty()) ||
-        !Objects.isNull(attributes.getUserDefinedField1()) ||
-        !Objects.isNull(attributes.getUserDefinedField2()) ||
-        !Objects.isNull(attributes.getUserDefinedField3()) ||
-        !Objects.isNull(attributes.getUserDefinedField4()) ||
-        !Objects.isNull(attributes.getUserDefinedField5())
+        !Strings.isEmpty(attributes.getUserDefinedField1()) ||
+        !Strings.isEmpty(attributes.getUserDefinedField2()) ||
+        !Strings.isEmpty(attributes.getUserDefinedField3()) ||
+        !Strings.isEmpty(attributes.getUserDefinedField4()) ||
+        !Strings.isEmpty(attributes.getUserDefinedField5())
       )) {
       throw new InputValidationException(INVALID_IS_SELECTED_TITLE, INVALID_IS_SELECTED_DETAILS);
     }

--- a/src/test/resources/requests/kb-ebsco/resource/put-managed-resource-is-not-selected.json
+++ b/src/test/resources/requests/kb-ebsco/resource/put-managed-resource-is-not-selected.json
@@ -1,0 +1,55 @@
+{
+  "data" : {
+    "id" : "19-3964-762169",
+    "type" : "resources",
+    "attributes" : {
+      "isTitleCustom" : false,
+      "titleId" : 762169,
+      "name" : "\"Great Satan\" Vs. the \"Mad Mullahs\": How the United States and Iran Demonize Each Other",
+      "coverageStatement": "",
+      "customEmbargoPeriod": {},
+      "isPackageCustom" : false,
+      "isSelected" : true,
+      "managedCoverages": [
+        {
+          "beginCoverage": "2016-01-01",
+          "endCoverage": "2016-12-31"
+        }
+      ],
+      "customCoverages": [],
+      "isTokenNeeded" : false,
+      "locationId" : 2863717,
+      "managedEmbargoPeriod": {
+        "embargoValue": 0
+      },
+      "packageId" : "19-3964",
+      "packageName" : "ABC-CLIO eBook Collection",
+      "url" : "https://publisher.abc-clio.com/9780313068003/",
+      "providerId" : 19,
+      "providerName" : "ABC-CLIO",
+      "visibilityData": {
+        "isHidden": false,
+        "reason": ""
+      },
+      "proxy": {},
+      "userDefinedField1": "",
+      "userDefinedField2": "",
+      "userDefinedField3": "",
+      "userDefinedField4": "",
+      "userDefinedField5": "",
+      "publisherName": "Praeger",
+      "edition": "",
+      "publicationType": "Book",
+      "subjects": [
+        {
+          "type": "BISAC",
+          "subject": "SOCIAL SCIENCE / Ethnic Studies / General"
+        }
+      ],
+      "contributors": [],
+      "identifiers": [],
+      "isPeerReviewed": false,
+      "description": ""
+    }
+  }
+}

--- a/src/test/resources/requests/rmapi/resources/put-managed-resource-is-not-selected.json
+++ b/src/test/resources/requests/rmapi/resources/put-managed-resource-is-not-selected.json
@@ -1,0 +1,5 @@
+{
+  "isSelected": false,
+  "titleName": null,
+  "pubType": "Book"
+}

--- a/src/test/resources/responses/rmapi/resources/get-managed-resource-updated-response-is-selected-false.json
+++ b/src/test/resources/responses/rmapi/resources/get-managed-resource-updated-response-is-selected-false.json
@@ -1,0 +1,98 @@
+{
+  "titleId": 762169,
+  "titleName": "\"Great Satan\" Vs. the \"Mad Mullahs\": How the United States and Iran Demonize Each Other",
+  "publisherName": "Praeger",
+  "identifiersList": [
+    {
+      "id": "300079",
+      "source": "ResourceIdentifier",
+      "subtype": 0,
+      "type": 7
+    },
+    {
+      "id": "762169",
+      "source": "AtoZ",
+      "subtype": 0,
+      "type": 9
+    },
+    {
+      "id": "978-0-275-98214-0",
+      "source": "ResourceIdentifier",
+      "subtype": 1,
+      "type": 1
+    },
+    {
+      "id": "978-0-313-06800-3",
+      "source": "ResourceIdentifier",
+      "subtype": 2,
+      "type": 1
+    },
+    {
+      "id": "978-1-282-40979-8",
+      "source": "ResourceIdentifier",
+      "subtype": 2,
+      "type": 1
+    }
+  ],
+  "subjectsList": [
+    {
+      "type": "BISAC",
+      "subject": "SOCIAL SCIENCE / Ethnic Studies / General"
+    }
+  ],
+  "isTitleCustom": false,
+  "pubType": "Book",
+  "customerResourcesList": [
+    {
+      "titleId": 762169,
+      "packageId": 3964,
+      "packageName": "ABC-CLIO eBook Collection",
+      "packageType": "Variable",
+      "proxy": {
+        "id": "Test-proxy-id",
+        "inherited": false
+      },
+      "isPackageCustom": false,
+      "vendorId": 19,
+      "vendorName": "ABC-CLIO",
+      "locationId": 2863717,
+      "isSelected": false,
+      "isTokenNeeded": false,
+      "visibilityData": {
+        "isHidden": false,
+        "reason": "Hidden by Customer"
+      },
+      "managedCoverageList": [
+        {
+          "beginCoverage": "2005-01-01",
+          "endCoverage": "2005-12-31"
+        }
+      ],
+      "customCoverageList": [],
+      "coverageStatement": "test coverage statement",
+      "managedEmbargoPeriod": {
+        "embargoUnit": null,
+        "embargoValue": 0
+      },
+      "customEmbargoPeriod": {
+        "embargoUnit": "Years",
+        "embargoValue": 10
+      },
+      "url": "https://publisher.abc-clio.com/9780313068003/",
+      "userDefinedField1": "test 1",
+      "userDefinedField2": "test 2",
+      "userDefinedField3": "",
+      "userDefinedField4": null,
+      "userDefinedField5": "test 5"
+    }
+  ],
+  "description": null,
+  "edition": null,
+  "isPeerReviewed": false,
+  "contributorsList": [
+    {
+      "type": "author",
+      "contributor": "Beeman, William O."
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
Make is possible to de-select resource if PUT /resources/{id} request contains userDefinedFields

## Approach
Allow empty userDefinedFields for PUT /resources/{id} requests where
isSelected=false.
Remove case in which PUT request is not sent to RM API if request is
invalid. This case was used to update tags when isSelected=false, but
now tags are updated in a separate endpoint.