### PR TITLE
MODKBEKBJ-463 Change status endpoint behavior

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <rmb.version>30.1.0</rmb.version>
     <folio-di-support.version>1.1.0</folio-di-support.version>
     <folio-service-tools.version>1.5.1</folio-service-tools.version>
-    <folio-holdingsiq-client.version>1.9.0</folio-holdingsiq-client.version>
+    <folio-holdingsiq-client.version>1.9.1-SNAPSHOT</folio-holdingsiq-client.version>
     <folio-liquibase-util.version>1.0.0</folio-liquibase-util.version>
     <mod-configuration-client.version>4.0.3</mod-configuration-client.version>
 

--- a/src/main/java/org/folio/rest/impl/EholdingsStatusImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsStatusImpl.java
@@ -76,6 +76,7 @@ public class EholdingsStatusImpl implements EholdingsStatus {
       ErrorHandler errorHandler = new ErrorHandler();
 
       errorHandler
+        .addRmApiMapping()
         .add(NotFoundException.class, notFoundToInvalidStatusMapper())
         .add(BadRequestException.class, error400BadRequestMapper())
         .add(NotAuthorizedException.class, error401NotAuthorizedMapper());

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsKbCredentialsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsKbCredentialsImplTest.java
@@ -289,7 +289,7 @@ public class EholdingsKbCredentialsImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn422OnPatchWhenCredentialsAreInvalid() {
-    String credentialsId = saveKbCredentials(STUB_API_URL, STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+    String credentialsId = saveKbCredentials(getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
 
     KbCredentialsPatchRequest kbCredentialsPatchRequest = stubPatchRequest();
     kbCredentialsPatchRequest.getData().getAttributes().setCustomerId("updated");

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsKbCredentialsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsKbCredentialsImplTest.java
@@ -724,7 +724,7 @@ public class EholdingsKbCredentialsImplTest extends WireMockTestBase {
   private void mockVerifyFailedCredentialsRequest() {
     stubFor(
       get(urlPathMatching("/rm/rmaccounts/.*"))
-        .willReturn(aResponse().withStatus(SC_UNPROCESSABLE_ENTITY)));
+        .willReturn(aResponse().withStatus(SC_UNAUTHORIZED)));
   }
 
 }


### PR DESCRIPTION
## Purpose
Change status endpoint behavior to send `isConfigurationValid = false` only when the configuration is really invalid

## Approach
* change `holdingsiq-client` version to `1.9.1-SNAPSHOT`
* add error mapping
* add tests

#### TODOS and Open Questions
- [x] Close https://github.com/folio-org/folio-holdingsiq-client/pull/42 first
