### PR TITLE
MODKBEKBJ-412 - Support DELETE /eholdings/kb-credentials/{credId}/users/{userId} to remove association between user and KB

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -42,6 +42,11 @@
           "permissionsRequired": ["kb-ebsco.kb-credentials.users.collection.post"]
         },
         {
+          "methods": ["DELETE"],
+          "pathPattern": "/eholdings/kb-credentials/{credentialsId}/users/{userId}",
+          "permissionsRequired": ["kb-ebsco.kb-credentials.users.item.delete"]
+        },
+        {
           "methods": ["GET"],
           "pathPattern": "/eholdings/packages",
           "permissionsRequired": ["kb-ebsco.packages.collection.get"]
@@ -552,12 +557,18 @@
       "description": "Post assigned users to KB credentials"
     },
     {
+      "permissionName": "kb-ebsco.kb-credentials.users.item.delete",
+      "displayName": "delete association between user and KB credentials",
+      "description": "delete association between user and KB credentials"
+    },
+    {
       "permissionName": "kb-ebsco.kb-credentials.users.all",
       "displayName": "EBSCO KB Broker users assigned to credentials - all permissions",
       "description": "All permissions for manging users assigned to EBSCO KB Credentials",
       "subPermissions": [
         "kb-ebsco.kb-credentials.users.collection.get",
-        "kb-ebsco.kb-credentials.users.collection.post"
+        "kb-ebsco.kb-credentials.users.collection.post",
+        "kb-ebsco.kb-credentials.users.item.delete"
       ]
     },
     {

--- a/ramls/assigned-users.raml
+++ b/ramls/assigned-users.raml
@@ -44,7 +44,7 @@ types:
         example: application/vnd.api+json
     body:
       application/vnd.api+json:
-        description: Create KB credentials
+        description: Assign user to KB credentials
         type: assignedUserPostRequest
         example:
           strict: false
@@ -91,7 +91,7 @@ types:
     put:
       body:
         application/vnd.api+json:
-          description: Create KB credentials
+          description: Update User Assignment to KB Credentials
           type: assignedUserPutRequest
           example:
             strict: false
@@ -123,3 +123,24 @@ types:
               example:
                 strict: false
                 value: !include examples/assignedUsers/assigned_users_put_422_response.json
+    delete:
+      description: Remove association between user and KB Credentials
+      responses:
+        204:
+          description: No Content
+        404:
+          description: Not Found
+          body:
+            application/vnd.api+json:
+              type: jsonapiError
+              example:
+                strict: false
+                value: !include examples/assignedUsers/assigned_users_delete_404_response.json
+        400:
+          description: Bad Request
+          body:
+            application/vnd.api+json:
+              type: jsonapiError
+              example:
+                strict: false
+                value: !include examples/assignedUsers/assigned_users_delete_400_response.json

--- a/ramls/examples/assignedUsers/assigned_users_delete_400_response.json
+++ b/ramls/examples/assignedUsers/assigned_users_delete_400_response.json
@@ -1,0 +1,11 @@
+{
+  "errors": [
+    {
+      "title": "invalid input syntax for type uuid: \"invalid-id\"",
+      "detail": "22P02"
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/examples/assignedUsers/assigned_users_delete_404_response.json
+++ b/ramls/examples/assignedUsers/assigned_users_delete_404_response.json
@@ -1,0 +1,10 @@
+{
+  "errors": [
+    {
+      "title": "Assigned User with id '99999999-9999-9999-9999-999999999999' does not exist"
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/src/main/java/org/folio/repository/assigneduser/AssignedUserRepository.java
+++ b/src/main/java/org/folio/repository/assigneduser/AssignedUserRepository.java
@@ -10,4 +10,6 @@ public interface AssignedUserRepository {
   CompletableFuture<DbAssignedUser> save(DbAssignedUser entity, String tenant);
 
   CompletableFuture<Void> update(DbAssignedUser dbAssignedUser, String tenant);
+
+  CompletableFuture<Void> delete(String credentialsId, String userId, String tenant);
 }

--- a/src/main/java/org/folio/repository/assigneduser/AssignedUserRepositoryImpl.java
+++ b/src/main/java/org/folio/repository/assigneduser/AssignedUserRepositoryImpl.java
@@ -36,8 +36,6 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.UpdateResult;
-import org.folio.rest.jaxrs.model.AssignedUser;
-import org.folio.service.exc.ServiceExceptions;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -45,7 +43,9 @@ import org.springframework.stereotype.Component;
 import org.folio.db.exc.ConstraintViolationException;
 import org.folio.db.exc.DbExcUtils;
 import org.folio.db.exc.translation.DBExceptionTranslator;
+import org.folio.rest.jaxrs.model.AssignedUser;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.service.exc.ServiceExceptions;
 
 @Component
 public class AssignedUserRepositoryImpl implements AssignedUserRepository {
@@ -58,7 +58,6 @@ public class AssignedUserRepositoryImpl implements AssignedUserRepository {
 
   private static final String USER_ASSIGN_NOT_ALLOWED_MESSAGE = "The user is already assigned to another credentials";
   private static final String KB_CREDENTIALS_NOT_FOUND_MESSAGE = "KB credentials with id '%s' not found";
-  private static final String USER_NOT_FOUND_MESSAGE = "Assigned User with id '%s' does not exist";
 
   @Autowired
   private Vertx vertx;

--- a/src/main/java/org/folio/repository/assigneduser/AssignedUsersConstants.java
+++ b/src/main/java/org/folio/repository/assigneduser/AssignedUsersConstants.java
@@ -1,5 +1,6 @@
 package org.folio.repository.assigneduser;
 
+import static org.folio.repository.SqlQueryHelper.deleteQuery;
 import static org.folio.repository.SqlQueryHelper.insertQuery;
 import static org.folio.repository.SqlQueryHelper.selectQuery;
 import static org.folio.repository.SqlQueryHelper.updateOnConflictedIdQuery;
@@ -20,8 +21,10 @@ public class AssignedUsersConstants {
 
   public static final String SELECT_ASSIGNED_USERS_BY_CREDENTIALS_ID_QUERY;
   public static final String UPSERT_ASSIGNED_USERS_QUERY;
-  public static final String UPDATE_ASSIGNED_USER_QUERY;
   public static final String INSERT_ASSIGNED_USER_QUERY;
+  public static final String UPDATE_ASSIGNED_USER_QUERY;
+  public static final String DELETE_ASSIGNED_USER_QUERY;
+  public static final String ASSIGNED_USER_COLUMN_LIST;
 
   static {
     String[] allColumns = new String[] {
@@ -30,11 +33,13 @@ public class AssignedUsersConstants {
     String[] updateColumns = new String[] {
       USER_NAME, FIRST_NAME, MIDDLE_NAME, LAST_NAME, PATRON_GROUP
     };
+    ASSIGNED_USER_COLUMN_LIST = String.format("%s, %s, %s, %s, %s, %s, %s", (Object[]) allColumns);
 
     SELECT_ASSIGNED_USERS_BY_CREDENTIALS_ID_QUERY = selectQuery() + " " + whereQuery(CREDENTIALS_ID) + ";";
     UPSERT_ASSIGNED_USERS_QUERY = insertQuery(allColumns) + " " + updateOnConflictedIdQuery(ID_COLUMN, allColumns) + ";";
     INSERT_ASSIGNED_USER_QUERY = insertQuery(allColumns) + ";";
     UPDATE_ASSIGNED_USER_QUERY = updateQuery(updateColumns) + " " + whereQuery(ID_COLUMN, CREDENTIALS_ID) + ";";
+    DELETE_ASSIGNED_USER_QUERY = deleteQuery() + " " + whereQuery(CREDENTIALS_ID, ID_COLUMN) + ";";
   }
 
   private AssignedUsersConstants() {

--- a/src/main/java/org/folio/repository/assigneduser/AssignedUsersConstants.java
+++ b/src/main/java/org/folio/repository/assigneduser/AssignedUsersConstants.java
@@ -1,8 +1,5 @@
 package org.folio.repository.assigneduser;
 
-import static java.lang.String.join;
-import static java.util.Collections.nCopies;
-
 import static org.folio.repository.SqlQueryHelper.deleteQuery;
 import static org.folio.repository.SqlQueryHelper.insertQuery;
 import static org.folio.repository.SqlQueryHelper.selectQuery;
@@ -27,7 +24,6 @@ public class AssignedUsersConstants {
   public static final String INSERT_ASSIGNED_USER_QUERY;
   public static final String UPDATE_ASSIGNED_USER_QUERY;
   public static final String DELETE_ASSIGNED_USER_QUERY;
-  public static final String ASSIGNED_USER_COLUMN_LIST;
 
   static {
     String[] allColumns = new String[] {
@@ -36,7 +32,6 @@ public class AssignedUsersConstants {
     String[] updateColumns = new String[] {
       USER_NAME, FIRST_NAME, MIDDLE_NAME, LAST_NAME, PATRON_GROUP
     };
-    ASSIGNED_USER_COLUMN_LIST = String.format(join(",", nCopies(7, "%s")), (Object[]) allColumns);
 
     SELECT_ASSIGNED_USERS_BY_CREDENTIALS_ID_QUERY = selectQuery() + " " + whereQuery(CREDENTIALS_ID) + ";";
     UPSERT_ASSIGNED_USERS_QUERY = insertQuery(allColumns) + " " + updateOnConflictedIdQuery(ID_COLUMN, allColumns) + ";";

--- a/src/main/java/org/folio/repository/assigneduser/AssignedUsersConstants.java
+++ b/src/main/java/org/folio/repository/assigneduser/AssignedUsersConstants.java
@@ -1,5 +1,8 @@
 package org.folio.repository.assigneduser;
 
+import static java.lang.String.join;
+import static java.util.Collections.nCopies;
+
 import static org.folio.repository.SqlQueryHelper.deleteQuery;
 import static org.folio.repository.SqlQueryHelper.insertQuery;
 import static org.folio.repository.SqlQueryHelper.selectQuery;
@@ -33,7 +36,7 @@ public class AssignedUsersConstants {
     String[] updateColumns = new String[] {
       USER_NAME, FIRST_NAME, MIDDLE_NAME, LAST_NAME, PATRON_GROUP
     };
-    ASSIGNED_USER_COLUMN_LIST = String.format("%s, %s, %s, %s, %s, %s, %s", (Object[]) allColumns);
+    ASSIGNED_USER_COLUMN_LIST = String.format(join(",", nCopies(7, "%s")), (Object[]) allColumns);
 
     SELECT_ASSIGNED_USERS_BY_CREDENTIALS_ID_QUERY = selectQuery() + " " + whereQuery(CREDENTIALS_ID) + ";";
     UPSERT_ASSIGNED_USERS_QUERY = insertQuery(allColumns) + " " + updateOnConflictedIdQuery(ID_COLUMN, allColumns) + ";";

--- a/src/main/java/org/folio/rest/impl/EholdingsAssignedUsersImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsAssignedUsersImpl.java
@@ -69,6 +69,17 @@ public class EholdingsAssignedUsersImpl implements EholdingsKbCredentialsIdUsers
       .exceptionally(handleException(asyncResultHandler));
   }
 
+  @Override
+  @Validate
+  @HandleValidationErrors
+  public void deleteEholdingsKbCredentialsUsersByIdAndUserId(String id, String userId, Map<String, String> okapiHeaders,
+                                                             Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    assignedUsersService.delete(id, userId, okapiHeaders)
+      .thenAccept(kbCredentials -> asyncResultHandler.handle(succeededFuture(
+        DeleteEholdingsKbCredentialsUsersByIdAndUserIdResponse.respond204())))
+      .exceptionally(handleException(asyncResultHandler));
+  }
+
   private Function<Throwable, Void> handleException(Handler<AsyncResult<Response>> asyncResultHandler) {
     return throwable -> {
       errorHandler.handle(asyncResultHandler, throwable);

--- a/src/main/java/org/folio/service/assignedusers/AssignedUsersService.java
+++ b/src/main/java/org/folio/service/assignedusers/AssignedUsersService.java
@@ -16,4 +16,6 @@ public interface AssignedUsersService {
 
   CompletableFuture<Void> update(String credentialsId, String userId, AssignedUserPutRequest entity,
                                  Map<String, String> okapiHeaders);
+
+  CompletableFuture<Void> delete(String credentialsId, String userId, Map<String, String> okapiHeaders);
 }

--- a/src/main/java/org/folio/service/assignedusers/AssignedUsersServiceImpl.java
+++ b/src/main/java/org/folio/service/assignedusers/AssignedUsersServiceImpl.java
@@ -62,4 +62,9 @@ public class AssignedUsersServiceImpl implements AssignedUsersService {
     }
     return future;
   }
+
+  @Override
+  public CompletableFuture<Void> delete(String credentialsId, String userId, Map<String, String> okapiHeaders) {
+    return repository.delete(credentialsId, userId, tenantId(okapiHeaders));
+  }
 }

--- a/src/test/java/org/folio/util/AssignedUsersTestUtil.java
+++ b/src/test/java/org/folio/util/AssignedUsersTestUtil.java
@@ -10,7 +10,6 @@ import static org.folio.repository.assigneduser.AssignedUsersConstants.PATRON_GR
 import static org.folio.repository.assigneduser.AssignedUsersConstants.UPSERT_ASSIGNED_USERS_QUERY;
 import static org.folio.repository.assigneduser.AssignedUsersConstants.USER_NAME;
 import static org.folio.test.util.TestUtil.STUB_TENANT;
-import static org.folio.util.KbCredentialsTestUtil.KB_CREDENTIALS_ENDPOINT;
 
 import java.util.Arrays;
 import java.util.List;
@@ -32,8 +31,6 @@ import org.folio.rest.jaxrs.model.AssignedUser;
 import org.folio.rest.persist.PostgresClient;
 
 public class AssignedUsersTestUtil {
-
-  public static final String KB_CREDENTIALS_ASSIGNED_USER_ENDPOINT = KB_CREDENTIALS_ENDPOINT + "/%s/users";
 
   private static final Converter<DbAssignedUser, AssignedUser> CONVERTER =
     new AssignedUserCollectionItemConverter.FromDb();
@@ -62,14 +59,6 @@ public class AssignedUsersTestUtil {
         .map(CONVERTER::convert)
         .collect(Collectors.toList())));
     return future.join();
-  }
-
-  public static String resourcePath(String... params) {
-    if (params.length == 1) {
-      return String.format(KB_CREDENTIALS_ASSIGNED_USER_ENDPOINT, params[0]);
-    } else {
-      return String.format(KB_CREDENTIALS_ASSIGNED_USER_ENDPOINT, params[0]) + "/" + params[1];
-    }
   }
 
   private static DbAssignedUser parseAssignedUser(JsonObject row) {


### PR DESCRIPTION
## Purpose
implementation story for https://issues.folio.org/browse/MODKBEKBJ-412

## Approach
* modified ModuleDescriptor file
* modified assigned-users.raml file
* added implementation for DELETE /eholdings/kb-credentials/{credId}/users/{userId}
* added tests
