### PR TITLE
MODKBEKBJ-450 Remove restrictions to support deleting KB credentials

### DIFF
--- a/src/main/resources/liquibase/tenant/changelog-3.5.2.xml
+++ b/src/main/resources/liquibase/tenant/changelog-3.5.2.xml
@@ -5,4 +5,5 @@
 
   <include file="liquibase/tenant/scripts/v3.5.2/alter-kb-credentials-table.xml"/>
   <include file="liquibase/tenant/scripts/v3.5.2/alter-access-type-mapping-table.xml"/>
+  <include file="liquibase/tenant/scripts/v3.5.2/enable-delete-cascade-from-kb-credentials.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/liquibase/tenant/scripts/v3.5.2/enable-delete-cascade-from-kb-credentials.xml
+++ b/src/main/resources/liquibase/tenant/scripts/v3.5.2/enable-delete-cascade-from-kb-credentials.xml
@@ -1,0 +1,147 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+  <changeSet id="MODKBEKBJ-450@@recreate-fkey-from-assigned-users-to-kb-credentials-with-delete-cascade" author="dmtkachenko">
+    <dropForeignKeyConstraint
+      baseTableName="assigned_users"
+      constraintName="fk_assigned_users_kb_credentials"
+      baseTableSchemaName="${database.defaultSchemaName}"/>
+
+    <addForeignKeyConstraint
+      baseColumnNames="credentials_id"
+      baseTableName="assigned_users"
+      baseTableSchemaName="${database.defaultSchemaName}"
+      constraintName="fk_assigned_users_kb_credentials"
+      deferrable="false"
+      initiallyDeferred="false"
+      onDelete="CASCADE"
+      onUpdate="RESTRICT"
+      referencedColumnNames="id"
+      referencedTableName="kb_credentials"
+      referencedTableSchemaName="${database.defaultSchemaName}"/>
+  </changeSet>
+
+  <changeSet id="MODKBEKBJ-450@@recreate-fkey-from-access-types-mappings-to-access-types-with-delete-cascade" author="dmtkachenko">
+    <dropForeignKeyConstraint
+      baseTableName="access_types_mappings"
+      constraintName="fk_access_types_mappings_access_types"
+      baseTableSchemaName="${database.defaultSchemaName}"/>
+
+    <addForeignKeyConstraint
+        baseColumnNames="access_type_id"
+        baseTableName="access_types_mappings"
+        baseTableSchemaName="${database.defaultSchemaName}"
+        constraintName="fk_access_types_mappings_access_types"
+        deferrable="false"
+        initiallyDeferred="false"
+        onDelete="CASCADE"
+        onUpdate="RESTRICT"
+        referencedColumnNames="id"
+        referencedTableName="access_types"
+        referencedTableSchemaName="${database.defaultSchemaName}"/>
+  </changeSet>
+
+  <changeSet id="MODKBEKBJ-450@@recreate-fkey-from-access-types-to-kb-credentials-with-delete-cascade" author="dmtkachenko">
+    <dropForeignKeyConstraint
+      baseTableName="access_types"
+      constraintName="fk_access_types_kb_credentials"
+      baseTableSchemaName="${database.defaultSchemaName}"/>
+
+    <addForeignKeyConstraint
+      baseColumnNames="credentials_id"
+      baseTableName="access_types"
+      baseTableSchemaName="${database.defaultSchemaName}"
+      constraintName="fk_access_types_kb_credentials"
+      deferrable="false"
+      initiallyDeferred="false"
+      onDelete="CASCADE"
+      onUpdate="RESTRICT"
+      referencedColumnNames="id"
+      referencedTableName="kb_credentials"
+      referencedTableSchemaName="${database.defaultSchemaName}"/>
+  </changeSet>
+
+  <changeSet id="MODKBEKBJ-450@@recreate-fkey-from-packages-to-kb-credentials-with-delete-cascade" author="dmtkachenko">
+    <dropForeignKeyConstraint
+      baseTableName="packages"
+      constraintName="fk_packages_kb_credentials"
+      baseTableSchemaName="${database.defaultSchemaName}"/>
+
+    <addForeignKeyConstraint
+      baseColumnNames="credentials_id"
+      baseTableName="packages"
+      baseTableSchemaName="${database.defaultSchemaName}"
+      constraintName="fk_packages_kb_credentials"
+      deferrable="false"
+      initiallyDeferred="false"
+      onDelete="CASCADE"
+      onUpdate="RESTRICT"
+      referencedColumnNames="id"
+      referencedTableName="kb_credentials"
+      referencedTableSchemaName="${database.defaultSchemaName}"/>
+  </changeSet>
+
+  <changeSet id="MODKBEKBJ-450@@recreate-fkey-from-providers-to-kb-credentials-with-delete-cascade" author="dmtkachenko">
+    <dropForeignKeyConstraint
+      baseTableName="providers"
+      constraintName="fk_providers_kb_credentials"
+      baseTableSchemaName="${database.defaultSchemaName}"/>
+
+    <addForeignKeyConstraint
+      baseColumnNames="credentials_id"
+      baseTableName="providers"
+      baseTableSchemaName="${database.defaultSchemaName}"
+      constraintName="fk_providers_kb_credentials"
+      deferrable="false"
+      initiallyDeferred="false"
+      onDelete="CASCADE"
+      onUpdate="RESTRICT"
+      referencedColumnNames="id"
+      referencedTableName="kb_credentials"
+      referencedTableSchemaName="${database.defaultSchemaName}"/>
+  </changeSet>
+
+  <changeSet id="MODKBEKBJ-450@@recreate-fkey-from-resources-to-kb-credentials-with-delete-cascade" author="dmtkachenko">
+    <dropForeignKeyConstraint
+      baseTableName="resources"
+      constraintName="fk_resources_kb_credentials"
+      baseTableSchemaName="${database.defaultSchemaName}"/>
+
+    <addForeignKeyConstraint
+      baseColumnNames="credentials_id"
+      baseTableName="resources"
+      baseTableSchemaName="${database.defaultSchemaName}"
+      constraintName="fk_resources_kb_credentials"
+      deferrable="false"
+      initiallyDeferred="false"
+      onDelete="CASCADE"
+      onUpdate="RESTRICT"
+      referencedColumnNames="id"
+      referencedTableName="kb_credentials"
+      referencedTableSchemaName="${database.defaultSchemaName}"/>
+  </changeSet>
+
+  <changeSet id="MODKBEKBJ-450@@recreate-fkey-from-titles-to-kb-credentials-with-delete-cascade" author="dmtkachenko">
+    <dropForeignKeyConstraint
+      baseTableName="titles"
+      constraintName="fk_titles_kb_credentials"
+      baseTableSchemaName="${database.defaultSchemaName}"/>
+
+    <addForeignKeyConstraint
+      baseColumnNames="credentials_id"
+      baseTableName="titles"
+      baseTableSchemaName="${database.defaultSchemaName}"
+      constraintName="fk_titles_kb_credentials"
+      deferrable="false"
+      initiallyDeferred="false"
+      onDelete="CASCADE"
+      onUpdate="RESTRICT"
+      referencedColumnNames="id"
+      referencedTableName="kb_credentials"
+      referencedTableSchemaName="${database.defaultSchemaName}"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsAccessTypesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsAccessTypesImplTest.java
@@ -42,7 +42,6 @@ import static org.folio.util.KBTestUtil.clearDataFromTable;
 import static org.folio.util.KbCredentialsTestUtil.STUB_API_URL;
 import static org.folio.util.KbCredentialsTestUtil.STUB_CREDENTIALS_NAME;
 import static org.folio.util.KbCredentialsTestUtil.STUB_TOKEN_HEADER;
-import static org.folio.util.KbCredentialsTestUtil.saveKbCredentials;
 import static org.folio.util.TokenTestUtils.generateToken;
 
 import java.io.IOException;
@@ -299,14 +298,15 @@ public class EholdingsAccessTypesImplTest extends WireMockTestBase {
   }
 
   @Test
-  public void shouldReturn400OnDeleteWhenAssignedToRecords() {
+  public void shouldReturn204OnDeleteWhenAssignedToRecords() {
     List<AccessType> accessTypes = testData(credentialsId);
     String id = insertAccessType(accessTypes.get(0), vertx);
     insertAccessTypeMapping("11111111-1111", RecordType.PACKAGE, id, vertx);
 
     String resourcePath = String.format(KB_CREDENTIALS_ACCESS_TYPE_ID_ENDPOINT, credentialsId, id);
-    JsonapiError errors = deleteWithStatus(resourcePath, SC_BAD_REQUEST).as(JsonapiError.class);
-    assertEquals("Can't delete access type that has assigned records", errors.getErrors().get(0).getTitle());
+    int statusCode = deleteWithNoContent(resourcePath).response().statusCode();
+
+    assertEquals(SC_NO_CONTENT, statusCode);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Remove referential integrity restrictions to support deleting KB credentials

## Approach
* recreate foreign key constraints with `ON DELETE CASCADE` option