### PR TITLE
MODKBEKBJ-433  Update RMAPITemplate to use new configuration routine

### DIFF
--- a/src/main/java/org/folio/rest/util/template/RMAPITemplateContext.java
+++ b/src/main/java/org/folio/rest/util/template/RMAPITemplateContext.java
@@ -1,5 +1,6 @@
 package org.folio.rest.util.template;
 
+import lombok.Builder;
 import lombok.Value;
 
 import org.folio.holdingsiq.model.Configuration;
@@ -12,13 +13,18 @@ import org.folio.rmapi.ResourcesServiceImpl;
 import org.folio.rmapi.TitlesServiceImpl;
 
 @Value
+@Builder(toBuilder = true)
 public class RMAPITemplateContext {
-  private HoldingsIQService holdingsService;
-  private PackageServiceImpl packagesService;
-  private ProvidersServiceImpl providersService;
-  private ResourcesServiceImpl resourcesService;
-  private TitlesServiceImpl titlesService;
-  private LoadService loadingService;
-  private OkapiData okapiData;
-  private Configuration configuration;
+
+  HoldingsIQService holdingsService;
+  PackageServiceImpl packagesService;
+  ProvidersServiceImpl providersService;
+  ResourcesServiceImpl resourcesService;
+  TitlesServiceImpl titlesService;
+  LoadService loadingService;
+  OkapiData okapiData;
+  Configuration configuration;
+  String credentialsId;
+  String credentialsName;
+
 }

--- a/src/main/java/org/folio/rest/util/template/RMAPITemplateFactory.java
+++ b/src/main/java/org/folio/rest/util/template/RMAPITemplateFactory.java
@@ -6,33 +6,38 @@ import javax.ws.rs.core.Response;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Lookup;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.stereotype.Component;
 
-import org.folio.holdingsiq.service.ConfigurationService;
 import org.folio.rest.validator.HeaderValidator;
+import org.folio.service.kbcredentials.UserKbCredentialsService;
 
 @Component
 public class RMAPITemplateFactory {
-  @Autowired
-  private ConfigurationService configurationService;
+
   @Autowired
   private ConversionService conversionService;
   @Autowired
   private HeaderValidator headerValidator;
 
-  public RMAPITemplate createTemplate(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler){
-    return new RMAPITemplate(configurationService, conversionService, headerValidator, getContextBuilder(), okapiHeaders, asyncResultHandler);
+  public RMAPITemplate createTemplate(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler) {
+    return new RMAPITemplate(
+        lookupUserKbCredentialsService(), conversionService, headerValidator,
+        lookupContextBuilder(), okapiHeaders, asyncResultHandler);
   }
 
   /**
    * Because of @Lookup annotation this method will be overridden by Spring, and new instance of context builder will be returned
    */
   @Lookup
-  public RMAPITemplateContextBuilder getContextBuilder(){
+  public RMAPITemplateContextBuilder lookupContextBuilder(){
+    return null;
+  }
+
+  @Lookup("nonSecuredUserCredentialsService")
+  public UserKbCredentialsService lookupUserKbCredentialsService() {
     return null;
   }
 }


### PR DESCRIPTION
## Purpose
Apply new configuration routine to RMAPITemplate, populate context with credential details (credentialsId, credentialsName) so that other services could filter data appropriately. ([MODKBEKBJ-433](https://issues.folio.org/browse/MODKBEKBJ-433))

## Approach
- add credentialsId, credentialsName to RMAPITemplateContext
- call `UserKbCredentialsService.findByUser()` inside `RMAPITemplate` to get user credentials and populate `Configuration` in `RMAPITemplateContext`