### PR TITLE
MODKBEKBJ-380 Fix delete access type implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <raml-module-builder.version>29.1.1</raml-module-builder.version>
     <vertx.version>3.8.4</vertx.version>
-    <aspectj.version>1.9.1</aspectj.version>
+    <aspectj.version>1.9.4</aspectj.version>
     <folio-service-tools.version>1.4.0</folio-service-tools.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <jsonschema_paths>types/**</jsonschema_paths>

--- a/src/main/java/org/folio/repository/DbUtil.java
+++ b/src/main/java/org/folio/repository/DbUtil.java
@@ -1,6 +1,6 @@
 package org.folio.repository;
 
-import static org.folio.repository.accesstypes.AccessTypesMappingTableConstants.ACCESS_TYPES_MAPPING_TABLE_NAME;
+import static org.folio.repository.accesstypes.AccessTypeMappingsTableConstants.ACCESS_TYPES_MAPPING_TABLE_NAME;
 import static org.folio.repository.accesstypes.AccessTypesTableConstants.ACCESS_TYPES_TABLE_NAME;
 import static org.folio.repository.holdings.HoldingsTableConstants.HOLDINGS_TABLE;
 import static org.folio.repository.holdings.status.HoldingsStatusAuditTableConstants.HOLDINGS_STATUS_AUDIT_TABLE;

--- a/src/main/java/org/folio/repository/accesstypes/AccessTypeMappingsRepository.java
+++ b/src/main/java/org/folio/repository/accesstypes/AccessTypeMappingsRepository.java
@@ -1,15 +1,18 @@
 package org.folio.repository.accesstypes;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.repository.RecordType;
 
-public interface AccessTypesMappingRepository {
-
-  CompletableFuture<AccessTypeMapping> save(AccessTypeMapping accessTypeMapping, String tenantId);
+public interface AccessTypeMappingsRepository {
 
   CompletableFuture<Optional<AccessTypeMapping>> findByRecord(String recordId, RecordType recordType, String tenantId);
+
+  CompletableFuture<Collection<AccessTypeMapping>> findByAccessTypeId(String accessTypeId, String tenantId);
+
+  CompletableFuture<AccessTypeMapping> save(AccessTypeMapping accessTypeMapping, String tenantId);
 
   CompletableFuture<Void> deleteByRecord(String recordId, RecordType recordType, String tenantId);
 }

--- a/src/main/java/org/folio/repository/accesstypes/AccessTypeMappingsRepositoryImpl.java
+++ b/src/main/java/org/folio/repository/accesstypes/AccessTypeMappingsRepositoryImpl.java
@@ -4,17 +4,21 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
 import static org.folio.common.FutureUtils.mapResult;
+import static org.folio.common.ListUtils.mapItems;
 import static org.folio.db.DbUtils.createParams;
 import static org.folio.repository.DbUtil.getAccessTypesMappingTableName;
-import static org.folio.repository.accesstypes.AccessTypesMappingTableConstants.ACCESS_TYPE_ID_COLUMN;
-import static org.folio.repository.accesstypes.AccessTypesMappingTableConstants.DELETE_MAPPING_BY_RECORD_ID_AND_RECORD_TYPE;
-import static org.folio.repository.accesstypes.AccessTypesMappingTableConstants.ID_COLUMN;
-import static org.folio.repository.accesstypes.AccessTypesMappingTableConstants.RECORD_ID_COLUMN;
-import static org.folio.repository.accesstypes.AccessTypesMappingTableConstants.RECORD_TYPE_COLUMN;
-import static org.folio.repository.accesstypes.AccessTypesMappingTableConstants.SELECT_MAPPING_BY_RECORD_ID_AND_RECORD_TYPE;
-import static org.folio.repository.accesstypes.AccessTypesMappingTableConstants.UPSERT_MAPPING;
+import static org.folio.repository.accesstypes.AccessTypeMappingsTableConstants.ACCESS_TYPE_ID_COLUMN;
+import static org.folio.repository.accesstypes.AccessTypeMappingsTableConstants.DELETE_MAPPING_BY_RECORD_ID_AND_RECORD_TYPE;
+import static org.folio.repository.accesstypes.AccessTypeMappingsTableConstants.ID_COLUMN;
+import static org.folio.repository.accesstypes.AccessTypeMappingsTableConstants.RECORD_ID_COLUMN;
+import static org.folio.repository.accesstypes.AccessTypeMappingsTableConstants.RECORD_TYPE_COLUMN;
+import static org.folio.repository.accesstypes.AccessTypeMappingsTableConstants.SELECT_MAPPING_BY_ACCESS_TYPE_ID;
+import static org.folio.repository.accesstypes.AccessTypeMappingsTableConstants.SELECT_MAPPING_BY_RECORD_ID_AND_RECORD_TYPE;
+import static org.folio.repository.accesstypes.AccessTypeMappingsTableConstants.UPSERT_MAPPING;
 import static org.folio.util.FutureUtils.mapVertxFuture;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -36,27 +40,14 @@ import org.folio.repository.RecordType;
 import org.folio.rest.persist.PostgresClient;
 
 @Component
-public class AccessTypesMappingRepositoryImpl implements AccessTypesMappingRepository {
+public class AccessTypeMappingsRepositoryImpl implements AccessTypeMappingsRepository {
 
-  private static final Logger LOG = LoggerFactory.getLogger(AccessTypesMappingRepositoryImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AccessTypeMappingsRepositoryImpl.class);
 
   @Autowired
   private Vertx vertx;
   @Autowired
   private DBExceptionTranslator excTranslator;
-
-  @Override
-  public CompletableFuture<AccessTypeMapping> save(AccessTypeMapping mapping, String tenantId) {
-
-    JsonArray params = createUpsertParams(mapping);
-    String query = format(UPSERT_MAPPING, getAccessTypesMappingTableName(tenantId));
-
-    LOG.info("Do insert query = {}", query);
-    Promise<UpdateResult> promise = Promise.promise();
-    pgClient(tenantId).execute(query, params, promise);
-
-    return mapVertxFuture(promise.future().recover(excTranslator.translateOrPassBy())).thenApply(updateResult -> mapping);
-  }
 
   @Override
   public CompletableFuture<Optional<AccessTypeMapping>> findByRecord(String recordId, RecordType recordType,
@@ -69,6 +60,31 @@ public class AccessTypesMappingRepositoryImpl implements AccessTypesMappingRepos
     pgClient(tenantId).select(query, params, promise);
 
     return mapResult(promise.future(), this::mapToAccessTypeMapping);
+  }
+
+  @Override
+  public CompletableFuture<Collection<AccessTypeMapping>> findByAccessTypeId(String accessTypeId, String tenantId) {
+    JsonArray params = createParams(Collections.singletonList(accessTypeId));
+    String query = format(SELECT_MAPPING_BY_ACCESS_TYPE_ID, getAccessTypesMappingTableName(tenantId));
+
+    LOG.info("Do select query = {}", query);
+    Promise<ResultSet> promise = Promise.promise();
+    pgClient(tenantId).select(query, params, promise);
+
+    return mapResult(promise.future(), resultSet -> mapItems(resultSet.getRows(), this::mapAccessItem));
+  }
+
+  @Override
+  public CompletableFuture<AccessTypeMapping> save(AccessTypeMapping mapping, String tenantId) {
+
+    JsonArray params = createUpsertParams(mapping);
+    String query = format(UPSERT_MAPPING, getAccessTypesMappingTableName(tenantId));
+
+    LOG.info("Do insert query = {}", query);
+    Promise<UpdateResult> promise = Promise.promise();
+    pgClient(tenantId).execute(query, params, promise);
+
+    return mapVertxFuture(promise.future().recover(excTranslator.translateOrPassBy())).thenApply(updateResult -> mapping);
   }
 
   @Override

--- a/src/main/java/org/folio/repository/accesstypes/AccessTypeMappingsTableConstants.java
+++ b/src/main/java/org/folio/repository/accesstypes/AccessTypeMappingsTableConstants.java
@@ -1,6 +1,6 @@
 package org.folio.repository.accesstypes;
 
-public class AccessTypesMappingTableConstants {
+public class AccessTypeMappingsTableConstants {
 
   public static final String ID_COLUMN = "id";
   public static final String RECORD_ID_COLUMN = "record_id";
@@ -25,7 +25,10 @@ public class AccessTypesMappingTableConstants {
   public static final String SELECT_MAPPING_BY_RECORD_ID_AND_RECORD_TYPE =
     "SELECT * FROM %s WHERE " + CONDITION_BY_RECORD_ID_AND_RECORD_TYPE + " LIMIT 1;";
 
-  private AccessTypesMappingTableConstants() {
+  public static final String SELECT_MAPPING_BY_ACCESS_TYPE_ID =
+    "SELECT * FROM %s WHERE " + ACCESS_TYPE_ID_COLUMN + " = ?;";
+
+  private AccessTypeMappingsTableConstants() {
   }
 
 }

--- a/src/main/java/org/folio/repository/accesstypes/AccessTypesRepositoryImpl.java
+++ b/src/main/java/org/folio/repository/accesstypes/AccessTypesRepositoryImpl.java
@@ -86,10 +86,10 @@ public class AccessTypesRepositoryImpl implements AccessTypesRepository {
     pgClient(tenantId).update(ACCESS_TYPES_TABLE_NAME, accessType, id, promise);
 
     return mapResult(promise.future().recover(excTranslator.translateOrPassBy()), updateResult -> {
-      if(updateResult.getUpdated() == 0){
+      if (updateResult.getUpdated() == 0) {
         throw new NotFoundException(String.format(ACCESS_TYPE_NOT_FOUND_MESSAGE, id));
       }
-    return null;
+      return null;
     });
   }
 
@@ -111,11 +111,11 @@ public class AccessTypesRepositoryImpl implements AccessTypesRepository {
     pgClient(tenantId).delete(ACCESS_TYPES_TABLE_NAME, id, promise);
 
     return mapResult(promise.future().recover(excTranslator.translateOrPassBy()), updateResult -> {
-      if(updateResult.getUpdated() == 0){
+      if (updateResult.getUpdated() == 0) {
         throw new NotFoundException(String.format(ACCESS_TYPE_NOT_FOUND_MESSAGE, id));
       }
       return null;
-     });
+    });
   }
 
   private AccessTypeCollectionItem mapAccessItem(JsonObject row) {

--- a/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
@@ -92,6 +92,7 @@ import org.folio.rmapi.result.PackageResult;
 import org.folio.rmapi.result.ResourceCollectionResult;
 import org.folio.rmapi.result.TitleCollectionResult;
 import org.folio.rmapi.result.TitleResult;
+import org.folio.service.accesstypes.AccessTypeMappingsService;
 import org.folio.service.accesstypes.AccessTypesService;
 import org.folio.service.holdings.HoldingsService;
 import org.folio.spring.SpringContextUtil;
@@ -142,6 +143,8 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
   private Converter<Titles, TitleCollectionResult> titleCollectionConverter;
   @Autowired
   private AccessTypesService accessTypesService;
+  @Autowired
+  private AccessTypeMappingsService accessTypeMappingsService;
 
   public EholdingsPackagesImpl() {
     SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
@@ -350,7 +353,7 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
 
   private CompletableFuture<Void> updateRecordMapping(AccessTypeCollectionItem accessType, String recordId,
                                                       Map<String, String> okapiHeaders) {
-    return accessTypesService.updateRecordMapping(accessType, recordId, RecordType.PACKAGE, okapiHeaders);
+    return accessTypeMappingsService.update(accessType, recordId, RecordType.PACKAGE, okapiHeaders);
   }
 
   private CompletableFuture<AccessTypeCollectionItem> fetchAccessType(PackagePutRequest entity,

--- a/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
@@ -30,6 +30,7 @@ import io.vertx.core.Vertx;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.logging.log4j.util.Strings;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.convert.converter.Converter;
@@ -269,7 +270,7 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
               throw new InputValidationException(INVALID_PACKAGE_TITLE, INVALID_PACKAGE_DETAILS);
             }
             return context.getPackagesService().deletePackage(parsedPackageId)
-              .thenCompose(aVoid -> deleteTags(parsedPackageId, context.getOkapiData().getTenant()));
+              .thenCompose(aVoid -> deleteAssignedResources(parsedPackageId, okapiHeaders));
           }))
       .execute();
   }
@@ -526,10 +527,9 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
   }
 
   private CompletableFuture<Void> deleteTags(PackageId packageId, String tenant) {
-    return
-      packageRepository.delete(packageId, tenant)
-        .thenCompose(o -> tagRepository.deleteRecordTags(tenant, getPackageId(packageId), RecordType.PACKAGE))
-        .thenCompose(aBoolean -> completedFuture(null));
+    return packageRepository.delete(packageId, tenant)
+      .thenCompose(o -> tagRepository.deleteRecordTags(tenant, getPackageId(packageId), RecordType.PACKAGE))
+      .thenCompose(aBoolean -> completedFuture(null));
   }
 
   private CompletableFuture<Void> updateTags(Tags tags, PackageInfoInDB packages, String tenant) {
@@ -537,10 +537,9 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
       return completedFuture(null);
     } else {
       PackageId id = packages.getId();
-      return
-        updateStoredPackage(tags, packages, tenant)
-          .thenCompose(o -> tagRepository.updateRecordTags(tenant, getPackageId(id), RecordType.PACKAGE, tags.getTagList()))
-          .thenApply(updated -> null);
+      return updateStoredPackage(tags, packages, tenant)
+        .thenCompose(o -> tagRepository.updateRecordTags(tenant, getPackageId(id), RecordType.PACKAGE, tags.getTagList()))
+        .thenApply(updated -> null);
     }
   }
 
@@ -588,16 +587,20 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
     CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
     return future.whenComplete((packageById, e) -> {
       if (e instanceof ResourceNotFoundException) {
-        String recordId = getPackageId(packageId);
-        CompletableFuture<Void> deleteAccessMapping = updateRecordMapping(null, recordId, okapiHeaders);
-        CompletableFuture<Void> deleteTags = deleteTags(packageId, TenantTool.tenantId(okapiHeaders));
-
-        CompletableFuture.allOf(deleteAccessMapping, deleteTags)
+        deleteAssignedResources(packageId, okapiHeaders)
           .thenAccept(o -> deleteFuture.complete(null));
       } else {
         deleteFuture.complete(null);
       }
     }).thenCombine(deleteFuture, (o, aBoolean) -> future.join());
+  }
+
+  @NotNull
+  private CompletableFuture<Void> deleteAssignedResources(PackageId packageId, Map<String, String> okapiHeaders) {
+    CompletableFuture<Void> deleteAccessMapping = updateRecordMapping(null, getPackageId(packageId), okapiHeaders);
+    CompletableFuture<Void> deleteTags = deleteTags(packageId, TenantTool.tenantId(okapiHeaders));
+
+    return CompletableFuture.allOf(deleteAccessMapping, deleteTags);
   }
 
   private String getPackageId(PackageId packageId) {

--- a/src/main/java/org/folio/service/accesstypes/AccessTypeMappingsService.java
+++ b/src/main/java/org/folio/service/accesstypes/AccessTypeMappingsService.java
@@ -1,0 +1,20 @@
+package org.folio.service.accesstypes;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.repository.RecordType;
+import org.folio.repository.accesstypes.AccessTypeMapping;
+import org.folio.rest.jaxrs.model.AccessTypeCollectionItem;
+
+public interface AccessTypeMappingsService {
+
+  CompletableFuture<AccessTypeMapping> findByRecord(String recordId, RecordType recordType,
+                                                    Map<String, String> okapiHeaders);
+
+  CompletableFuture<Collection<AccessTypeMapping>> findByAccessTypeId(String accessTypeId, Map<String, String> okapiHeaders);
+
+  CompletableFuture<Void> update(AccessTypeCollectionItem accessType, String recordId, RecordType recordType,
+                                 Map<String, String> okapiHeaders);
+}

--- a/src/main/java/org/folio/service/accesstypes/AccessTypeMappingsServiceImpl.java
+++ b/src/main/java/org/folio/service/accesstypes/AccessTypeMappingsServiceImpl.java
@@ -1,0 +1,68 @@
+package org.folio.service.accesstypes;
+
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import javax.ws.rs.NotFoundException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.folio.repository.RecordType;
+import org.folio.repository.accesstypes.AccessTypeMapping;
+import org.folio.repository.accesstypes.AccessTypeMappingsRepository;
+import org.folio.rest.jaxrs.model.AccessTypeCollectionItem;
+
+@Component
+public class AccessTypeMappingsServiceImpl implements AccessTypeMappingsService {
+
+  @Autowired
+  private AccessTypeMappingsRepository mappingRepository;
+
+  @Override
+  public CompletableFuture<AccessTypeMapping> findByRecord(String recordId, RecordType recordType,
+                                                           Map<String, String> okapiHeaders) {
+    return mappingRepository.findByRecord(recordId, recordType, tenantId(okapiHeaders))
+      .thenApply(mapping -> mapping.orElseThrow(() -> new NotFoundException(
+        String.format("Access type mapping not found: recordId = %s, recordType = %s", recordId, recordType)))
+      );
+  }
+
+  @Override
+  public CompletableFuture<Collection<AccessTypeMapping>> findByAccessTypeId(String accessTypeId,
+                                                                             Map<String, String> okapiHeaders) {
+    return mappingRepository.findByAccessTypeId(accessTypeId, tenantId(okapiHeaders));
+  }
+
+  @Override
+  public CompletableFuture<Void> update(AccessTypeCollectionItem accessType, String recordId, RecordType recordType,
+                                        Map<String, String> okapiHeaders) {
+    if (accessType == null) {
+      return mappingRepository.deleteByRecord(recordId, recordType, tenantId(okapiHeaders));
+    }
+
+    return mappingRepository.findByRecord(recordId, recordType, tenantId(okapiHeaders))
+      .thenCompose(dbMapping -> {
+        AccessTypeMapping mapping;
+        if (dbMapping.isPresent()) {
+          mapping = dbMapping.get().toBuilder().accessTypeId(accessType.getId()).build();
+        } else {
+          mapping = createAccessTypeMapping(accessType, recordId, recordType);
+        }
+        return mappingRepository.save(mapping, tenantId(okapiHeaders)).thenApply(result -> null);
+      });
+  }
+
+  private AccessTypeMapping createAccessTypeMapping(AccessTypeCollectionItem accessType, String recordId,
+                                                    RecordType recordType) {
+    return AccessTypeMapping.builder()
+      .id(UUID.randomUUID().toString())
+      .accessTypeId(accessType.getId())
+      .recordId(recordId)
+      .recordType(recordType).build();
+  }
+}

--- a/src/main/java/org/folio/service/accesstypes/AccessTypesService.java
+++ b/src/main/java/org/folio/service/accesstypes/AccessTypesService.java
@@ -9,19 +9,16 @@ import org.folio.rest.jaxrs.model.AccessTypeCollectionItem;
 
 public interface AccessTypesService {
 
-  CompletableFuture<AccessTypeCollectionItem> save(AccessTypeCollectionItem accessType, Map<String, String> okapiHeaders);
-
   CompletableFuture<AccessTypeCollection> findAll(Map<String, String> okapiHeaders);
 
   CompletableFuture<AccessTypeCollectionItem> findById(String id, Map<String, String> okapiHeaders);
 
-  CompletableFuture<Void> deleteById(String id, Map<String, String> okapiHeaders);
+  CompletableFuture<AccessTypeCollectionItem> findByRecord(String recordId, RecordType recordType,
+                                                           Map<String, String> okapiHeaders);
+
+  CompletableFuture<AccessTypeCollectionItem> save(AccessTypeCollectionItem accessType, Map<String, String> okapiHeaders);
 
   CompletableFuture<Void> update(String id, AccessTypeCollectionItem accessType, Map<String, String> okapiHeaders);
 
-  CompletableFuture<Void> updateRecordMapping(AccessTypeCollectionItem accessType, String recordId, RecordType recordType,
-                                              Map<String, String> okapiHeaders);
-
-  CompletableFuture<AccessTypeCollectionItem> findByRecord(String recordId, RecordType recordType,
-                                                           Map<String, String> okapiHeaders);
+  CompletableFuture<Void> deleteById(String id, Map<String, String> okapiHeaders);
 }

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsPackagesTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsPackagesTest.java
@@ -375,6 +375,27 @@ public class EholdingsPackagesTest extends WireMockTestBase {
   }
 
   @Test
+  public void shouldDeletePackageAccessTypeMappingOnDelete() throws IOException, URISyntaxException {
+    try {
+      String accessTypeId = insertAccessTypes(testData(), vertx).get(0).getId();
+      insertAccessTypeMapping(FULL_PACKAGE_ID, PACKAGE, accessTypeId, vertx);
+
+      mockDefaultConfiguration(getWiremockUrl());
+      mockGet(new EqualToPattern(PACKAGE_BY_ID_URL), CUSTOM_PACKAGE_STUB_FILE);
+
+      EqualToJsonPattern putBodyPattern = new EqualToJsonPattern("{\"isSelected\":false}", true, true);
+      mockPut(new EqualToPattern(PACKAGE_BY_ID_URL), putBodyPattern, SC_NO_CONTENT);
+
+      deleteWithNoContent(PACKAGES_PATH);
+
+      List<AccessTypeMapping> mappingsAfterRequest = AccessTypesTestUtil.getAccessTypeMappings(vertx);
+      assertThat(mappingsAfterRequest, empty());
+    } finally {
+      clearAccessTypes(vertx);
+    }
+  }
+
+  @Test
   public void shouldDeletePackageOnDeleteRequest() throws IOException, URISyntaxException {
     sendPost(readFile("requests/kb-ebsco/package/post-package-request.json"));
     sendPutTags(Collections.singletonList(STUB_TAG_VALUE));

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsPackagesTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsPackagesTest.java
@@ -622,38 +622,6 @@ public class EholdingsPackagesTest extends WireMockTestBase {
   }
 
   @Test
-  public void shouldDeleteAccessTypeMappingWhenRMAPIsend404() throws URISyntaxException, IOException {
-    try {
-      List<AccessTypeCollectionItem> accessTypes = insertAccessTypes(testData(), vertx);
-      String currentAccessTypeId = accessTypes.get(0).getId();
-      String newAccessTypeId = accessTypes.get(1).getId();
-      insertAccessTypeMapping(FULL_PACKAGE_ID, PACKAGE, currentAccessTypeId, vertx);
-
-      mockDefaultConfiguration(getWiremockUrl());
-
-      PackageByIdData packageData = mapper
-        .readValue(getFile(CUSTOM_PACKAGE_STUB_FILE), PackageByIdData.class)
-        .toByIdBuilder()
-        .contentType("AggregatedFullText")
-        .build();
-
-      String updatedPackageValue = mapper.writeValueAsString(packageData);
-      mockUpdateScenario(PACKAGE_URL_PATTERN, readFile(CUSTOM_PACKAGE_STUB_FILE), updatedPackageValue);
-      stubFor(get(PACKAGE_URL_PATTERN).willReturn(new ResponseDefinitionBuilder().withStatus(SC_NOT_FOUND)));
-
-      String putBody = String.format(readFile("requests/kb-ebsco/package/put-package-custom-with-access-type.json"),
-        newAccessTypeId);
-      putWithStatus(PACKAGES_PATH, putBody, SC_NOT_FOUND);
-
-      List<AccessTypeMapping> accessTypeMappingsInDB = getAccessTypeMappings(vertx);
-      assertEquals(0, accessTypeMappingsInDB.size());
-    } finally {
-      clearAccessTypes(vertx);
-      clearAccessTypesMapping(vertx);
-    }
-  }
-
-  @Test
   public void shouldReturn422OnPutWhenPackageIsNotUpdatable() throws URISyntaxException, IOException {
 
       String putBody = readFile("requests/kb-ebsco/package/put-package-not-selected-non-empty-fields.json");

--- a/src/test/java/org/folio/util/AccessTypesTestUtil.java
+++ b/src/test/java/org/folio/util/AccessTypesTestUtil.java
@@ -2,8 +2,8 @@ package org.folio.util;
 
 import static org.apache.commons.lang3.StringUtils.join;
 
-import static org.folio.repository.accesstypes.AccessTypesMappingTableConstants.ACCESS_TYPES_MAPPING_FIELD_LIST;
-import static org.folio.repository.accesstypes.AccessTypesMappingTableConstants.ACCESS_TYPES_MAPPING_TABLE_NAME;
+import static org.folio.repository.accesstypes.AccessTypeMappingsTableConstants.ACCESS_TYPES_MAPPING_FIELD_LIST;
+import static org.folio.repository.accesstypes.AccessTypeMappingsTableConstants.ACCESS_TYPES_MAPPING_TABLE_NAME;
 import static org.folio.repository.accesstypes.AccessTypesTableConstants.ACCESS_TYPES_TABLE_NAME;
 import static org.folio.repository.accesstypes.AccessTypesTableConstants.ID_COLUMN;
 import static org.folio.repository.accesstypes.AccessTypesTableConstants.JSONB_COLUMN;


### PR DESCRIPTION
## Purpose
Implement story [MODKBEKBJ-380](https://issues.folio.org/browse/MODKBEKBJ-380).
Make not allowable to delete access status type when it is assigned to any record.

## Approach
* Check assignments of access status type and send error if is assigned
* Extract `AccessTypeMappingsService` from `AccessTypesService`