### PR TITLE
MODKBEKBJ-487 Implement resources' cost-per-use sort

### DIFF
--- a/ramls/costperuse.raml
+++ b/ramls/costperuse.raml
@@ -12,6 +12,8 @@ documentation:
 traits:
   costPerUseCommon: !include traits/costPerUseCommon.raml
   pageable: !include traits/pageable.raml
+  sortable: !include traits/sortable.raml
+  orderable: !include traits/orderable.raml
 
 types:
   resourceCostPerUse: !include types/uc/costperuse/resourceCostPerUse.json
@@ -19,6 +21,8 @@ types:
   packageCostPerUse: !include types/uc/costperuse/packageCostPerUse.json
   titleCostPerUse: !include types/uc/costperuse/titleCostPerUse.json
   jsonapiError: !include types/jsonapiError.json
+  order:
+    enum: [asc, desc]
 
 /eholdings/resources/{resourceId}/costperuse:
   displayName: Cost-per-use
@@ -141,7 +145,9 @@ types:
       example: "15-440285"
   get:
     description: Retrieve cost-per-use information for package resources
-    is: [costPerUseCommon, pageable: {maxCountValue: 1000, defaultCountValue: 100}]
+    is: [costPerUseCommon, orderable,
+    sortable: {defaultValue: 'name', possibleValues: 'name, type, cost, usage, costperuse, percent'},
+    pageable: {maxCountValue: 1000, defaultCountValue: 100}]
     responses:
       200:
         description: OK

--- a/ramls/packages.raml
+++ b/ramls/packages.raml
@@ -34,7 +34,9 @@ types:
   displayName: Packages
   get:
     description: Retrieve a collection of packages based on the search query.
-    is: [queriable, filterable, taggable, accessible, sortable, pageable: {maxCountValue: 100, defaultCountValue: 25}]
+    is: [queriable, filterable, taggable, accessible,
+    sortable: {defaultValue: 'relevance', possibleValues: 'name, relevance'},
+    pageable: {maxCountValue: 100, defaultCountValue: 25}]
     queryParameters:
       filter[custom]:
         displayName: Custom Packages List
@@ -218,7 +220,9 @@ types:
     /resources:
       get:
         description: Include all resources belonging to a specific package
-        is: [sortable, taggable, accessible, titleFilterable, pageable: {maxCountValue: 100, defaultCountValue: 25}]
+        is: [taggable, accessible, titleFilterable,
+        sortable: {defaultValue: 'relevance', possibleValues: 'name, relevance'},
+        pageable: {maxCountValue: 100, defaultCountValue: 25}]
         responses:
           200:
             description: OK

--- a/ramls/providers.raml
+++ b/ramls/providers.raml
@@ -32,7 +32,9 @@ traits:
   description: Collection of available providers in eholdings.
   get:
     description: Get a list of providers based on the search query.
-    is: [queriable, taggable, sortable, pageable: {maxCountValue: 100, defaultCountValue: 25}]
+    is: [queriable, taggable,
+    sortable: {defaultValue: 'relevance', possibleValues: 'name, relevance'},
+    pageable: {maxCountValue: 100, defaultCountValue: 25}]
     responses:
       200:
         description: OK
@@ -126,7 +128,9 @@ traits:
     /packages:
       get:
         description: Search within a list of packages associated with a given provider.
-        is: [queriable, taggable, accessible, filterable, sortable, pageable: {maxCountValue: 100, defaultCountValue: 25}]
+        is: [queriable, taggable, accessible, filterable,
+        sortable: {defaultValue: 'relevance', possibleValues: 'name, relevance'},
+        pageable: {maxCountValue: 100, defaultCountValue: 25}]
         responses:
           200:
             description: OK

--- a/ramls/titles.raml
+++ b/ramls/titles.raml
@@ -24,7 +24,9 @@ types:
   description: Collection of available titles in eholdings.
   get:
     description: Get a set of titles matching the given search criteria.
-    is: [taggable, accessible, filterable, sortable, pageable: {maxCountValue: 100, defaultCountValue: 25}, includable]
+    is: [taggable, accessible, filterable, includable,
+    sortable: {defaultValue: 'relevance', possibleValues: 'name, relevance'},
+    pageable: {maxCountValue: 100, defaultCountValue: 25}]
     responses:
       200:
         description: OK

--- a/ramls/traits/orderable.raml
+++ b/ramls/traits/orderable.raml
@@ -1,0 +1,6 @@
+queryParameters:
+  order:
+    description: Order
+    type: order
+    default: asc
+    required: false

--- a/ramls/traits/sortable.raml
+++ b/ramls/traits/sortable.raml
@@ -2,7 +2,6 @@ queryParameters:
   sort:
     displayName: Sort options
     type: string
-    description: Option by which results are sorted. Defaults to relevance if query or name if no query. Possible values are name, relevance.
-    example : name
-    default: relevance
+    description: Option by which results are sorted. Possible values are <<possibleValues>>.
+    default: <<defaultValue>>
     required: false

--- a/ramls/types/uc/costperuse/resourceAnalysisCost.json
+++ b/ramls/types/uc/costperuse/resourceAnalysisCost.json
@@ -18,6 +18,11 @@
       "type": "string",
       "description": "Publication type",
       "$ref": "../../publicationType.json"
+    },
+    "percent": {
+      "type": "number",
+      "description": "Percent of usage",
+      "example": "20.5"
     }
   }
 }

--- a/src/main/java/org/folio/client/uc/UCApigeeEbscoClientImpl.java
+++ b/src/main/java/org/folio/client/uc/UCApigeeEbscoClientImpl.java
@@ -45,7 +45,7 @@ public class UCApigeeEbscoClientImpl implements UCApigeeEbscoClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(UCApigeeEbscoClientImpl.class);
 
-  private static final int TIMEOUT = 20000;
+  private static final int TIMEOUT = 50000;
 
   private static final String FISCAL_YEAR_PARAM = "fiscalYear";
   private static final String FISCAL_MONTH_PARAM = "fiscalMonth";

--- a/src/main/java/org/folio/common/ComparatorUtils.java
+++ b/src/main/java/org/folio/common/ComparatorUtils.java
@@ -6,10 +6,10 @@ import static java.util.Comparator.nullsFirst;
 import java.util.Comparator;
 import java.util.function.Function;
 
-public final class ComparatorUtils {
+import lombok.experimental.UtilityClass;
 
-  private ComparatorUtils() {
-  }
+@UtilityClass
+public final class ComparatorUtils {
 
   public static Comparator<Double> nullsFirstDouble() {
     return nullsFirst(Double::compare);

--- a/src/main/java/org/folio/common/ComparatorUtils.java
+++ b/src/main/java/org/folio/common/ComparatorUtils.java
@@ -1,0 +1,29 @@
+package org.folio.common;
+
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.nullsFirst;
+
+import java.util.Comparator;
+import java.util.function.Function;
+
+public final class ComparatorUtils {
+
+  private ComparatorUtils() {
+  }
+
+  public static Comparator<Double> nullsFirstDouble() {
+    return nullsFirst(Double::compare);
+  }
+
+  public static Comparator<Integer> nullsFirstInteger() {
+    return nullsFirst(Integer::compare);
+  }
+
+  public static <T> Comparator<T> nullFirstDouble(Function<T, Double> extractor) {
+    return comparing(extractor, nullsFirstDouble());
+  }
+
+  public static <T> Comparator<T> nullFirstInteger(Function<T, Integer> extractor) {
+    return comparing(extractor, nullsFirstInteger());
+  }
+}

--- a/src/main/java/org/folio/common/FunctionUtils.java
+++ b/src/main/java/org/folio/common/FunctionUtils.java
@@ -2,10 +2,10 @@ package org.folio.common;
 
 import java.util.function.Function;
 
-public final class FunctionUtils {
+import lombok.experimental.UtilityClass;
 
-  private FunctionUtils() {
-  }
+@UtilityClass
+public class FunctionUtils {
 
   public static  <T> Function<T, Void> nothing() {
     return result -> null;

--- a/src/main/java/org/folio/common/ListUtils.java
+++ b/src/main/java/org/folio/common/ListUtils.java
@@ -9,14 +9,14 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.StringUtils;
 
-public final class ListUtils {
+@UtilityClass
+public class ListUtils {
 
   private static final Pattern SPLIT_BY_COMMA_PATTERN = Pattern.compile("\\s*,\\s*");
 
-  private ListUtils() {
-  }
 
   public static <T, R> List<R> mapItems(Collection<T> source, Function<? super T, ? extends R> mapper) {
     Objects.requireNonNull(source, "Collection is null");

--- a/src/main/java/org/folio/common/LogUtils.java
+++ b/src/main/java/org/folio/common/LogUtils.java
@@ -2,8 +2,10 @@ package org.folio.common;
 
 import io.vertx.core.logging.Logger;
 import io.vertx.sqlclient.Tuple;
+import lombok.experimental.UtilityClass;
 
-public final class LogUtils {
+@UtilityClass
+public class LogUtils {
 
   private static final String COUNT_LOG_MESSAGE = "Do count query = {} with params = {}";
   private static final String DELETE_LOG_MESSAGE = "Do delete query = {} with params = {}";
@@ -11,7 +13,6 @@ public final class LogUtils {
   private static final String SELECT_LOG_MESSAGE = "Do select query = {} with params = {}";
   private static final String UPDATE_LOG_MESSAGE = "Do update query = {} with params = {}";
 
-  private LogUtils(){}
 
   public static void logCountQuery(Logger logger, String query) {
     logCountQuery(logger, query, Tuple.tuple());

--- a/src/main/java/org/folio/rest/converter/costperuse/CostPerUseConverterUtils.java
+++ b/src/main/java/org/folio/rest/converter/costperuse/CostPerUseConverterUtils.java
@@ -10,6 +10,8 @@ import java.util.stream.IntStream;
 import org.apache.commons.collections4.IterableUtils;
 
 import org.folio.client.uc.configuration.CommonUCConfiguration;
+import org.folio.client.uc.model.UCCostAnalysis;
+import org.folio.client.uc.model.UCCostAnalysisDetails;
 import org.folio.client.uc.model.UCPlatformUsage;
 import org.folio.client.uc.model.UCTitleCostPerUse;
 import org.folio.client.uc.model.UCUsage;
@@ -116,5 +118,15 @@ final class CostPerUseConverterUtils {
     return new CostPerUseParameters()
       .withStartMonth(Month.fromValue(configuration.getFiscalMonth()))
       .withCurrency(configuration.getAnalysisCurrency());
+  }
+
+  public static double getPackageTitlesTotalCost(Map<String, UCCostAnalysis> titlePackageCost) {
+    return titlePackageCost.values().stream()
+      .map(UCCostAnalysis::getCurrent)
+      .filter(Objects::nonNull)
+      .map(UCCostAnalysisDetails::getCost)
+      .filter(Objects::nonNull)
+      .mapToDouble(Double::doubleValue)
+      .sum();
   }
 }

--- a/src/main/java/org/folio/rest/converter/costperuse/PackageCostPerUseConverter.java
+++ b/src/main/java/org/folio/rest/converter/costperuse/PackageCostPerUseConverter.java
@@ -6,18 +6,16 @@ import static org.apache.commons.lang3.math.NumberUtils.INTEGER_ZERO;
 import static org.folio.rest.converter.costperuse.CostPerUseConverterUtils.convertParameters;
 import static org.folio.rest.converter.costperuse.CostPerUseConverterUtils.getAllPlatformUsages;
 import static org.folio.rest.converter.costperuse.CostPerUseConverterUtils.getNonPublisherUsages;
+import static org.folio.rest.converter.costperuse.CostPerUseConverterUtils.getPackageTitlesTotalCost;
 import static org.folio.rest.converter.costperuse.CostPerUseConverterUtils.getPublisherUsages;
 import static org.folio.rest.converter.costperuse.CostPerUseConverterUtils.getTotalUsage;
 
 import java.util.List;
-import java.util.Objects;
 
 import org.jetbrains.annotations.NotNull;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
-import org.folio.client.uc.model.UCCostAnalysis;
-import org.folio.client.uc.model.UCCostAnalysisDetails;
 import org.folio.rest.jaxrs.model.CostAnalysis;
 import org.folio.rest.jaxrs.model.CostAnalysisAttributes;
 import org.folio.rest.jaxrs.model.PackageCostPerUse;
@@ -35,13 +33,7 @@ public class PackageCostPerUseConverter implements Converter<PackageCostPerUseRe
 
     Double cost;
     if (titlePackageCost != null) {
-      cost = titlePackageCost.values().stream()
-        .map(UCCostAnalysis::getCurrent)
-        .filter(Objects::nonNull)
-        .map(UCCostAnalysisDetails::getCost)
-        .filter(Objects::nonNull)
-        .mapToDouble(Double::doubleValue)
-        .sum();
+      cost = getPackageTitlesTotalCost(titlePackageCost);
     } else {
       cost = ucPackageCostPerUse.getAnalysis().getCurrent().getCost();
     }

--- a/src/main/java/org/folio/rest/converter/costperuse/ResourceCostPerUseCollectionConverter.java
+++ b/src/main/java/org/folio/rest/converter/costperuse/ResourceCostPerUseCollectionConverter.java
@@ -50,12 +50,6 @@ public class ResourceCostPerUseCollectionConverter
                                                                               Map<String, UCCostAnalysis> titlePackageCostMap,
                                                                               Double packageCost) {
     var ucCostAnalysis = titlePackageCostMap.get(getTitlePackageId(dbHoldingInfo));
-    PublicationType publicationType = null;
-    try {
-      publicationType = PublicationType.fromValue(dbHoldingInfo.getResourceType());
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
 
     Double costPercent;
     if (DOUBLE_ZERO.equals(packageCost)) {
@@ -71,7 +65,7 @@ public class ResourceCostPerUseCollectionConverter
       .withType(ResourceCostPerUseCollectionItem.Type.RESOURCE_COST_PER_USE_ITEM)
       .withAttributes(new ResourceCostAnalysisAttributes()
         .withName(dbHoldingInfo.getPublicationTitle())
-        .withPublicationType(publicationType)
+        .withPublicationType(PublicationType.fromValue(dbHoldingInfo.getResourceType()))
         .withCost(ucCostAnalysis.getCurrent().getCost())
         .withUsage(ucCostAnalysis.getCurrent().getUsage())
         .withCostPerUse(ucCostAnalysis.getCurrent().getCostPerUse())

--- a/src/main/java/org/folio/rest/impl/EholdingsCostperuseImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsCostperuseImpl.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.aspect.HandleValidationErrors;
+import org.folio.rest.jaxrs.model.Order;
 import org.folio.rest.jaxrs.resource.EholdingsPackagesPackageIdCostperuse;
 import org.folio.rest.jaxrs.resource.EholdingsPackagesPackageIdResourcesCostperuse;
 import org.folio.rest.jaxrs.resource.EholdingsResourcesResourceIdCostperuse;
@@ -84,13 +85,15 @@ public class EholdingsCostperuseImpl
   @Validate
   @HandleValidationErrors
   public void getEholdingsPackagesResourcesCostperuseByPackageId(String packageId, String platform, String fiscalYear,
-                                                                 int page, int count, Map<String, String> okapiHeaders,
+                                                                 Order order, String sort, int page, int count,
+                                                                 Map<String, String> okapiHeaders,
                                                                  Handler<AsyncResult<Response>> asyncResultHandler,
                                                                  Context vertxContext) {
-    costPerUseService.getPackageResourcesCostPerUse(packageId, platform, fiscalYear, page, count, okapiHeaders)
+    costPerUseService.getPackageResourcesCostPerUse(packageId, platform, fiscalYear, sort, order, page, count, okapiHeaders)
       .thenAccept(costPerUseCollection ->
         asyncResultHandler.handle(succeededFuture(
-          GetEholdingsPackagesResourcesCostperuseByPackageIdResponse.respond200WithApplicationVndApiJson(costPerUseCollection)))
+          GetEholdingsPackagesResourcesCostperuseByPackageIdResponse
+            .respond200WithApplicationVndApiJson(costPerUseCollection)))
       )
       .exceptionally(costPerUseErrorHandler.handle(asyncResultHandler));
   }

--- a/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
@@ -282,11 +282,11 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
   @Override
   @Validate
   @HandleValidationErrors
-  public void getEholdingsPackagesResourcesByPackageId(String packageId, String sort, List<String> filterTags,
+  public void getEholdingsPackagesResourcesByPackageId(String packageId, List<String> filterTags,
                                                        List<String> filterAccessType, String filterSelected,
                                                        String filterType, String filterName, String filterIsxn,
-                                                       String filterSubject, String filterPublisher, int page, int count,
-                                                       Map<String, String> okapiHeaders,
+                                                       String filterSubject, String filterPublisher, String sort, int page,
+                                                       int count, Map<String, String> okapiHeaders,
                                                        Handler<AsyncResult<Response>> asyncResultHandler,
                                                        Context vertxContext) {
 

--- a/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
@@ -92,9 +92,9 @@ public class EholdingsTitlesImpl implements EholdingsTitles {
   @HandleValidationErrors
   public void getEholdingsTitles(List<String> filterTags, List<String> filterAccessType, String filterSelected,
                                  String filterType, String filterName, String filterIsxn, String filterSubject,
-                                 String filterPublisher, String sort, int page, int count, String include,
-                                 Map<String, String> okapiHeaders,
-                                 Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+                                 String filterPublisher, String include, String sort, int page, int count,
+                                 Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+                                 Context vertxContext) {
     Filter filter = Filter.builder()
       .recordType(RecordType.TITLE)
       .filterTags(filterTags)

--- a/src/main/java/org/folio/rmapi/result/ResourceCostPerUseCollectionResult.java
+++ b/src/main/java/org/folio/rmapi/result/ResourceCostPerUseCollectionResult.java
@@ -8,6 +8,7 @@ import lombok.Value;
 
 import org.folio.client.uc.configuration.CommonUCConfiguration;
 import org.folio.client.uc.model.UCCostAnalysis;
+import org.folio.client.uc.model.UCPackageCostPerUse;
 import org.folio.repository.holdings.DbHoldingInfo;
 
 @Value
@@ -16,5 +17,6 @@ public class ResourceCostPerUseCollectionResult {
 
   List<DbHoldingInfo> holdingInfos;
   Map<String, UCCostAnalysis> titlePackageCostMap;
+  UCPackageCostPerUse packageCostPerUse;
   CommonUCConfiguration configuration;
 }

--- a/src/main/java/org/folio/service/kbcredentials/UserKbCredentialsServiceImpl.java
+++ b/src/main/java/org/folio/service/kbcredentials/UserKbCredentialsServiceImpl.java
@@ -21,7 +21,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.core.convert.converter.Converter;
 
-import org.folio.cache.VertxCache;
 import org.folio.repository.assigneduser.AssignedUserRepository;
 import org.folio.repository.kbcredentials.DbKbCredentials;
 import org.folio.repository.kbcredentials.KbCredentialsRepository;
@@ -37,15 +36,11 @@ public class UserKbCredentialsServiceImpl implements UserKbCredentialsService {
   private final AssignedUserRepository assignedUserRepository;
   private final Converter<DbKbCredentials, KbCredentials> credentialsFromDBConverter;
 
-  private final VertxCache<String, KbCredentials> cache;
-
   @Override
   public CompletableFuture<KbCredentials> findByUser(Map<String, String> okapiHeaders) {
     return fetchUserInfo(okapiHeaders)
-      .thenCompose(userInfo -> cache.getValueOrLoad(
-        userInfo.getUserId(),
-        () -> findUserCredentials(userInfo, tenantId(okapiHeaders)).thenApply(credentialsFromDBConverter::convert)
-      ));
+      .thenCompose(userInfo -> findUserCredentials(userInfo, tenantId(okapiHeaders)))
+      .thenApply(credentialsFromDBConverter::convert);
   }
 
   private CompletableFuture<DbKbCredentials> findUserCredentials(UserInfo userInfo, String tenant) {

--- a/src/main/java/org/folio/service/uc/UCCostPerUseService.java
+++ b/src/main/java/org/folio/service/uc/UCCostPerUseService.java
@@ -3,6 +3,7 @@ package org.folio.service.uc;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.folio.rest.jaxrs.model.Order;
 import org.folio.rest.jaxrs.model.PackageCostPerUse;
 import org.folio.rest.jaxrs.model.ResourceCostPerUse;
 import org.folio.rest.jaxrs.model.ResourceCostPerUseCollection;
@@ -20,7 +21,8 @@ public interface UCCostPerUseService {
                                                             Map<String, String> okapiHeaders);
 
   CompletableFuture<ResourceCostPerUseCollection> getPackageResourcesCostPerUse(String packageId, String platform,
-                                                                                String fiscalYear, int page, int size,
+                                                                                String fiscalYear, String sort, Order order,
+                                                                                int page, int size,
                                                                                 Map<String, String> okapiHeaders);
 
 }

--- a/src/main/java/org/folio/service/uc/sorting/CostPerUseSort.java
+++ b/src/main/java/org/folio/service/uc/sorting/CostPerUseSort.java
@@ -1,0 +1,19 @@
+package org.folio.service.uc.sorting;
+
+public enum CostPerUseSort {
+
+  NAME, TYPE, COST, USAGE, COSTPERUSE, PERCENT;
+
+  public static CostPerUseSort from(String value) {
+    return CostPerUseSort.valueOf(value.toUpperCase());
+  }
+
+  public static boolean contains(String value) {
+    for (CostPerUseSort c : CostPerUseSort.values()) {
+      if (c.name().equalsIgnoreCase(value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/org/folio/service/uc/sorting/UCSortingComparatorProvider.java
+++ b/src/main/java/org/folio/service/uc/sorting/UCSortingComparatorProvider.java
@@ -1,0 +1,11 @@
+package org.folio.service.uc.sorting;
+
+import java.util.Comparator;
+
+import org.folio.rest.jaxrs.model.Order;
+
+public interface UCSortingComparatorProvider<I> {
+
+  Comparator<I> get(CostPerUseSort sorting, Order order);
+
+}

--- a/src/main/java/org/folio/service/uc/sorting/UCSortingComparatorProviders.java
+++ b/src/main/java/org/folio/service/uc/sorting/UCSortingComparatorProviders.java
@@ -1,0 +1,52 @@
+package org.folio.service.uc.sorting;
+
+import static org.folio.service.uc.sorting.CostPerUseSort.COST;
+import static org.folio.service.uc.sorting.CostPerUseSort.COSTPERUSE;
+import static org.folio.service.uc.sorting.CostPerUseSort.PERCENT;
+import static org.folio.service.uc.sorting.CostPerUseSort.TYPE;
+import static org.folio.service.uc.sorting.CostPerUseSort.USAGE;
+
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import lombok.experimental.UtilityClass;
+
+import org.folio.common.ComparatorUtils;
+import org.folio.rest.jaxrs.model.Order;
+import org.folio.rest.jaxrs.model.ResourceCostPerUseCollectionItem;
+
+@UtilityClass
+public class UCSortingComparatorProviders {
+
+  public static UCSortingComparatorProvider<ResourceCostPerUseCollectionItem> forResources() {
+    Function<ResourceCostPerUseCollectionItem, String> nameExtractor = o -> o.getAttributes().getName();
+
+    Map<CostPerUseSort, Comparator<ResourceCostPerUseCollectionItem>> comparatorPerSort =
+        new EnumMap<>(CostPerUseSort.class);
+
+    comparatorPerSort.put(TYPE,
+        Comparator.<ResourceCostPerUseCollectionItem, String>comparing(o -> o.getAttributes().getPublicationType().value())
+            .thenComparing(nameExtractor));
+    comparatorPerSort.put(COST,
+        ComparatorUtils.<ResourceCostPerUseCollectionItem>nullFirstDouble(o -> o.getAttributes().getCost())
+            .thenComparing(nameExtractor));
+    comparatorPerSort.put(USAGE,
+        ComparatorUtils.<ResourceCostPerUseCollectionItem>nullFirstInteger(o -> o.getAttributes().getUsage())
+            .thenComparing(nameExtractor));
+    comparatorPerSort.put(COSTPERUSE,
+        ComparatorUtils.<ResourceCostPerUseCollectionItem>nullFirstDouble(o -> o.getAttributes().getCostPerUse())
+            .thenComparing(nameExtractor));
+    comparatorPerSort.put(PERCENT,
+        ComparatorUtils.<ResourceCostPerUseCollectionItem>nullFirstDouble(o -> o.getAttributes().getPercent())
+            .thenComparing(nameExtractor));
+
+    return (sorting, order) -> {
+      Comparator<ResourceCostPerUseCollectionItem> comparator =
+          comparatorPerSort.getOrDefault(sorting, Comparator.comparing(nameExtractor));
+
+      return order == Order.ASC ? comparator : comparator.reversed();
+    };
+  }
+}

--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -118,6 +118,12 @@ public class ApplicationConfig {
   }
 
   @Bean
+  public VertxCache<String, KbCredentials> userKbCredentialsCache(Vertx vertx,
+      @Value("${kb-credentials.cache.expire}") long expirationTime) {
+    return new VertxCache<>(vertx, expirationTime, "userKbCredentialsCache");
+  }
+
+  @Bean
   public VertxCache<VendorIdCacheKey, Long> vendorIdCache(Vertx vertx,
       @Value("${vendor.id.cache.expire}") long expirationTime) {
     return new VertxCache<>(vertx, expirationTime, "vendorIdCache");
@@ -265,8 +271,9 @@ public class ApplicationConfig {
   public UserKbCredentialsService securedUserCredentialsService(KbCredentialsRepository credentialsRepository,
                                                                 AssignedUserRepository assignedUserRepository,
                                                                 @Qualifier("secured")
-                                                                  Converter<DbKbCredentials, KbCredentials> converter) {
-    return new UserKbCredentialsServiceImpl(credentialsRepository, assignedUserRepository, converter);
+                                                                  Converter<DbKbCredentials, KbCredentials> converter,
+                                                                VertxCache<String, KbCredentials> userKbCredentialsCache) {
+    return new UserKbCredentialsServiceImpl(credentialsRepository, assignedUserRepository, converter, userKbCredentialsCache);
   }
 
   @Bean("securedCredentialsService")
@@ -282,8 +289,9 @@ public class ApplicationConfig {
   public UserKbCredentialsService nonSecuredUserCredentialsService(KbCredentialsRepository repository,
                                                                    AssignedUserRepository assignedUserRepository,
                                                                    @Qualifier("nonSecured")
-                                                                     Converter<DbKbCredentials, KbCredentials> converter) {
-    return new UserKbCredentialsServiceImpl(repository, assignedUserRepository, converter);
+                                                                     Converter<DbKbCredentials, KbCredentials> converter,
+                                                                   VertxCache<String, KbCredentials> userKbCredentialsCache) {
+    return new UserKbCredentialsServiceImpl(repository, assignedUserRepository, converter, userKbCredentialsCache);
   }
 
   @Bean("nonSecuredCredentialsService")

--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -66,6 +66,7 @@ import org.folio.rest.exception.InputValidationException;
 import org.folio.rest.jaxrs.model.CurrencyCollection;
 import org.folio.rest.jaxrs.model.KbCredentials;
 import org.folio.rest.jaxrs.model.KbCredentialsCollection;
+import org.folio.rest.jaxrs.model.ResourceCostPerUseCollectionItem;
 import org.folio.rest.jaxrs.model.UCSettings;
 import org.folio.rest.jaxrs.model.UCSettingsPostRequest;
 import org.folio.rest.util.ErrorHandler;
@@ -84,6 +85,8 @@ import org.folio.service.uc.UCAuthService;
 import org.folio.service.uc.UCSettingsService;
 import org.folio.service.uc.UCSettingsServiceImpl;
 import org.folio.service.uc.UcAuthenticationException;
+import org.folio.service.uc.sorting.UCSortingComparatorProvider;
+import org.folio.service.uc.sorting.UCSortingComparatorProviders;
 
 @Configuration
 @ComponentScan(basePackages = {
@@ -323,6 +326,11 @@ public class ApplicationConfig {
     UCApigeeEbscoClient ebscoClient,
     UCSettingsRepository repository) {
     return new UCSettingsServiceImpl(kbCredentialsService, repository, authService, ebscoClient, fromConverter, toConverter);
+  }
+
+  @Bean
+  public UCSortingComparatorProvider<ResourceCostPerUseCollectionItem> resourceUCSortingComparatorProvider() {
+    return UCSortingComparatorProviders.forResources();
   }
 
 }

--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -121,12 +121,6 @@ public class ApplicationConfig {
   }
 
   @Bean
-  public VertxCache<String, KbCredentials> userKbCredentialsCache(Vertx vertx,
-      @Value("${kb-credentials.cache.expire}") long expirationTime) {
-    return new VertxCache<>(vertx, expirationTime, "userKbCredentialsCache");
-  }
-
-  @Bean
   public VertxCache<VendorIdCacheKey, Long> vendorIdCache(Vertx vertx,
       @Value("${vendor.id.cache.expire}") long expirationTime) {
     return new VertxCache<>(vertx, expirationTime, "vendorIdCache");
@@ -274,9 +268,8 @@ public class ApplicationConfig {
   public UserKbCredentialsService securedUserCredentialsService(KbCredentialsRepository credentialsRepository,
                                                                 AssignedUserRepository assignedUserRepository,
                                                                 @Qualifier("secured")
-                                                                  Converter<DbKbCredentials, KbCredentials> converter,
-                                                                VertxCache<String, KbCredentials> userKbCredentialsCache) {
-    return new UserKbCredentialsServiceImpl(credentialsRepository, assignedUserRepository, converter, userKbCredentialsCache);
+                                                                  Converter<DbKbCredentials, KbCredentials> converter) {
+    return new UserKbCredentialsServiceImpl(credentialsRepository, assignedUserRepository, converter);
   }
 
   @Bean("securedCredentialsService")
@@ -292,9 +285,8 @@ public class ApplicationConfig {
   public UserKbCredentialsService nonSecuredUserCredentialsService(KbCredentialsRepository repository,
                                                                    AssignedUserRepository assignedUserRepository,
                                                                    @Qualifier("nonSecured")
-                                                                     Converter<DbKbCredentials, KbCredentials> converter,
-                                                                   VertxCache<String, KbCredentials> userKbCredentialsCache) {
-    return new UserKbCredentialsServiceImpl(repository, assignedUserRepository, converter, userKbCredentialsCache);
+                                                                     Converter<DbKbCredentials, KbCredentials> converter) {
+    return new UserKbCredentialsServiceImpl(repository, assignedUserRepository, converter);
   }
 
   @Bean("nonSecuredCredentialsService")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,7 +36,6 @@ uc.title-package.cache.expire=86400
 uc.title-package.cache.enable=false
 currencies.cache.expire=86400
 configuration.cache.expire=120
-kb-credentials.cache.expire=120
 package.cache.expire=86400
 resource.cache.expire=86400
 title.cache.expire=86400

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,6 +36,7 @@ uc.title-package.cache.expire=86400
 uc.title-package.cache.enable=false
 currencies.cache.expire=86400
 configuration.cache.expire=120
+kb-credentials.cache.expire=120
 package.cache.expire=86400
 resource.cache.expire=86400
 title.cache.expire=86400

--- a/src/main/resources/liquibase/tenant/changelog-3.6.0.xml
+++ b/src/main/resources/liquibase/tenant/changelog-3.6.0.xml
@@ -7,4 +7,5 @@
   <include file="liquibase/tenant/scripts/v3.6.0/create-usage-consolidation-settings-table.xml"/>
   <include file="liquibase/tenant/scripts/v3.6.0/update-access-types-view-user-name-column.xml"/>
   <include file="liquibase/tenant/scripts/v3.6.0/create-usage-consolidation-credentials-table.xml"/>
+  <include file="liquibase/tenant/scripts/v3.6.0/create-holdings-package-id-index.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/liquibase/tenant/scripts/v3.6.0/create-holdings-package-id-index.xml
+++ b/src/main/resources/liquibase/tenant/scripts/v3.6.0/create-holdings-package-id-index.xml
@@ -1,0 +1,12 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+  <changeSet id="MODKBEKBJ-487@@create-holdings-package-id-index" author="psmagin">
+    <createIndex tableName="holdings" indexName="holdings_package_id_idx">
+      <column name="package_id"/>
+    </createIndex>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/folio/rest/impl/WireMockTestBase.java
+++ b/src/test/java/org/folio/rest/impl/WireMockTestBase.java
@@ -36,6 +36,7 @@ import org.folio.holdingsiq.model.Configuration;
 import org.folio.holdingsiq.model.PackageByIdData;
 import org.folio.holdingsiq.model.Title;
 import org.folio.holdingsiq.model.VendorById;
+import org.folio.rest.jaxrs.model.KbCredentials;
 import org.folio.rmapi.cache.PackageCacheKey;
 import org.folio.rmapi.cache.ResourceCacheKey;
 import org.folio.rmapi.cache.TitleCacheKey;
@@ -79,6 +80,8 @@ public abstract class WireMockTestBase extends TestBase {
   private VertxCache<TitleCacheKey, Title> titleCache;
   @Autowired
   private VertxCache<String, String> ucTokenCache;
+  @Autowired
+  private VertxCache<String, KbCredentials> userKbCredentialsCache;
 
   @BeforeClass
   public static void setUpClass(TestContext context) {
@@ -100,6 +103,7 @@ public abstract class WireMockTestBase extends TestBase {
     resourceCache.invalidateAll();
     titleCache.invalidateAll();
     ucTokenCache.invalidateAll();
+    userKbCredentialsCache.invalidateAll();
   }
 
   protected void setUpTestUsers() {

--- a/src/test/java/org/folio/rest/impl/WireMockTestBase.java
+++ b/src/test/java/org/folio/rest/impl/WireMockTestBase.java
@@ -36,7 +36,6 @@ import org.folio.holdingsiq.model.Configuration;
 import org.folio.holdingsiq.model.PackageByIdData;
 import org.folio.holdingsiq.model.Title;
 import org.folio.holdingsiq.model.VendorById;
-import org.folio.rest.jaxrs.model.KbCredentials;
 import org.folio.rmapi.cache.PackageCacheKey;
 import org.folio.rmapi.cache.ResourceCacheKey;
 import org.folio.rmapi.cache.TitleCacheKey;
@@ -80,8 +79,6 @@ public abstract class WireMockTestBase extends TestBase {
   private VertxCache<TitleCacheKey, Title> titleCache;
   @Autowired
   private VertxCache<String, String> ucTokenCache;
-  @Autowired
-  private VertxCache<String, KbCredentials> userKbCredentialsCache;
 
   @BeforeClass
   public static void setUpClass(TestContext context) {
@@ -103,7 +100,6 @@ public abstract class WireMockTestBase extends TestBase {
     resourceCache.invalidateAll();
     titleCache.invalidateAll();
     ucTokenCache.invalidateAll();
-    userKbCredentialsCache.invalidateAll();
   }
 
   protected void setUpTestUsers() {

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsCostperuseImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsCostperuseImplTest.java
@@ -598,6 +598,9 @@ public class EholdingsCostperuseImplTest extends WireMockTestBase {
 
     saveHolding(credentialsId, generateHolding(packageId, 1), OffsetDateTime.now(), vertx);
 
+    String stubApigeeGetPackageResponseFile = "responses/uc/packages/get-package-cost-per-use-with-empty-cost-response.json";
+    mockSuccessfulPackageCostPerUse(packageId, stubApigeeGetPackageResponseFile);
+
     stubFor(post(urlPathMatching("/uc/costperuse/titles"))
       .willReturn(aResponse().withStatus(SC_BAD_REQUEST).withBody("Random error message"))
     );

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsCostperuseImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsCostperuseImplTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 
@@ -334,6 +335,8 @@ public class EholdingsCostperuseImplTest extends WireMockTestBase {
       saveHolding(credentialsId, generateHolding(packageId, i), OffsetDateTime.now(), vertx);
     }
 
+    String stubApigeeGetPackageResponseFile = "responses/uc/packages/get-package-cost-per-use-with-empty-cost-response.json";
+    mockSuccessfulPackageCostPerUse(packageId, stubApigeeGetPackageResponseFile);
     String stubApigeeGetTitlePackageResponseFile =
       "responses/uc/title-packages/get-multiply-title-packages-cost-per-use-for-package-response.json";
     mockSuccessfulTitlePackageCostPerUse(stubApigeeGetTitlePackageResponseFile);
@@ -361,6 +364,8 @@ public class EholdingsCostperuseImplTest extends WireMockTestBase {
       saveHolding(credentialsId, generateHolding(packageId, i), OffsetDateTime.now(), vertx);
     }
 
+    String stubApigeeGetPackageResponseFile = "responses/uc/packages/get-package-cost-per-use-with-empty-cost-response.json";
+    mockSuccessfulPackageCostPerUse(packageId, stubApigeeGetPackageResponseFile);
     String stubApigeeGetTitlePackageResponseFile =
       "responses/uc/title-packages/get-multiply-title-packages-cost-per-use-for-package-response.json";
     mockSuccessfulTitlePackageCostPerUse(stubApigeeGetTitlePackageResponseFile);
@@ -374,6 +379,182 @@ public class EholdingsCostperuseImplTest extends WireMockTestBase {
     assertThat(actual.getData(), hasSize(5));
     assertThat(actual.getData(), everyItem(hasProperty("resourceId", startsWith("1-" + packageId))));
     assertThat(actual.getData().get(0).getAttributes(), hasProperty("usage", equalTo(1)));
+  }
+
+  @Test
+  public void shouldReturnResourcesCostPerUseCollectionWithSortByUsageAsc() {
+    String packageId = "222222";
+    String year = "2019";
+    String platform = "publisher";
+    String sort = "usage";
+    String order = "asc";
+
+    for (int i = 1; i <= 3; i++) {
+      saveHolding(credentialsId, generateHolding(packageId, i), OffsetDateTime.now(), vertx);
+    }
+
+    String stubApigeeGetPackageResponseFile = "responses/uc/packages/get-package-cost-per-use-with-empty-cost-response.json";
+    mockSuccessfulPackageCostPerUse(packageId, stubApigeeGetPackageResponseFile);
+    String stubApigeeGetTitlePackageResponseFile =
+      "responses/uc/title-packages/get-different-title-packages-cost-per-use-for-package-response.json";
+    mockSuccessfulTitlePackageCostPerUse(stubApigeeGetTitlePackageResponseFile);
+
+    ResourceCostPerUseCollection
+      actual = getWithOk(packageResourcesEndpoint(packageId, year, platform, null, null, sort, order), JOHN_TOKEN_HEADER)
+      .as(ResourceCostPerUseCollection.class);
+
+    assertThat(actual, notNullValue());
+    assertThat(actual.getMeta().getTotalResults(), equalTo(3));
+    assertThat(actual.getData(), hasSize(3));
+    assertThat(actual.getData(), everyItem(hasProperty("resourceId", startsWith("1-" + packageId))));
+    assertThat(actual.getData().get(0).getAttributes(), hasProperty("usage", equalTo(1)));
+    assertThat(actual.getData().get(2).getAttributes(), hasProperty("usage", equalTo(10)));
+  }
+
+  @Test
+  public void shouldReturnResourcesCostPerUseCollectionWithSortByUsageDesc() {
+    String packageId = "222222";
+    String year = "2019";
+    String platform = "publisher";
+    String sort = "usage";
+    String order = "desc";
+
+    for (int i = 1; i <= 3; i++) {
+      saveHolding(credentialsId, generateHolding(packageId, i), OffsetDateTime.now(), vertx);
+    }
+
+    String stubApigeeGetPackageResponseFile = "responses/uc/packages/get-package-cost-per-use-with-empty-cost-response.json";
+    mockSuccessfulPackageCostPerUse(packageId, stubApigeeGetPackageResponseFile);
+    String stubApigeeGetTitlePackageResponseFile =
+      "responses/uc/title-packages/get-different-title-packages-cost-per-use-for-package-response.json";
+    mockSuccessfulTitlePackageCostPerUse(stubApigeeGetTitlePackageResponseFile);
+
+    ResourceCostPerUseCollection
+      actual = getWithOk(packageResourcesEndpoint(packageId, year, platform, null, null, sort, order), JOHN_TOKEN_HEADER)
+      .as(ResourceCostPerUseCollection.class);
+
+    assertThat(actual, notNullValue());
+    assertThat(actual.getMeta().getTotalResults(), equalTo(3));
+    assertThat(actual.getData(), hasSize(3));
+    assertThat(actual.getData(), everyItem(hasProperty("resourceId", startsWith("1-" + packageId))));
+    assertThat(actual.getData().get(0).getAttributes(), hasProperty("usage", equalTo(10)));
+    assertThat(actual.getData().get(2).getAttributes(), hasProperty("usage", equalTo(1)));
+  }
+
+  @Test
+  public void shouldReturnResourcesCostPerUseCollectionWithSortByCost() {
+    String packageId = "222222";
+    String year = "2019";
+    String platform = "publisher";
+    String sort = "cost";
+
+    for (int i = 1; i <= 3; i++) {
+      saveHolding(credentialsId, generateHolding(packageId, i), OffsetDateTime.now(), vertx);
+    }
+
+    String stubApigeeGetPackageResponseFile = "responses/uc/packages/get-package-cost-per-use-with-empty-cost-response.json";
+    mockSuccessfulPackageCostPerUse(packageId, stubApigeeGetPackageResponseFile);
+    String stubApigeeGetTitlePackageResponseFile =
+      "responses/uc/title-packages/get-different-title-packages-cost-per-use-for-package-response.json";
+    mockSuccessfulTitlePackageCostPerUse(stubApigeeGetTitlePackageResponseFile);
+
+    ResourceCostPerUseCollection
+      actual = getWithOk(packageResourcesEndpoint(packageId, year, platform, null, null, sort, null), JOHN_TOKEN_HEADER)
+      .as(ResourceCostPerUseCollection.class);
+
+    assertThat(actual, notNullValue());
+    assertThat(actual.getMeta().getTotalResults(), equalTo(3));
+    assertThat(actual.getData(), hasSize(3));
+    assertThat(actual.getData(), everyItem(hasProperty("resourceId", startsWith("1-" + packageId))));
+    assertThat(actual.getData().get(0).getAttributes(), hasProperty("cost", nullValue()));
+    assertThat(actual.getData().get(2).getAttributes(), hasProperty("cost", equalTo(200.0)));
+  }
+
+  @Test
+  public void shouldReturnResourcesCostPerUseCollectionWithSortByCostPerUse() {
+    String packageId = "222222";
+    String year = "2019";
+    String platform = "publisher";
+    String sort = "costperuse";
+
+    for (int i = 1; i <= 3; i++) {
+      saveHolding(credentialsId, generateHolding(packageId, i), OffsetDateTime.now(), vertx);
+    }
+
+    String stubApigeeGetPackageResponseFile = "responses/uc/packages/get-package-cost-per-use-with-empty-cost-response.json";
+    mockSuccessfulPackageCostPerUse(packageId, stubApigeeGetPackageResponseFile);
+    String stubApigeeGetTitlePackageResponseFile =
+      "responses/uc/title-packages/get-different-title-packages-cost-per-use-for-package-response.json";
+    mockSuccessfulTitlePackageCostPerUse(stubApigeeGetTitlePackageResponseFile);
+
+    ResourceCostPerUseCollection
+      actual = getWithOk(packageResourcesEndpoint(packageId, year, platform, null, null, sort, null), JOHN_TOKEN_HEADER)
+      .as(ResourceCostPerUseCollection.class);
+
+    assertThat(actual, notNullValue());
+    assertThat(actual.getMeta().getTotalResults(), equalTo(3));
+    assertThat(actual.getData(), hasSize(3));
+    assertThat(actual.getData(), everyItem(hasProperty("resourceId", startsWith("1-" + packageId))));
+    assertThat(actual.getData().get(0).getAttributes(), hasProperty("costPerUse", nullValue()));
+    assertThat(actual.getData().get(2).getAttributes(), hasProperty("costPerUse", equalTo(50.0)));
+  }
+
+  @Test
+  public void shouldReturnResourcesCostPerUseCollectionWithSortByPercent() {
+    String packageId = "222222";
+    String year = "2019";
+    String platform = "publisher";
+    String sort = "percent";
+
+    for (int i = 1; i <= 3; i++) {
+      saveHolding(credentialsId, generateHolding(packageId, i), OffsetDateTime.now(), vertx);
+    }
+
+    String stubApigeeGetPackageResponseFile = "responses/uc/packages/get-package-cost-per-use-with-empty-cost-response.json";
+    mockSuccessfulPackageCostPerUse(packageId, stubApigeeGetPackageResponseFile);
+    String stubApigeeGetTitlePackageResponseFile =
+      "responses/uc/title-packages/get-different-title-packages-cost-per-use-for-package-response.json";
+    mockSuccessfulTitlePackageCostPerUse(stubApigeeGetTitlePackageResponseFile);
+
+    ResourceCostPerUseCollection
+      actual = getWithOk(packageResourcesEndpoint(packageId, year, platform, null, null, sort, null), JOHN_TOKEN_HEADER)
+      .as(ResourceCostPerUseCollection.class);
+
+    assertThat(actual, notNullValue());
+    assertThat(actual.getMeta().getTotalResults(), equalTo(3));
+    assertThat(actual.getData(), hasSize(3));
+    assertThat(actual.getData(), everyItem(hasProperty("resourceId", startsWith("1-" + packageId))));
+    assertThat(actual.getData().get(0).getAttributes(), hasProperty("cost", nullValue()));
+    assertThat(actual.getData().get(2).getAttributes(), hasProperty("cost", equalTo(200.0)));
+  }
+
+  @Test
+  public void shouldReturnResourcesCostPerUseCollectionSortedByNameWhenSortingByEqualsValues() {
+    String packageId = "222222";
+    String year = "2019";
+    String platform = "publisher";
+    String sort = "type";
+
+    for (int i = 1; i <= 3; i++) {
+      saveHolding(credentialsId, generateHolding(packageId, i, String.valueOf(i)), OffsetDateTime.now(), vertx);
+    }
+
+    String stubApigeeGetPackageResponseFile = "responses/uc/packages/get-package-cost-per-use-with-empty-cost-response.json";
+    mockSuccessfulPackageCostPerUse(packageId, stubApigeeGetPackageResponseFile);
+    String stubApigeeGetTitlePackageResponseFile =
+      "responses/uc/title-packages/get-different-title-packages-cost-per-use-for-package-response.json";
+    mockSuccessfulTitlePackageCostPerUse(stubApigeeGetTitlePackageResponseFile);
+
+    ResourceCostPerUseCollection
+      actual = getWithOk(packageResourcesEndpoint(packageId, year, platform, null, null, sort, null), JOHN_TOKEN_HEADER)
+      .as(ResourceCostPerUseCollection.class);
+
+    assertThat(actual, notNullValue());
+    assertThat(actual.getMeta().getTotalResults(), equalTo(3));
+    assertThat(actual.getData(), hasSize(3));
+    assertThat(actual.getData(), everyItem(hasProperty("resourceId", startsWith("1-" + packageId))));
+    assertThat(actual.getData().get(0).getAttributes(), hasProperty("name", equalTo("1")));
+    assertThat(actual.getData().get(2).getAttributes(), hasProperty("name", equalTo("3")));
   }
 
   @Test
@@ -395,6 +576,19 @@ public class EholdingsCostperuseImplTest extends WireMockTestBase {
         .as(JsonapiError.class);
 
     assertErrorContainsTitle(error, "Invalid platform");
+  }
+
+  @Test
+  public void shouldReturn422OnGetPackageResourcesCPUWhenSortIsInvalid() {
+    String packageId = "222222";
+    String year = "2019";
+    String platform = "all";
+    String sort = "invalid";
+    JsonapiError error =
+      getWithStatus(packageResourcesEndpoint(packageId, year, platform, null, null, sort, null), SC_UNPROCESSABLE_ENTITY)
+        .as(JsonapiError.class);
+
+    assertErrorContainsTitle(error, "Invalid sort");
   }
 
   @Test
@@ -480,14 +674,24 @@ public class EholdingsCostperuseImplTest extends WireMockTestBase {
   }
 
   private String packageResourcesEndpoint(String packageId, String year, String platform, String page, String size) {
+    return packageResourcesEndpoint(packageId, year, platform, page, size, null, null);
+  }
+
+  private String packageResourcesEndpoint(String packageId, String year, String platform, String page, String size,
+                                          String sort, String order) {
     String baseUrl = String.format("eholdings/packages/1-%s/resources/costperuse", packageId);
-    StringBuilder paramsSb = getEndpointParams(year, platform, page, size);
+    StringBuilder paramsSb = getEndpointParams(year, platform, page, size, sort, order);
     return paramsSb.length() > 0
       ? baseUrl + "?" + paramsSb.toString()
       : baseUrl;
   }
 
-  private StringBuilder getEndpointParams(String year, String platform, String page, String size) {
+  private StringBuilder getEndpointParams(String year, String platform) {
+    return getEndpointParams(year, platform, null, null, null, null);
+  }
+
+  private StringBuilder getEndpointParams(String year, String platform, String page, String size, String sort,
+                                          String order) {
     StringBuilder paramsSb = new StringBuilder();
     if (year != null) {
       paramsSb.append("fiscalYear=").append(year);
@@ -495,6 +699,8 @@ public class EholdingsCostperuseImplTest extends WireMockTestBase {
     addParam(platform, paramsSb, "platform=");
     addParam(page, paramsSb, "page=");
     addParam(size, paramsSb, "count=");
+    addParam(sort, paramsSb, "sort=");
+    addParam(order, paramsSb, "order=");
     return paramsSb;
   }
 
@@ -507,15 +713,22 @@ public class EholdingsCostperuseImplTest extends WireMockTestBase {
     }
   }
 
-  private StringBuilder getEndpointParams(String year, String platform) {
-    return getEndpointParams(year, platform, null, null);
-  }
-
   private DbHoldingInfo generateHolding(String packageId, int titleId) {
     return DbHoldingInfo.builder()
       .packageId(packageId)
       .titleId(String.valueOf(titleId))
       .publicationTitle(random.nextObject(String.class))
+      .publisherName(random.nextObject(String.class))
+      .resourceType("Book")
+      .vendorId("1")
+      .build();
+  }
+
+  private DbHoldingInfo generateHolding(String packageId, int titleId, String titleName) {
+    return DbHoldingInfo.builder()
+      .packageId(packageId)
+      .titleId(String.valueOf(titleId))
+      .publicationTitle(titleName)
       .publisherName(random.nextObject(String.class))
       .resourceType("Book")
       .vendorId("1")

--- a/src/test/resources/responses/uc/title-packages/get-different-title-packages-cost-per-use-for-package-response.json
+++ b/src/test/resources/responses/uc/title-packages/get-different-title-packages-cost-per-use-for-package-response.json
@@ -1,5 +1,5 @@
 {
   "1.222222": { "current": { "usage": 1 } },
   "2.222222": { "current": { "cost": 100, "usage": 2, "costPerUse": 50 } },
-  "3.222222": { "current": { "cost": 200, "usage": 10, "costPerUse": 20 } }
+    "3.222222": { "current": { "cost": 200, "usage": 10, "costPerUse": 20 } }
 }

--- a/src/test/resources/responses/uc/title-packages/get-different-title-packages-cost-per-use-for-package-response.json
+++ b/src/test/resources/responses/uc/title-packages/get-different-title-packages-cost-per-use-for-package-response.json
@@ -1,0 +1,5 @@
+{
+  "1.222222": { "current": { "usage": 1 } },
+  "2.222222": { "current": { "cost": 100, "usage": 2, "costPerUse": 50 } },
+  "3.222222": { "current": { "cost": 200, "usage": 10, "costPerUse": 20 } }
+}

--- a/src/test/resources/test-application.properties
+++ b/src/test/resources/test-application.properties
@@ -35,6 +35,7 @@ uc.token.cache.expire=3600
 uc.title-package.cache.expire=86400
 currencies.cache.expire=86400
 configuration.cache.expire=120
+kb-credentials.cache.expire=120
 package.cache.expire=86400
 resource.cache.expire=86400
 title.cache.expire=86400

--- a/src/test/resources/test-application.properties
+++ b/src/test/resources/test-application.properties
@@ -35,7 +35,6 @@ uc.token.cache.expire=3600
 uc.title-package.cache.expire=86400
 currencies.cache.expire=86400
 configuration.cache.expire=120
-kb-credentials.cache.expire=120
 package.cache.expire=86400
 resource.cache.expire=86400
 title.cache.expire=86400


### PR DESCRIPTION
## Purpose
Make `/eholdings/packages/<packageId>/resources/costperuse` sortable.

## Approach
* Add new parameters to endoint:
  * `sort` with possible values:
    * name
    * type
    * cost
    * usage
    * costperuse
    * percent
  * `order` with possible value:
    * asc
    * desc
* Implement calculating `percent of cost` (it was accidentally missed in previous PR)
* Actions have been taken to improve performance:
  * add index to `package_id` in `holdings` table
  * add cache for KB Credentials

#### TODOS and Open Questions
- [ ] The performance of work with the `holdings` table can be improved by changing the type of the `package_id` column to an integer. Also, the `vendor_id` and `title_id` columns could be migrated.

**varchar column type query analysis:**
![with_simple_index](https://user-images.githubusercontent.com/5904625/98532376-48f85e80-228a-11eb-87c5-199319819f24.png)

**integer column type query analysis:**
![with_simple_index_integer](https://user-images.githubusercontent.com/5904625/98532379-4990f500-228a-11eb-8768-4f998934a20d.png)
