### PR TITLE
MODKBEKBJ-417 -Update GET /eholdings/root-proxy to support multiple KB credentials

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -197,6 +197,11 @@
           "permissionsRequired": ["kb-ebsco.root-proxy.get"]
         },
         {
+          "methods": ["GET"],
+          "pathPattern": "/eholdings/kb-credentials/{id}/root-proxy",
+          "permissionsRequired": ["kb-ebsco.kb-credentials.root-proxy.get"]
+        },
+        {
           "methods": ["PUT"],
           "pathPattern": "/eholdings/root-proxy",
           "permissionsRequired": ["kb-ebsco.root-proxy.put"]
@@ -475,6 +480,11 @@
       "description": "Get proxy types"
     },
     {
+      "permissionName": "kb-ebsco.kb-credentials.root-proxy.get",
+      "displayName": "get root proxy by KB credentials",
+      "description": "Get root proxy by KB credentials"
+    },
+    {
       "permissionName": "kb-ebsco.root-proxy.get",
       "displayName": "get root proxy",
       "description": "Get root proxy"
@@ -587,6 +597,7 @@
         "kb-ebsco.kb-credentials.custom-labels.collection.get",
         "kb-ebsco.kb-credentials.custom-labels.collection.put",
         "kb-ebsco.kb-credentials.proxy-types.collection.get",
+        "kb-ebsco.kb-credentials.root-proxy.get",
         "kb-ebsco.kb-credentials.access-types.collection.get"
       ]
     },
@@ -658,6 +669,7 @@
         "kb-ebsco.kb-credentials.proxy-types.collection.get",
         "kb-ebsco.proxy-types.collection.get",
         "kb-ebsco.root-proxy.get",
+        "kb-ebsco.kb-credentials.root-proxy.get",
         "kb-ebsco.root-proxy.put",
         "kb-ebsco.tags.collection.get",
         "kb-ebsco.unique.tags.collection.get",

--- a/ramls/examples/proxies/root_proxy_by_credentials_id_get_404_response.json
+++ b/ramls/examples/proxies/root_proxy_by_credentials_id_get_404_response.json
@@ -1,0 +1,10 @@
+{
+  "errors": [
+    {
+      "title": "KB credentials with id '99999999-9999-9999-9999-999999999999' not found"
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/proxies.raml
+++ b/ramls/proxies.raml
@@ -101,3 +101,29 @@ types:
             example:
               strict: false
               value: !include examples/proxies/root_proxy_put_422_response.json
+/eholdings/kb-credentials/{id}/root-proxy:
+  displayName: Root Proxy
+  description: Root Proxy that is currently selected from proxy-type list for KB Credentials.
+  uriParameters:
+    id:
+      pattern : "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+  get:
+    description: Get the ID of root proxy that is currently selected from proxy-type list.
+    responses:
+      200:
+        description: OK
+        body:
+          application/vnd.api+json:
+            description: Get the ID of root proxy that is currently selected from proxy-type list.
+            type: rootProxy
+            example:
+              strict: false
+              value: !include examples/proxies/root_proxy_get_200_response.json
+      404:
+        description: Not Found
+        body:
+          application/vnd.api+json:
+            type: jsonapiError
+            example:
+              strict: false
+              value: !include examples/proxies/root_proxy_by_credentials_id_get_404_response.json

--- a/ramls/types/proxies/rootProxyData.json
+++ b/ramls/types/proxies/rootProxyData.json
@@ -9,12 +9,20 @@
     "id": {
       "type": "string",
       "description": "Unique identifier of root proxy",
+      "enum": ["root-proxy"],
       "example": "root-proxy"
     },
     "type": {
       "type": "string",
       "description": "Type of root proxy",
+      "enum": ["rootProxies"],
       "example": "rootProxies"
+    },
+    "credentialsId": {
+      "type": "string",
+      "description": "The UUID of credentials",
+      "$ref": "../../raml-util/schemas/uuid.schema",
+      "examples": "2ffa1940-2cf6-48b1-8cc9-5e539c61d93f"
     },
     "attributes": {
       "type": "object",

--- a/ramls/types/proxies/rootProxyDataAttributes.json
+++ b/ramls/types/proxies/rootProxyDataAttributes.json
@@ -9,6 +9,7 @@
     "id": {
       "type": "string",
       "description": "Root Proxy ID",
+      "enum": ["root-proxy"],
       "example": "root-proxy"
     },
     "proxyTypeId": {

--- a/src/main/java/org/folio/rest/converter/proxy/RootProxyConverter.java
+++ b/src/main/java/org/folio/rest/converter/proxy/RootProxyConverter.java
@@ -12,17 +12,15 @@ import org.folio.rest.util.RestConstants;
 
 @Component
 public class RootProxyConverter implements Converter<RootProxyCustomLabels, RootProxy> {
-  private static final String ROOT_PROXY_ID = "root-proxy";
-  private static final String ROOT_PROXY_TYPE = "rootProxies";
 
   @Override
   public RootProxy convert(@NonNull RootProxyCustomLabels proxy) {
     return new org.folio.rest.jaxrs.model.RootProxy()
       .withData(new RootProxyData()
-        .withId(ROOT_PROXY_ID)
-        .withType(ROOT_PROXY_TYPE)
+        .withId(RootProxyData.Id.ROOT_PROXY)
+        .withType(RootProxyData.Type.ROOT_PROXIES)
         .withAttributes(new RootProxyDataAttributes()
-          .withId(ROOT_PROXY_ID)
+          .withId(RootProxyDataAttributes.Id.ROOT_PROXY)
           .withProxyTypeId(proxy.getProxy().getId())))
       .withJsonapi(RestConstants.JSONAPI);
   }

--- a/src/main/java/org/folio/service/rootproxies/RootProxyService.java
+++ b/src/main/java/org/folio/service/rootproxies/RootProxyService.java
@@ -1,0 +1,13 @@
+package org.folio.service.rootproxies;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.rest.jaxrs.model.RootProxy;
+
+public interface RootProxyService {
+
+  CompletableFuture<RootProxy> findByCredentialsId(String credentialsId, Map<String, String> okapiHeaders);
+
+  CompletableFuture<RootProxy> findByUser(Map<String, String> okapiHeaders);
+}

--- a/src/main/java/org/folio/service/rootproxies/RootProxyServiceImpl.java
+++ b/src/main/java/org/folio/service/rootproxies/RootProxyServiceImpl.java
@@ -1,0 +1,59 @@
+package org.folio.service.rootproxies;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+import io.vertx.core.Vertx;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import org.folio.holdingsiq.model.Configuration;
+import org.folio.holdingsiq.model.RootProxyCustomLabels;
+import org.folio.holdingsiq.service.impl.HoldingsIQServiceImpl;
+import org.folio.rest.jaxrs.model.KbCredentials;
+import org.folio.rest.jaxrs.model.RootProxy;
+import org.folio.service.kbcredentials.KbCredentialsService;
+
+@Component
+public class RootProxyServiceImpl implements RootProxyService {
+
+  @Autowired
+  @Qualifier("nonSecuredCredentialsService")
+  private KbCredentialsService credentialsService;
+  @Autowired
+  private Converter<KbCredentials, Configuration> configurationConverter;
+  @Autowired
+  private Converter<RootProxyCustomLabels, RootProxy> rootProxyConverter;
+  @Autowired
+  private Vertx vertx;
+
+  @Override
+  public CompletableFuture<RootProxy> findByCredentialsId(String credentialsId, Map<String, String> okapiHeaders) {
+    return credentialsService.findById(credentialsId, okapiHeaders)
+      .thenCompose(this::retrieveRootProxy);
+  }
+
+  @Override
+  public CompletableFuture<RootProxy> findByUser(Map<String, String> okapiHeaders) {
+    return credentialsService.findByUser(okapiHeaders)
+      .thenCompose(this::retrieveRootProxy);
+  }
+
+  private CompletableFuture<RootProxy> retrieveRootProxy(KbCredentials kbCredentials) {
+    final HoldingsIQServiceImpl holdingsIQService = createHoldingsIQService(kbCredentials);
+    return holdingsIQService.retrieveRootProxyCustomLabels()
+      .thenApply(rootProxyConverter::convert)
+      .thenApply(rootProxy -> {
+        rootProxy.getData().setCredentialsId(kbCredentials.getId());
+        return rootProxy;
+      });
+  }
+
+  private HoldingsIQServiceImpl createHoldingsIQService(KbCredentials credentials) {
+    final Configuration rmApiConfig = configurationConverter.convert(credentials);
+    return new HoldingsIQServiceImpl(Objects.requireNonNull(rmApiConfig), vertx);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/ProxiesTestData.java
+++ b/src/test/java/org/folio/rest/impl/ProxiesTestData.java
@@ -1,0 +1,23 @@
+package org.folio.rest.impl;
+
+import io.restassured.http.Header;
+
+import org.folio.okapi.common.XOkapiHeaders;
+
+public class ProxiesTestData {
+
+  public static final String STUB_CREDENTILS_ID = "12312312-1231-1231-a111-111111111111";
+
+  public static final String JOHN_ID = "47d9ca93-9c82-4d6a-8d7f-7a73963086b9";
+  public static final String johnToken = "eyJhbGciOiJIUzI1NiJ9." +
+    "eyJzdWIiOiJqb2huX2RvZSIsInVzZXJfaWQiOiI0N2Q5Y2E5My05YzgyLTRkNmEtOGQ3Zi03YTczOTYzMDg2Y" +
+    "jkiLCJpYXQiOjE1ODU4OTUxNDQsInRlbmFudCI6ImZzIn0.HTx-4aUFIPtEHO-6ZcYML6K3-0VRDGv3KX44JoT3hxg";
+  public static final Header JOHN_TOKEN_HEADER = new Header(XOkapiHeaders.TOKEN, johnToken);
+
+  public static final String JANE_ID = "781fce7d-5cf5-490d-ad89-a3d192eb526c";
+  public static final String janeToken = "eyJhbGciOiJIUzI1NiJ9." +
+    "eyJzdWIiOiJqYW5lX2RvZSIsInVzZXJfaWQiOiI3ODFmY2U3ZC01Y2Y1LTQ5MGQtYWQ4OS1hM2QxOTJlYjUyN" +
+    "mMiLCJpYXQiOjE1ODU4OTUxNDQsInRlbmFudCI6ImZzIn0.kM0PYy49d92g5qhqPgTFz8aknjO7fQlZ5kljCC_M3-c";
+  public static final Header JANE_TOKEN_HEADER = new Header(XOkapiHeaders.TOKEN, janeToken);
+
+}

--- a/src/test/java/org/folio/rest/impl/RmApiConstants.java
+++ b/src/test/java/org/folio/rest/impl/RmApiConstants.java
@@ -1,0 +1,10 @@
+package org.folio.rest.impl;
+
+import static org.folio.rest.impl.WireMockTestBase.STUB_CUSTOMER_ID;
+
+public class RmApiConstants {
+
+  public static final String RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL = "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/";
+  public static final String RMAPI_PROXIES_URL = "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/proxies.*";
+
+}

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EHoldingsProxyTypesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EHoldingsProxyTypesImplTest.java
@@ -9,6 +9,12 @@ import static org.junit.Assert.assertThat;
 
 import static org.folio.repository.assigneduser.AssignedUsersConstants.ASSIGNED_USERS_TABLE_NAME;
 import static org.folio.repository.kbcredentials.KbCredentialsTableConstants.KB_CREDENTIALS_TABLE_NAME;
+import static org.folio.rest.impl.ProxiesTestData.JANE_ID;
+import static org.folio.rest.impl.ProxiesTestData.JANE_TOKEN_HEADER;
+import static org.folio.rest.impl.ProxiesTestData.JOHN_ID;
+import static org.folio.rest.impl.ProxiesTestData.JOHN_TOKEN_HEADER;
+import static org.folio.rest.impl.ProxiesTestData.STUB_CREDENTILS_ID;
+import static org.folio.rest.impl.RmApiConstants.RMAPI_PROXIES_URL;
 import static org.folio.test.util.TestUtil.mockGet;
 import static org.folio.test.util.TestUtil.readFile;
 import static org.folio.util.AssignedUsersTestUtil.insertAssignedUser;
@@ -21,34 +27,20 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
-import io.restassured.http.Header;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.impl.WireMockTestBase;
 import org.folio.rest.jaxrs.model.JsonapiError;
 
 @RunWith(VertxUnitRunner.class)
 public class EHoldingsProxyTypesImplTest extends WireMockTestBase {
 
-  private static final String RMI_PROXIES_URL = "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/proxies.*";
   private static final String EHOLDINGS_PROXY_TYPES_URL = "eholdings/proxy-types";
   private static final String EHOLDINGS_PROXY_TYPES_BY_CREDENTIALS_ID_URL = "/eholdings/kb-credentials/%s/proxy-types";
-  private static final String STUB_CREDENTILS_ID = "12312312-1231-1231-a111-111111111111";
-  private static final String JOHN_ID = "47d9ca93-9c82-4d6a-8d7f-7a73963086b9";
-  private static final String JANE_ID = "781fce7d-5cf5-490d-ad89-a3d192eb526c";
-  private static final String johnToken = "eyJhbGciOiJIUzI1NiJ9." +
-    "eyJzdWIiOiJqb2huX2RvZSIsInVzZXJfaWQiOiI0N2Q5Y2E5My05YzgyLTRkNmEtOGQ3Zi03YTczOTYzMDg2Y" +
-    "jkiLCJpYXQiOjE1ODU4OTUxNDQsInRlbmFudCI6ImZzIn0.HTx-4aUFIPtEHO-6ZcYML6K3-0VRDGv3KX44JoT3hxg";
-  private static final String janeToken = "eyJhbGciOiJIUzI1NiJ9." +
-    "eyJzdWIiOiJqYW5lX2RvZSIsInVzZXJfaWQiOiI3ODFmY2U3ZC01Y2Y1LTQ5MGQtYWQ4OS1hM2QxOTJlYjUyN" +
-    "mMiLCJpYXQiOjE1ODU4OTUxNDQsInRlbmFudCI6ImZzIn0.kM0PYy49d92g5qhqPgTFz8aknjO7fQlZ5kljCC_M3-c";
-  private static final Header JOHN_TOKEN_HEADER = new Header(XOkapiHeaders.TOKEN, johnToken);
-  private static final Header JANE_TOKEN_HEADER = new Header(XOkapiHeaders.TOKEN, janeToken);
 
   @After
   public void tearDown() {
@@ -61,7 +53,7 @@ public class EHoldingsProxyTypesImplTest extends WireMockTestBase {
     insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
     insertAssignedUser(JOHN_ID, STUB_CREDENTILS_ID, "john_doe", "John", null, "Doe", "patron", vertx);
 
-    mockGet(new RegexPattern(RMI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-response.json");
+    mockGet(new RegexPattern(RMAPI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-response.json");
 
     String actual = getWithStatus(EHOLDINGS_PROXY_TYPES_URL, SC_OK, JOHN_TOKEN_HEADER).asString();
 
@@ -73,7 +65,7 @@ public class EHoldingsProxyTypesImplTest extends WireMockTestBase {
   public void shouldReturnProxyTypesWhenOneCredentialsExistsAndUserNotAssigned() throws IOException, URISyntaxException {
     insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
 
-    mockGet(new RegexPattern(RMI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-response.json");
+    mockGet(new RegexPattern(RMAPI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-response.json");
 
     String actual = getWithStatus(EHOLDINGS_PROXY_TYPES_URL, SC_OK, JOHN_TOKEN_HEADER).asString();
 
@@ -83,9 +75,9 @@ public class EHoldingsProxyTypesImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturnEmptyProxyTypesFromEmptyRMApiResponse() throws IOException, URISyntaxException {
-    String credentialsId = insertKbCredentials(getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
-    insertAssignedUser(JOHN_ID, credentialsId, "john_doe", "John", null, "Doe", "patron", vertx);
-    mockGet(new RegexPattern(RMI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-empty-response.json");
+    insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+    insertAssignedUser(JOHN_ID, STUB_CREDENTILS_ID, "john_doe", "John", null, "Doe", "patron", vertx);
+    mockGet(new RegexPattern(RMAPI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-empty-response.json");
 
     String actual = getWithStatus(EHOLDINGS_PROXY_TYPES_URL, SC_OK, JOHN_TOKEN_HEADER).asString();
 
@@ -95,8 +87,8 @@ public class EHoldingsProxyTypesImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn404WhenUserNotAssignedToKbCredentials() {
-    String credentialsId = insertKbCredentials(getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
-    insertAssignedUser(JOHN_ID, credentialsId, "john_doe", "John", null, "Doe", "patron", vertx);
+    insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+    insertAssignedUser(JOHN_ID, STUB_CREDENTILS_ID, "john_doe", "John", null, "Doe", "patron", vertx);
     insertKbCredentials(getWiremockUrl(), STUB_CREDENTIALS_NAME + "1", STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
 
     JsonapiError error = getWithStatus(EHOLDINGS_PROXY_TYPES_URL, SC_NOT_FOUND, JANE_TOKEN_HEADER).as(JsonapiError.class);
@@ -112,20 +104,20 @@ public class EHoldingsProxyTypesImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn401WhenRMAPIRequestCompletesWith401ErrorStatus() {
-    String credentialsId = insertKbCredentials(getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
-    insertAssignedUser(JOHN_ID, credentialsId, "john_doe", "John", null, "Doe", "patron", vertx);
+    insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+    insertAssignedUser(JOHN_ID, STUB_CREDENTILS_ID, "john_doe", "John", null, "Doe", "patron", vertx);
 
-    mockGet(new RegexPattern(RMI_PROXIES_URL), SC_UNAUTHORIZED);
+    mockGet(new RegexPattern(RMAPI_PROXIES_URL), SC_UNAUTHORIZED);
     final JsonapiError error = getWithStatus(EHOLDINGS_PROXY_TYPES_URL, SC_UNAUTHORIZED, JOHN_TOKEN_HEADER).as(JsonapiError.class);
     assertThat(error.getErrors().get(0).getTitle(), containsString("Unauthorized Access"));
   }
 
   @Test
   public void shouldReturn403WhenRMAPIRequestCompletesWith403ErrorStatus() {
-    String credentialsId = insertKbCredentials(getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
-    insertAssignedUser(JOHN_ID, credentialsId, "john_doe", "John", null, "Doe", "patron", vertx);
+    insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+    insertAssignedUser(JOHN_ID, STUB_CREDENTILS_ID, "john_doe", "John", null, "Doe", "patron", vertx);
 
-    mockGet(new RegexPattern(RMI_PROXIES_URL), SC_FORBIDDEN);
+    mockGet(new RegexPattern(RMAPI_PROXIES_URL), SC_FORBIDDEN);
     final JsonapiError error = getWithStatus(EHOLDINGS_PROXY_TYPES_URL, SC_FORBIDDEN, JOHN_TOKEN_HEADER).as(JsonapiError.class);
     assertThat(error.getErrors().get(0).getTitle(), containsString("Unauthorized"));
   }
@@ -134,7 +126,7 @@ public class EHoldingsProxyTypesImplTest extends WireMockTestBase {
   public void shouldReturnProxyTypesCollection() throws IOException, URISyntaxException {
     insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
 
-    mockGet(new RegexPattern(RMI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-response.json");
+    mockGet(new RegexPattern(RMAPI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-response.json");
 
     String resourcePath = String.format(EHOLDINGS_PROXY_TYPES_BY_CREDENTIALS_ID_URL, STUB_CREDENTILS_ID);
     String actual = getWithOk(resourcePath).asString();
@@ -147,7 +139,7 @@ public class EHoldingsProxyTypesImplTest extends WireMockTestBase {
   public void shouldReturnEmptyCollection() throws IOException, URISyntaxException {
     insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
 
-    mockGet(new RegexPattern(RMI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-response.json");
+    mockGet(new RegexPattern(RMAPI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-response.json");
 
     String resourcePath = String.format(EHOLDINGS_PROXY_TYPES_BY_CREDENTIALS_ID_URL, STUB_CREDENTILS_ID);
     String actual = getWithOk(resourcePath).asString();
@@ -158,22 +150,22 @@ public class EHoldingsProxyTypesImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn401WhenRMAPIReturns401ErrorStatus() {
-    String credentialsId = insertKbCredentials(getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
-    insertAssignedUser(JOHN_ID, credentialsId, "john_doe", "John", null, "Doe", "patron", vertx);
+    insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+    insertAssignedUser(JOHN_ID, STUB_CREDENTILS_ID, "john_doe", "John", null, "Doe", "patron", vertx);
 
-    mockGet(new RegexPattern(RMI_PROXIES_URL), SC_UNAUTHORIZED);
-    final String path = String.format(EHOLDINGS_PROXY_TYPES_BY_CREDENTIALS_ID_URL, credentialsId);
+    mockGet(new RegexPattern(RMAPI_PROXIES_URL), SC_UNAUTHORIZED);
+    final String path = String.format(EHOLDINGS_PROXY_TYPES_BY_CREDENTIALS_ID_URL, STUB_CREDENTILS_ID);
     final JsonapiError error = getWithStatus(path, SC_UNAUTHORIZED, JOHN_TOKEN_HEADER).as(JsonapiError.class);
     assertThat(error.getErrors().get(0).getTitle(), containsString("Unauthorized Access"));
   }
 
   @Test
   public void shouldReturn403WhenRMAPIReturns403ErrorStatus() {
-    String credentialsId = insertKbCredentials(getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
-    insertAssignedUser(JOHN_ID, credentialsId, "john_doe", "John", null, "Doe", "patron", vertx);
+    insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+    insertAssignedUser(JOHN_ID, STUB_CREDENTILS_ID, "john_doe", "John", null, "Doe", "patron", vertx);
 
-    mockGet(new RegexPattern(RMI_PROXIES_URL), SC_FORBIDDEN);
-    final String path = String.format(EHOLDINGS_PROXY_TYPES_BY_CREDENTIALS_ID_URL, credentialsId);
+    mockGet(new RegexPattern(RMAPI_PROXIES_URL), SC_FORBIDDEN);
+    final String path = String.format(EHOLDINGS_PROXY_TYPES_BY_CREDENTIALS_ID_URL, STUB_CREDENTILS_ID);
     final JsonapiError error = getWithStatus(path, SC_FORBIDDEN, JOHN_TOKEN_HEADER).as(JsonapiError.class);
     assertThat(error.getErrors().get(0).getTitle(), containsString("Unauthorized"));
   }

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EHoldingsRootProxyImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EHoldingsRootProxyImplTest.java
@@ -8,13 +8,29 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_FORBIDDEN;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
+import static org.folio.repository.assigneduser.AssignedUsersConstants.ASSIGNED_USERS_TABLE_NAME;
+import static org.folio.repository.kbcredentials.KbCredentialsTableConstants.KB_CREDENTIALS_TABLE_NAME;
+import static org.folio.rest.impl.ProxiesTestData.JANE_ID;
+import static org.folio.rest.impl.ProxiesTestData.JANE_TOKEN_HEADER;
+import static org.folio.rest.impl.ProxiesTestData.JOHN_ID;
+import static org.folio.rest.impl.ProxiesTestData.JOHN_TOKEN_HEADER;
+import static org.folio.rest.impl.ProxiesTestData.STUB_CREDENTILS_ID;
+import static org.folio.rest.impl.RmApiConstants.RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL;
+import static org.folio.test.util.TestUtil.mockGet;
 import static org.folio.test.util.TestUtil.readFile;
+import static org.folio.util.AssignedUsersTestUtil.insertAssignedUser;
+import static org.folio.util.KBTestUtil.clearDataFromTable;
 import static org.folio.util.KBTestUtil.mockDefaultConfiguration;
+import static org.folio.util.KbCredentialsTestUtil.STUB_CREDENTIALS_NAME;
+import static org.folio.util.KbCredentialsTestUtil.STUB_INVALID_TOKEN_HEADER;
+import static org.folio.util.KbCredentialsTestUtil.insertKbCredentials;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -22,13 +38,13 @@ import java.net.URISyntaxException;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
-
-import io.restassured.RestAssured;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-
 import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import org.folio.rest.impl.WireMockTestBase;
 import org.folio.rest.jaxrs.model.JsonapiError;
@@ -39,52 +55,122 @@ import org.folio.rest.util.RestConstants;
 
 @RunWith(VertxUnitRunner.class)
 public class EHoldingsRootProxyImplTest extends WireMockTestBase {
-  private static final String ROOT_PROXY_ID = "root-proxy";
-  private static final String ROOT_PROXY_TYPE = "rootProxies";
-  private static final String UPDATEROOT_PROXY_ENDPOINT = "eholdings/root-proxy";
 
-  @Test
-  public void shouldReturnRootProxyWhenCustIdAndAPIKeyAreValid() throws IOException, URISyntaxException {
-    String stubResponseFile = "responses/rmapi/proxiescustomlabels/get-success-response.json";
+  private static final String EHOLDINGS_ROOT_PROXY_URL = "eholdings/root-proxy";
+  private static final String EHOLDINGS_ROOT_PROXY_BY_CREDENTIALS_ID_URL = "/eholdings/kb-credentials/%s/root-proxy";
 
-    String expectedRootProxyID = "<n>";
+  private static final String RMAPI_ROOT_PROXY_CUSTOM_LABELS_RESPONSE = "responses/rmapi/proxiescustomlabels/get-success-response.json";
+  private static final String KB_EBSCO_GET_ROOT_PROXY_RESPONSE = "responses/kb-ebsco/root-proxy/get-root-proxy-response.json";
 
-    mockDefaultConfiguration(getWiremockUrl());
-    stubFor(
-      get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
-        .willReturn(new ResponseDefinitionBuilder()
-          .withBody(readFile(stubResponseFile))));
-
-    RestAssured.given()
-      .spec(getRequestSpecification())
-      .when()
-      .get(UPDATEROOT_PROXY_ENDPOINT)
-      .then()
-      .statusCode(SC_OK)
-      .body("data.id", equalTo(ROOT_PROXY_ID))
-      .body("data.type", equalTo(ROOT_PROXY_TYPE))
-      .body("data.attributes.id", equalTo(ROOT_PROXY_ID))
-      .body("data.attributes.proxyTypeId", equalTo(expectedRootProxyID));
+  @After
+  public void tearDown() {
+    clearDataFromTable(vertx, ASSIGNED_USERS_TABLE_NAME);
+    clearDataFromTable(vertx, KB_CREDENTIALS_TABLE_NAME);
   }
 
   @Test
-  public void shouldReturnUnauthorizedWhenRMAPIRequestCompletesWith401ErrorStatus() throws IOException, URISyntaxException {
-    mockDefaultConfiguration(getWiremockUrl());
-    stubFor(
-      get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
-        .willReturn(new ResponseDefinitionBuilder().withStatus(SC_UNAUTHORIZED)));
+  public void shouldReturnRootProxyWhenUserAssignedToKbCredentials() throws IOException, URISyntaxException {
+    insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+    insertAssignedUser(JOHN_ID, STUB_CREDENTILS_ID, "john_doe", "John", null, "Doe", "patron", vertx);
 
-    getWithStatus(UPDATEROOT_PROXY_ENDPOINT, SC_FORBIDDEN);
+    mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), RMAPI_ROOT_PROXY_CUSTOM_LABELS_RESPONSE);
+
+    String actual = getWithStatus(EHOLDINGS_ROOT_PROXY_URL, SC_OK, JOHN_TOKEN_HEADER).asString();
+
+    String expected = readFile(KB_EBSCO_GET_ROOT_PROXY_RESPONSE);
+    JSONAssert.assertEquals(expected, actual, true);
   }
 
   @Test
-  public void shouldReturnUnauthorizedWhenRMAPIRequestCompletesWith403ErrorStatus() throws IOException, URISyntaxException {
-    mockDefaultConfiguration(getWiremockUrl());
-    stubFor(
-      get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
-        .willReturn(new ResponseDefinitionBuilder().withStatus(SC_FORBIDDEN)));
+  public void shouldReturnRootProxyWhenOneCredentialsExistsAndUserNotAssigned() throws IOException, URISyntaxException {
+    insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
 
-    getWithStatus(UPDATEROOT_PROXY_ENDPOINT, SC_FORBIDDEN);
+    mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), RMAPI_ROOT_PROXY_CUSTOM_LABELS_RESPONSE);
+
+    String actual = getWithStatus(EHOLDINGS_ROOT_PROXY_URL, SC_OK, JOHN_TOKEN_HEADER).asString();
+
+    String expected = readFile(KB_EBSCO_GET_ROOT_PROXY_RESPONSE);
+    JSONAssert.assertEquals(expected, actual, true);
+  }
+
+  @Test
+  public void shouldReturn404WhenUserNotAssignedToKbCredentials() {
+    insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+    insertAssignedUser(JOHN_ID, STUB_CREDENTILS_ID, "john_doe", "John", null, "Doe", "patron", vertx);
+    insertKbCredentials(getWiremockUrl(), STUB_CREDENTIALS_NAME + "1", STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+
+    JsonapiError error = getWithStatus(EHOLDINGS_ROOT_PROXY_URL, SC_NOT_FOUND, JANE_TOKEN_HEADER).as(JsonapiError.class);
+
+    Assert.assertThat(error.getErrors().get(0).getTitle(), containsString("User credentials not found: userId = " + JANE_ID));
+  }
+
+  @Test
+  public void shouldReturn401WhenNoTokenHeader(){
+    JsonapiError error = getWithStatus(EHOLDINGS_ROOT_PROXY_URL, SC_UNAUTHORIZED, STUB_INVALID_TOKEN_HEADER).as(JsonapiError.class);
+    Assert.assertThat(error.getErrors().get(0).getTitle(), containsString("Unauthorized"));
+  }
+
+  @Test
+  public void shouldReturn401WhenRMAPIRequestCompletesWith401ErrorStatus() {
+    insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+    insertAssignedUser(JOHN_ID, STUB_CREDENTILS_ID, "john_doe", "John", null, "Doe", "patron", vertx);
+
+    mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), SC_UNAUTHORIZED);
+    final JsonapiError error = getWithStatus(EHOLDINGS_ROOT_PROXY_URL, SC_UNAUTHORIZED, JOHN_TOKEN_HEADER).as(JsonapiError.class);
+    Assert.assertThat(error.getErrors().get(0).getTitle(), containsString("Unauthorized Access"));
+  }
+
+  @Test
+  public void shouldReturn403WhenRMAPIRequestCompletesWith403ErrorStatus() {
+    insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+    insertAssignedUser(JOHN_ID, STUB_CREDENTILS_ID, "john_doe", "John", null, "Doe", "patron", vertx);
+
+    mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), SC_FORBIDDEN);
+    final JsonapiError error = getWithStatus(EHOLDINGS_ROOT_PROXY_URL, SC_FORBIDDEN, JOHN_TOKEN_HEADER).as(JsonapiError.class);
+    Assert.assertThat(error.getErrors().get(0).getTitle(), containsString("Unauthorized"));
+  }
+
+  @Test
+  public void shouldReturnRootProxyWhenUserAssignedToCredentials() throws IOException, URISyntaxException {
+    insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+    insertAssignedUser(JOHN_ID, STUB_CREDENTILS_ID, "john_doe", "John", null, "Doe", "patron", vertx);
+
+    mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), RMAPI_ROOT_PROXY_CUSTOM_LABELS_RESPONSE);
+
+    final String path = String.format(EHOLDINGS_ROOT_PROXY_BY_CREDENTIALS_ID_URL, STUB_CREDENTILS_ID);
+    String actual = getWithStatus(path, SC_OK, JOHN_TOKEN_HEADER).asString();
+
+    String expected = readFile(KB_EBSCO_GET_ROOT_PROXY_RESPONSE);
+    JSONAssert.assertEquals(expected, actual, true);
+  }
+
+  @Test
+  public void shouldReturn401WhenRMAPIReturns401ErrorStatus() {
+    insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+    insertAssignedUser(JOHN_ID, STUB_CREDENTILS_ID, "john_doe", "John", null, "Doe", "patron", vertx);
+
+    mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), SC_UNAUTHORIZED);
+    final String path = String.format(EHOLDINGS_ROOT_PROXY_BY_CREDENTIALS_ID_URL, STUB_CREDENTILS_ID);
+    final JsonapiError error = getWithStatus(path, SC_UNAUTHORIZED, JOHN_TOKEN_HEADER).as(JsonapiError.class);
+    Assert.assertThat(error.getErrors().get(0).getTitle(), containsString("Unauthorized Access"));
+  }
+
+  @Test
+  public void shouldReturn403WhenRMAPIReturns403ErrorStatus() {
+    insertKbCredentials(STUB_CREDENTILS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+    insertAssignedUser(JOHN_ID, STUB_CREDENTILS_ID, "john_doe", "John", null, "Doe", "patron", vertx);
+
+    mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), SC_FORBIDDEN);
+    final String path = String.format(EHOLDINGS_ROOT_PROXY_BY_CREDENTIALS_ID_URL, STUB_CREDENTILS_ID);
+    final JsonapiError error = getWithStatus(path, SC_FORBIDDEN, JOHN_TOKEN_HEADER).as(JsonapiError.class);
+    Assert.assertThat(error.getErrors().get(0).getTitle(), containsString("Unauthorized"));
+  }
+
+  @Test
+  public void shouldReturn404WhenCredentialsNotFOund() {
+    final String path = String.format(EHOLDINGS_ROOT_PROXY_BY_CREDENTIALS_ID_URL, "11111111-1111-1111-a111-111111111111");
+    final JsonapiError error = getWithStatus(path, SC_NOT_FOUND, JOHN_TOKEN_HEADER).as(JsonapiError.class);
+    Assert.assertThat(error.getErrors().get(0).getTitle(), containsString("KbCredentials not found by id"));
   }
 
   @Test
@@ -94,16 +180,16 @@ public class EHoldingsRootProxyImplTest extends WireMockTestBase {
     mockDefaultConfiguration(getWiremockUrl());
 
     stubFor(
-      get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
+      get(new UrlPathPattern(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), true))
         .willReturn(new ResponseDefinitionBuilder().withBody(readFile(stubResponseFile))));
 
     stubFor(
-      put(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
+      put(new UrlPathPattern(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), true))
         .willReturn(new ResponseDefinitionBuilder().withStatus(HttpStatus.SC_NO_CONTENT)));
 
     RootProxy expected = getUpdatedRootProxy();
 
-    RootProxy rootProxy = putWithOk(UPDATEROOT_PROXY_ENDPOINT, readFile("requests/kb-ebsco/put-root-proxy.json"))
+    RootProxy rootProxy = putWithOk(EHOLDINGS_ROOT_PROXY_URL, readFile("requests/kb-ebsco/put-root-proxy.json"))
       .as(RootProxy.class);
 
     assertThat(rootProxy.getData().getId(), equalTo(expected.getData().getId()));
@@ -111,7 +197,7 @@ public class EHoldingsRootProxyImplTest extends WireMockTestBase {
     assertThat(rootProxy.getData().getAttributes().getId(), equalTo(expected.getData().getAttributes().getId()));
     assertThat(rootProxy.getData().getAttributes().getProxyTypeId(), equalTo(expected.getData().getAttributes().getProxyTypeId()));
 
-    verify(1, putRequestedFor(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
+    verify(1, putRequestedFor(new UrlPathPattern(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), true))
       .withRequestBody(equalToJson(readFile("requests/rmapi/proxiescustomlabels/put-root-proxy.json"))));
   }
 
@@ -123,14 +209,14 @@ public class EHoldingsRootProxyImplTest extends WireMockTestBase {
     mockDefaultConfiguration(getWiremockUrl());
 
     stubFor(
-        get(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
+        get(new UrlPathPattern(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), true))
           .willReturn(new ResponseDefinitionBuilder().withBody(readFile(stubGetResponseFile))));
 
     stubFor(
-      put(new UrlPathPattern(new RegexPattern("/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/"), true))
+      put(new UrlPathPattern(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), true))
         .willReturn(new ResponseDefinitionBuilder().withBody(readFile(stubPutResponseFile)).withStatus(SC_BAD_REQUEST)));
 
-    JsonapiError error = putWithStatus(UPDATEROOT_PROXY_ENDPOINT,
+    JsonapiError error = putWithStatus(EHOLDINGS_ROOT_PROXY_URL,
       readFile("requests/kb-ebsco/put-root-proxy.json"), SC_BAD_REQUEST).as(JsonapiError.class);
 
     assertThat(error.getErrors().get(0).getTitle(), equalTo("Invalid Proxy ID"));
@@ -139,10 +225,10 @@ public class EHoldingsRootProxyImplTest extends WireMockTestBase {
   private RootProxy getUpdatedRootProxy() {
     return new RootProxy()
       .withData(new RootProxyData()
-          .withId(ROOT_PROXY_ID)
-          .withType(ROOT_PROXY_TYPE)
+          .withId(RootProxyData.Id.ROOT_PROXY)
+          .withType(RootProxyData.Type.ROOT_PROXIES)
           .withAttributes(new RootProxyDataAttributes()
-              .withId(ROOT_PROXY_ID)
+              .withId(RootProxyDataAttributes.Id.ROOT_PROXY)
               .withProxyTypeId("Test-Proxy-ID-123")))
       .withJsonapi(RestConstants.JSONAPI);
   }

--- a/src/test/resources/responses/kb-ebsco/root-proxy/get-root-proxy-response.json
+++ b/src/test/resources/responses/kb-ebsco/root-proxy/get-root-proxy-response.json
@@ -2,7 +2,7 @@
   "data": {
     "id": "root-proxy",
     "type": "rootProxies",
-    "credentialsId": "2ffa1940-2cf6-48b1-8cc9-5e539c61d93f",
+    "credentialsId": "12312312-1231-1231-a111-111111111111",
     "attributes": {
       "id": "root-proxy",
       "proxyTypeId": "<n>"


### PR DESCRIPTION
## Purpose
Implementation for https://issues.folio.org/browse/MODKBEKBJ-417

## Approach
* modified existing rootProxyAttributes.json file to include credentialsId property.
* added implementation for GET /eholdings/kb-credentials/<credentialsId>/root-proxy
* added tests for GET /eholdings/kb-credentials/<credentialsId>/root-proxy
* modified the logic for GET /eholdings/root-proxy
* updated tests for GET /eholdings/root-proxy