### PR TITLE
return invalid status if configuration is not found

### DIFF
--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -88,26 +88,25 @@ public class ApplicationConfig {
 
   @Bean
   public VertxCache<String, org.folio.holdingsiq.model.Configuration> rmApiConfigurationCache(Vertx vertx,
-                                                                                              @Value("${configuration.cache.expire}")
-                                                                                                long expirationTime) {
+      @Value("${configuration.cache.expire}") long expirationTime) {
     return new VertxCache<>(vertx, expirationTime, "rmApiConfigurationCache");
   }
 
   @Bean
   public VertxCache<VendorIdCacheKey, Long> vendorIdCache(Vertx vertx,
-                                                          @Value("${vendor.id.cache.expire}") long expirationTime) {
+      @Value("${vendor.id.cache.expire}") long expirationTime) {
     return new VertxCache<>(vertx, expirationTime, "vendorIdCache");
   }
 
   @Bean
   public VertxCache<PackageCacheKey, PackageByIdData> packageCache(Vertx vertx,
-                                                                   @Value("${package.cache.expire}") long expirationTime) {
+      @Value("${package.cache.expire}") long expirationTime) {
     return new VertxCache<>(vertx, expirationTime, "packageCache");
   }
 
   @Bean
   public VertxCache<VendorCacheKey, VendorById> vendorCache(Vertx vertx,
-                                                            @Value("${vendor.cache.expire}") long expirationTime) {
+      @Value("${vendor.cache.expire}") long expirationTime) {
     return new VertxCache<>(vertx, expirationTime, "vendorCache");
   }
 
@@ -118,20 +117,17 @@ public class ApplicationConfig {
 
   @Bean
   public VertxCache<ResourceCacheKey, Title> resourceCache(Vertx vertx,
-                                                           @Value("${resource.cache.expire}") long expirationTime) {
+      @Value("${resource.cache.expire}") long expirationTime) {
     return new VertxCache<>(vertx, expirationTime, "resourceCache");
   }
 
   @Bean
   public ConfigurationService configurationService(
       @Qualifier("nonSecuredUserCredentialsService") UserKbCredentialsService userKbCredentialsService,
-      Converter<KbCredentials, org.folio.holdingsiq.model.Configuration> converter,
-      Vertx vertx,
+      Converter<KbCredentials, org.folio.holdingsiq.model.Configuration> converter, Vertx vertx,
       @Value("${configuration.cache.expire}") long expirationTime) {
-    return new ConfigurationServiceCache(
-      new LocalConfigurationServiceImpl(userKbCredentialsService, converter, vertx),
-      new VertxCache<>(vertx, expirationTime, "rmApiConfigurationCache")
-    );
+    return new ConfigurationServiceCache(new LocalConfigurationServiceImpl(userKbCredentialsService, converter, vertx),
+        new VertxCache<>(vertx, expirationTime, "rmApiConfigurationCache"));
   }
 
   @Bean
@@ -146,7 +142,7 @@ public class ApplicationConfig {
 
   @Bean
   public LoadServiceFacade loadServiceFacade(@Value("${holdings.load.implementation.qualifier}") String qualifier,
-                                             ApplicationContext context) {
+      ApplicationContext context) {
     return (LoadServiceFacade) context.getBean(qualifier);
   }
 

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsStatusTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsStatusTest.java
@@ -10,7 +10,6 @@ import static org.folio.test.util.TestUtil.STUB_TENANT;
 import static org.folio.test.util.TestUtil.STUB_TOKEN;
 import static org.folio.test.util.TestUtil.readFile;
 import static org.folio.util.KBTestUtil.clearDataFromTable;
-import static org.folio.util.KBTestUtil.mockEmptyConfiguration;
 import static org.folio.util.KBTestUtil.setupDefaultKBConfiguration;
 import static org.folio.util.KbCredentialsTestUtil.STUB_TOKEN_HEADER;
 
@@ -23,7 +22,6 @@ import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 import io.restassured.RestAssured;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -43,7 +41,6 @@ public class EholdingsStatusTest extends WireMockTestBase {
 
   @Test
   public void shouldReturnTrueWhenRMAPIRequestCompletesWith200Status() throws IOException, URISyntaxException {
-
     setupDefaultKBConfiguration(getWiremockUrl(), vertx);
 
     stubFor(
@@ -58,7 +55,6 @@ public class EholdingsStatusTest extends WireMockTestBase {
 
   @Test
   public void shouldReturnFalseWhenRMAPIRequestCompletesWithErrorStatus() {
-
     setupDefaultKBConfiguration(getWiremockUrl(), vertx);
 
     stubFor(
@@ -84,10 +80,7 @@ public class EholdingsStatusTest extends WireMockTestBase {
   }
 
   @Test
-  @Ignore
-  public void shouldReturnFalseIfEmptyConfig() throws IOException, URISyntaxException {
-    mockEmptyConfiguration(null);
-
+  public void shouldReturnFalseIfEmptyConfig() {
     final ConfigurationStatus status = getWithOk(EHOLDINGS_STATUS_PATH, STUB_TOKEN_HEADER).as(ConfigurationStatus.class);
 
     assertThat(status.getData().getAttributes().getIsConfigurationValid(), equalTo(false));


### PR DESCRIPTION
## Purpose
Return invalid status from `/eholdings/status` endpoint if no configuration (KB credentials) found for the current user.

## Approach
* map `Not Found` exception to invalid status