### PR TITLE
MODKBEKBJ-426 Embargo time units are not properly converted

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,12 @@
       <version>${spring.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jeasy</groupId>
+      <artifactId>easy-random-core</artifactId>
+      <version>4.0.0.RC1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/src/main/java/org/folio/rest/converter/common/attr/EmbargoPeriodConverter.java
+++ b/src/main/java/org/folio/rest/converter/common/attr/EmbargoPeriodConverter.java
@@ -1,9 +1,9 @@
 package org.folio.rest.converter.common.attr;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
@@ -14,9 +14,10 @@ import org.folio.rest.jaxrs.model.EmbargoPeriod.EmbargoUnit;
 @Component
 public class EmbargoPeriodConverter implements Converter<EmbargoPeriod, org.folio.rest.jaxrs.model.EmbargoPeriod> {
 
-  private static final Map<String, EmbargoUnit> EMBARGO_UNITS = new HashMap<>();
+  private static final Map<String, EmbargoUnit> EMBARGO_UNITS;
 
   static {
+    EMBARGO_UNITS = new CaseInsensitiveMap<>(4);
     EMBARGO_UNITS.put("Days", EmbargoUnit.DAYS);
     EMBARGO_UNITS.put("Weeks", EmbargoUnit.WEEKS);
     EMBARGO_UNITS.put("Months", EmbargoUnit.MONTHS);

--- a/src/test/java/org/folio/rest/converter/common/attr/EmbargoPeriodConverterTest.java
+++ b/src/test/java/org/folio/rest/converter/common/attr/EmbargoPeriodConverterTest.java
@@ -1,0 +1,119 @@
+package org.folio.rest.converter.common.attr;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.FromDataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import org.folio.rest.jaxrs.model.EmbargoPeriod;
+import org.folio.rest.jaxrs.model.EmbargoPeriod.EmbargoUnit;
+
+@RunWith(Theories.class)
+public class EmbargoPeriodConverterTest {
+
+  private static final int MIN_VALUE = 1;
+  private static final int MAX_VALUE = 100;
+
+  private EmbargoPeriodConverter converter;
+
+  @DataPoints("valid-periods")
+  public static org.folio.holdingsiq.model.EmbargoPeriod[] validPeriods() {
+    return Arrays.stream(EmbargoUnit.values())
+      .map(unit -> createPeriod(unit.value(), randomValue()))
+      .toArray(org.folio.holdingsiq.model.EmbargoPeriod[]::new);
+  }
+
+  @DataPoints("mixed-case-units")
+  public static org.folio.holdingsiq.model.EmbargoPeriod[] periodsWithMixedCaseUnits() {
+    return Arrays.stream(EmbargoUnit.values())
+      .map(unit -> createPeriod(mixCase(unit.value()), randomValue()))
+      .toArray(org.folio.holdingsiq.model.EmbargoPeriod[]::new);
+  }
+
+  private static String mixCase(String value) {
+    char[] result = value.toCharArray();
+
+    for (int i = 0; i < result.length; i++) {
+      boolean toUpperCase = RandomUtils.nextBoolean();
+
+      result[i] = toUpperCase ? Character.toUpperCase(result[i]) : Character.toLowerCase(result[i]);
+    }
+
+    return String.valueOf(result);
+  }
+
+  @DataPoints("invalid-units")
+  public static org.folio.holdingsiq.model.EmbargoPeriod[] periodsWithInvalidUnits() {
+    return ArrayUtils.toArray(
+      createPeriod(RandomStringUtils.randomAlphanumeric(10), randomValue()), // randomly generated unit name +
+      createPeriod(null, randomValue())  // unit == null
+    );
+  }
+
+  private static int randomValue() {
+    return RandomUtils.nextInt(MIN_VALUE, MAX_VALUE);
+  }
+
+  private static org.folio.holdingsiq.model.EmbargoPeriod createPeriod(String unit, int value) {
+    return org.folio.holdingsiq.model.EmbargoPeriod.builder()
+      .embargoUnit(unit)
+      .embargoValue(value).build();
+  }
+
+  @Before
+  public void setUp() {
+    converter = new EmbargoPeriodConverter();
+  }
+
+  @Test
+  public void testNullEmbargoPeriodConvertedToNull() {
+    EmbargoPeriod result = converter.convert(null);
+    assertNull(result);
+  }
+
+  @Theory
+  public void testEmbargoPeriodWithValidUnitConverted(
+      @FromDataPoints("valid-periods") org.folio.holdingsiq.model.EmbargoPeriod period) {
+    EmbargoPeriod result = converter.convert(period);
+
+    assertNotNull(result);
+    assertThat(result.getEmbargoUnit(), isOneOf(EmbargoUnit.values()));
+    assertThat(result.getEmbargoValue(), allOf(greaterThanOrEqualTo(MIN_VALUE), lessThanOrEqualTo(MAX_VALUE)));
+  }
+
+  @Theory
+  public void testCharacterCaseOfUnitIgnored(
+      @FromDataPoints("mixed-case-units") org.folio.holdingsiq.model.EmbargoPeriod period) {
+    EmbargoPeriod result = converter.convert(period);
+
+    assertNotNull(result);
+    assertThat(result.getEmbargoUnit(), isOneOf(EmbargoUnit.values()));
+    assertThat(result.getEmbargoValue(), allOf(greaterThanOrEqualTo(MIN_VALUE), lessThanOrEqualTo(MAX_VALUE)));
+  }
+
+  @Theory
+  public void testInvalidEmbargoUnitConvertedToNull(
+      @FromDataPoints("invalid-units") org.folio.holdingsiq.model.EmbargoPeriod period) {
+    EmbargoPeriod result = converter.convert(period);
+
+    assertNotNull(result);
+    assertNull(result.getEmbargoUnit());
+    assertThat(result.getEmbargoValue(), allOf(greaterThanOrEqualTo(MIN_VALUE), lessThanOrEqualTo(MAX_VALUE)));
+  }
+}


### PR DESCRIPTION
## Purpose
Fix the issue when embargo time units received from HoldingsIQ are not converted due to character case.

## Approach
* modify `EmbargoPeriodConverter` so that it ignores character case of embargo period unit