### PR TITLE
MODKBEKBJ-532 Fix filtering resources in package by access types

### DIFF
--- a/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
@@ -13,7 +13,6 @@ import static org.folio.rest.util.RestConstants.JSONAPI;
 import static org.folio.rest.util.RestConstants.TAGS_TYPE;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -82,7 +81,6 @@ import org.folio.rest.validator.PackagePutBodyValidator;
 import org.folio.rest.validator.PackageTagsPutBodyValidator;
 import org.folio.rest.validator.PackagesPostBodyValidator;
 import org.folio.rmapi.result.PackageResult;
-import org.folio.rmapi.result.ResourceCollectionResult;
 import org.folio.rmapi.result.TitleCollectionResult;
 import org.folio.rmapi.result.TitleResult;
 import org.folio.service.accesstypes.AccessTypeMappingsService;
@@ -312,8 +310,7 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
       template.requestAction(context -> filteredEntitiesLoader.fetchResourcesByTagFilter(filter.createTagFilter(), context));
     } else if (filter.isAccessTypeFilter()) {
       template.requestAction(context -> filteredEntitiesLoader
-        .fetchTitlesByAccessTypeFilter(filter.createAccessTypeFilter(), context)
-        .thenApply(titles -> new ResourceCollectionResult(titles, Collections.emptyList(), Collections.emptyList()))
+        .fetchResourcesByAccessTypeFilter(filter.createAccessTypeFilter(), context)
       );
     } else {
       template.requestAction(context ->

--- a/src/main/java/org/folio/rest/util/IdParser.java
+++ b/src/main/java/org/folio/rest/util/IdParser.java
@@ -58,8 +58,16 @@ public final class IdParser {
     return concat(resourceId.getProviderIdPart(), resourceId.getPackageIdPart(), resourceId.getTitleIdPart());
   }
 
+  public static List<String> resourceIdsToStrings(List<ResourceId> resourceIds) {
+    return mapItems(resourceIds, IdParser::resourceIdToString);
+  }
+
   public static String getResourceId(CustomerResources resource) {
     return concat(resource.getVendorId(), resource.getPackageId(), resource.getTitleId());
+  }
+
+  public static List<String> dbResourcesToIdStrings(List<DbResource> resources) {
+    return mapItems(resources, dbResource -> resourceIdToString(dbResource.getId()));
   }
 
   public static String getResourceId(HoldingsId holding) {

--- a/src/main/java/org/folio/rmapi/ResourcesServiceImpl.java
+++ b/src/main/java/org/folio/rmapi/ResourcesServiceImpl.java
@@ -100,6 +100,10 @@ public class ResourcesServiceImpl extends ResourcesHoldingsIQServiceImpl {
     return resourceCache.getValueOrLoad(cacheKey, () -> retrieveResource(resourceId));
   }
 
+  public CompletableFuture<Titles> retrieveResources(List<ResourceId> resourceIds) {
+    return retrieveResources(resourceIds, Collections.emptyList());
+  }
+
   public CompletableFuture<Titles> retrieveResources(List<ResourceId> resourceIds, List<String> includes) {
     Set<CompletableFuture<ResourceResult>> futures = resourceIds.stream()
       .map(id -> retrieveResource(id, includes, true))

--- a/src/main/java/org/folio/service/holdings/HoldingsService.java
+++ b/src/main/java/org/folio/service/holdings/HoldingsService.java
@@ -11,7 +11,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 
 import org.folio.repository.holdings.DbHoldingInfo;
-import org.folio.repository.resources.DbResource;
 import org.folio.rest.util.template.RMAPITemplateContext;
 import org.folio.service.holdings.message.DeltaReportCreatedMessage;
 import org.folio.service.holdings.message.DeltaReportMessage;
@@ -41,7 +40,7 @@ public interface HoldingsService {
   }
 
   @GenIgnore
-  default CompletableFuture<List<DbHoldingInfo>> getHoldingsByIds(List<DbResource> resourcesResult, String credentialsId, String tenant) {
+  default CompletableFuture<List<DbHoldingInfo>> getHoldingsByIds(List<String> ids, String credentialsId, String tenant) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/org/folio/service/holdings/HoldingsServiceImpl.java
+++ b/src/main/java/org/folio/service/holdings/HoldingsServiceImpl.java
@@ -1,6 +1,5 @@
 package org.folio.service.holdings;
 
-import static org.folio.common.ListUtils.mapItems;
 import static org.folio.db.RowSetUtils.toUUID;
 import static org.folio.holdingsiq.model.HoldingChangeType.HOLDING_ADDED;
 import static org.folio.holdingsiq.model.HoldingChangeType.HOLDING_DELETED;
@@ -56,11 +55,9 @@ import org.folio.repository.holdings.status.HoldingsStatusRepository;
 import org.folio.repository.holdings.status.retry.RetryStatus;
 import org.folio.repository.holdings.status.retry.RetryStatusRepository;
 import org.folio.repository.holdings.transaction.TransactionIdRepository;
-import org.folio.repository.resources.DbResource;
 import org.folio.rest.jaxrs.model.HoldingsLoadingStatus;
 import org.folio.rest.jaxrs.model.LoadStatusAttributes;
 import org.folio.rest.jaxrs.model.LoadStatusNameEnum;
-import org.folio.rest.util.IdParser;
 import org.folio.rest.util.template.RMAPITemplateContext;
 import org.folio.service.holdings.exception.ProcessInProgressException;
 import org.folio.service.holdings.message.ConfigurationMessage;
@@ -149,9 +146,9 @@ public class HoldingsServiceImpl implements HoldingsService {
   }
 
   @Override
-  public CompletableFuture<List<DbHoldingInfo>> getHoldingsByIds(List<DbResource> resourcesResult, String credentialsId,
+  public CompletableFuture<List<DbHoldingInfo>> getHoldingsByIds(List<String> ids, String credentialsId,
                                                                  String tenantId) {
-    return holdingsRepository.findAllById(getTitleIdsAsList(resourcesResult), toUUID(credentialsId), tenantId);
+    return holdingsRepository.findAllById(ids, toUUID(credentialsId), tenantId);
   }
 
   @Override
@@ -378,10 +375,6 @@ public class HoldingsServiceImpl implements HoldingsService {
       return null;
     });
     return responsePromise.future();
-  }
-
-  private List<String> getTitleIdsAsList(List<DbResource> resources) {
-    return mapItems(resources, dbResource -> IdParser.resourceIdToString(dbResource.getId()));
   }
 
   private CompletableFuture<Void> saveHoldings(List<Holding> holdings, OffsetDateTime updatedAt, UUID credentialsId,

--- a/src/main/java/org/folio/service/loader/FilteredEntitiesLoader.java
+++ b/src/main/java/org/folio/service/loader/FilteredEntitiesLoader.java
@@ -16,6 +16,9 @@ public interface FilteredEntitiesLoader {
   CompletableFuture<Packages> fetchPackagesByAccessTypeFilter(AccessTypeFilter accessTypeFilter,
                                                               RMAPITemplateContext context);
 
+  CompletableFuture<ResourceCollectionResult> fetchResourcesByAccessTypeFilter(AccessTypeFilter accessTypeFilter,
+                                                                               RMAPITemplateContext context);
+
   CompletableFuture<Titles> fetchTitlesByAccessTypeFilter(AccessTypeFilter accessTypeFilter, RMAPITemplateContext context);
 
   CompletableFuture<Vendors> fetchProvidersByTagFilter(TagFilter tagFilter, RMAPITemplateContext context);

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsPackagesTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsPackagesTest.java
@@ -75,7 +75,6 @@ import static org.folio.util.PackagesTestUtil.savePackage;
 import static org.folio.util.PackagesTestUtil.setUpPackages;
 import static org.folio.util.ResourcesTestUtil.buildResource;
 import static org.folio.util.TagsTestUtil.saveTag;
-import static org.folio.util.TitlesTestUtil.mockGetTitles;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -1061,7 +1060,7 @@ public class EholdingsPackagesTest extends WireMockTestBase {
     insertAccessTypeMapping(STUB_MANAGED_RESOURCE_ID, RESOURCE, accessTypes.get(0).getId(), vertx);
     insertAccessTypeMapping(STUB_MANAGED_RESOURCE_ID_2, RESOURCE, accessTypes.get(0).getId(), vertx);
 
-    mockGetTitles();
+    mockResourceById("responses/rmapi/titles/get-title-by-id-response.json");
 
     String resourcePath = PACKAGES_ENDPOINT + "/" + FULL_PACKAGE_ID + "/resources"
       + "?filter[access-type]=" + STUB_ACCESS_TYPE_NAME;
@@ -1081,7 +1080,7 @@ public class EholdingsPackagesTest extends WireMockTestBase {
     insertAccessTypeMapping(STUB_MANAGED_RESOURCE_ID, RESOURCE, accessTypes.get(0).getId(), vertx);
     insertAccessTypeMapping(STUB_MANAGED_RESOURCE_ID_2, RESOURCE, accessTypes.get(1).getId(), vertx);
 
-    mockGetTitles();
+    mockResourceById("responses/rmapi/titles/get-title-by-id-response.json");
 
     String resourcePath = PACKAGES_ENDPOINT + "/" + FULL_PACKAGE_ID + "/resources?page=2&count=1&"
       + "filter[access-type]=" + STUB_ACCESS_TYPE_NAME + "&filter[access-type]=" + STUB_ACCESS_TYPE_NAME_2;


### PR DESCRIPTION
## Purpose
Fix filtering resources in packages by access types

## Approach
* Update FilteredEntitiesLoader to load resources instead of titles