### PR TITLE
MODKBEKBJ-538 Add usage metric type to UC settings response

### DIFF
--- a/ramls/types/uc/uCSettingsDataAttributes.json
+++ b/ramls/types/uc/uCSettingsDataAttributes.json
@@ -35,6 +35,21 @@
       "$ref": "platformType.json",
       "example": "publisher",
       "default": "all"
+    },
+    "metricType": {
+      "type": "string",
+      "description": "Metric usage type",
+      "readonly": true,
+      "enum": [
+        "Total Item Requests",
+        "Unique Item Requests",
+        "Unknown"
+      ],
+      "javaEnumNames": [
+        "TOTAL",
+        "UNIQUE",
+        "UNKNOWN"
+      ]
     }
   },
   "required": [

--- a/ramls/uc.raml
+++ b/ramls/uc.raml
@@ -9,6 +9,16 @@ documentation:
   - title: mod-kb-ebsco-java
     content: Implements the eholdings interface using EBSCO KB as backend.
 
+traits:
+  metricType:
+    queryParameters:
+      metrictype:
+        displayName: Metric Type
+        description: Indicates that metric type should be included
+        type: boolean
+        required: false
+        default: false
+
 types:
   uCSettings: !include types/uc/uCSettings.json
   uCSettingsPostRequest: !include types/uc/uCSettingsPostRequest.json
@@ -22,6 +32,7 @@ types:
       pattern : "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
   get:
     description: Retrieve a Usage Consolidation settings.
+    is: [metricType]
     responses:
       200:
         description: OK
@@ -109,6 +120,7 @@ types:
   displayName: Usage Consolidation settings
   get:
     description: Retrieve a Usage Consolidation settings.
+    is: [metricType]
     responses:
       200:
         description: OK

--- a/src/main/java/org/folio/client/uc/UCApigeeEbscoClient.java
+++ b/src/main/java/org/folio/client/uc/UCApigeeEbscoClient.java
@@ -9,6 +9,7 @@ import org.folio.client.uc.configuration.GetTitlePackageUCConfiguration;
 import org.folio.client.uc.configuration.GetTitleUCConfiguration;
 import org.folio.client.uc.configuration.UCConfiguration;
 import org.folio.client.uc.model.UCCostAnalysis;
+import org.folio.client.uc.model.UCMetricType;
 import org.folio.client.uc.model.UCPackageCostPerUse;
 import org.folio.client.uc.model.UCTitleCostPerUse;
 import org.folio.client.uc.model.UCTitlePackageId;
@@ -24,4 +25,6 @@ public interface UCApigeeEbscoClient {
 
   CompletableFuture<Map<String, UCCostAnalysis>> getTitlePackageCostPerUse(List<UCTitlePackageId> ids,
                                                                            GetTitlePackageUCConfiguration configuration);
+
+  CompletableFuture<UCMetricType> getUsageMetricType(UCConfiguration configuration);
 }

--- a/src/main/java/org/folio/client/uc/UCApigeeEbscoClientImpl.java
+++ b/src/main/java/org/folio/client/uc/UCApigeeEbscoClientImpl.java
@@ -36,6 +36,7 @@ import org.folio.client.uc.configuration.GetTitlePackageUCConfiguration;
 import org.folio.client.uc.configuration.GetTitleUCConfiguration;
 import org.folio.client.uc.configuration.UCConfiguration;
 import org.folio.client.uc.model.UCCostAnalysis;
+import org.folio.client.uc.model.UCMetricType;
 import org.folio.client.uc.model.UCPackageCostPerUse;
 import org.folio.client.uc.model.UCTitleCostPerUse;
 import org.folio.client.uc.model.UCTitlePackageId;
@@ -61,6 +62,7 @@ public class UCApigeeEbscoClientImpl implements UCApigeeEbscoClient {
   private static final String POST_TITLES_URI = "/uc/costperuse/titles";
   private static final String GET_TITLE_URI = "/uc/costperuse/title/%s/%s";
   private static final String GET_PACKAGE_URI = "/uc/costperuse/package/%s";
+  private static final String GET_METRIC_URI = "/uc/usageanalysis/analysismetrictype";
 
   private final String baseUrl;
   private final WebClient webClient;
@@ -119,6 +121,18 @@ public class UCApigeeEbscoClientImpl implements UCApigeeEbscoClient {
     return mapVertxFuture(promise.future())
       .thenApply(HttpResponse::body)
       .thenApply(this::toCostAnalysisMap);
+  }
+
+  @Override
+  public CompletableFuture<UCMetricType> getUsageMetricType(UCConfiguration configuration) {
+    Promise<HttpResponse<JsonObject>> promise = Promise.promise();
+    constructGetRequest(GET_METRIC_URI, configuration)
+      .expect(ResponsePredicate.create(ResponsePredicate.SC_OK, errorConverter()))
+      .as(BodyCodec.jsonObject())
+      .send(promise);
+    return mapVertxFuture(promise.future())
+      .thenApply(HttpResponse::body)
+      .thenApply(jsonObject -> jsonObject.mapTo(UCMetricType.class));
   }
 
   private Map<String, UCCostAnalysis> toCostAnalysisMap(JsonObject jsonObject) {

--- a/src/main/java/org/folio/client/uc/model/UCMetricType.java
+++ b/src/main/java/org/folio/client/uc/model/UCMetricType.java
@@ -1,0 +1,12 @@
+package org.folio.client.uc.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Value;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UCMetricType {
+
+  int metricTypeId;
+  String description;
+}

--- a/src/main/java/org/folio/rest/impl/EholdingsUsageConsolidationImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsUsageConsolidationImpl.java
@@ -42,18 +42,18 @@ public class EholdingsUsageConsolidationImpl implements EholdingsKbCredentialsId
   }
 
   @Override
-  public void getEholdingsUc(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
-                             Context vertxContext) {
-    settingsService.fetchByUser(okapiHeaders)
+  public void getEholdingsUc(boolean metricType, Map<String, String> okapiHeaders,
+                             Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    settingsService.fetchByUser(metricType, okapiHeaders)
       .thenAccept(ucSettings -> asyncResultHandler.handle(succeededFuture(
         GetEholdingsUcResponse.respond200WithApplicationVndApiJson(ucSettings))))
       .exceptionally(errorHandler.handle(asyncResultHandler));
   }
 
   @Override
-  public void getEholdingsKbCredentialsUcById(String credentialsId, Map<String, String> okapiHeaders,
+  public void getEholdingsKbCredentialsUcById(String credentialsId, boolean metricType, Map<String, String> okapiHeaders,
                                               Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    settingsService.fetchByCredentialsId(credentialsId, okapiHeaders)
+    settingsService.fetchByCredentialsId(credentialsId, metricType, okapiHeaders)
       .thenAccept(ucSettings -> asyncResultHandler.handle(succeededFuture(
         GetEholdingsKbCredentialsUcByIdResponse.respond200WithApplicationVndApiJson(ucSettings))))
       .exceptionally(errorHandler.handle(asyncResultHandler));

--- a/src/main/java/org/folio/rmapi/result/UCSettingsResult.java
+++ b/src/main/java/org/folio/rmapi/result/UCSettingsResult.java
@@ -1,0 +1,14 @@
+package org.folio.rmapi.result;
+
+import lombok.Value;
+
+import org.folio.client.uc.model.UCMetricType;
+import org.folio.repository.uc.DbUCSettings;
+
+@Value
+public class UCSettingsResult {
+
+  DbUCSettings settings;
+  UCMetricType metricType;
+
+}

--- a/src/main/java/org/folio/service/uc/UCCostPerUseServiceImpl.java
+++ b/src/main/java/org/folio/service/uc/UCCostPerUseServiceImpl.java
@@ -337,7 +337,7 @@ public class UCCostPerUseServiceImpl implements UCCostPerUseService {
                                                                             MutableObject<PlatformType> platformTypeHolder,
                                                                             Map<String, String> okapiHeaders) {
     return authService.authenticate(okapiHeaders)
-      .thenCombine(settingsService.fetchByUser(okapiHeaders),
+      .thenCombine(settingsService.fetchByUser(false, okapiHeaders),
         toCommonUCConfiguration(platform, fiscalYear, platformTypeHolder)
       );
   }
@@ -347,7 +347,7 @@ public class UCCostPerUseServiceImpl implements UCCostPerUseService {
                                                                             RMAPITemplateContext context) {
     Map<String, String> okapiHeaders = context.getOkapiData().getOkapiHeaders();
     return authService.authenticate(okapiHeaders)
-      .thenCombine(settingsService.fetchByCredentialsId(context.getCredentialsId(), okapiHeaders),
+      .thenCombine(settingsService.fetchByCredentialsId(context.getCredentialsId(), false, okapiHeaders),
         toCommonUCConfiguration(platform, fiscalYear, platformTypeHolder)
       );
   }

--- a/src/main/java/org/folio/service/uc/UCSettingsService.java
+++ b/src/main/java/org/folio/service/uc/UCSettingsService.java
@@ -9,9 +9,10 @@ import org.folio.rest.jaxrs.model.UCSettingsPostRequest;
 
 public interface UCSettingsService {
 
-  CompletableFuture<UCSettings> fetchByUser(Map<String, String> okapiHeaders);
+  CompletableFuture<UCSettings> fetchByUser(boolean includeMetricType, Map<String, String> okapiHeaders);
 
-  CompletableFuture<UCSettings> fetchByCredentialsId(String credentialsId, Map<String, String> okapiHeaders);
+  CompletableFuture<UCSettings> fetchByCredentialsId(String credentialsId, boolean includeMetricType,
+                                                     Map<String, String> okapiHeaders);
 
   CompletableFuture<Void> update(String credentialsId, UCSettingsPatchRequest patchRequest,
                                  Map<String, String> okapiHeaders);

--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -30,6 +30,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.Converter;
@@ -37,7 +38,6 @@ import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.io.ClassPathResource;
 
 import org.folio.cache.VertxCache;
-import org.folio.client.uc.UCApigeeEbscoClient;
 import org.folio.client.uc.UCFailedRequestException;
 import org.folio.client.uc.model.UCCostAnalysis;
 import org.folio.config.ModConfiguration;
@@ -61,15 +61,10 @@ import org.folio.properties.customlabels.CustomLabelsProperties;
 import org.folio.repository.assigneduser.AssignedUserRepository;
 import org.folio.repository.kbcredentials.DbKbCredentials;
 import org.folio.repository.kbcredentials.KbCredentialsRepository;
-import org.folio.repository.uc.DbUCSettings;
-import org.folio.repository.uc.UCSettingsRepository;
 import org.folio.rest.exception.InputValidationException;
 import org.folio.rest.jaxrs.model.CurrencyCollection;
 import org.folio.rest.jaxrs.model.KbCredentials;
 import org.folio.rest.jaxrs.model.KbCredentialsCollection;
-import org.folio.rest.jaxrs.model.ResourceCostPerUseCollectionItem;
-import org.folio.rest.jaxrs.model.UCSettings;
-import org.folio.rest.jaxrs.model.UCSettingsPostRequest;
 import org.folio.rest.util.ErrorHandler;
 import org.folio.rmapi.LocalConfigurationServiceImpl;
 import org.folio.rmapi.cache.PackageCacheKey;
@@ -82,12 +77,7 @@ import org.folio.service.kbcredentials.KbCredentialsService;
 import org.folio.service.kbcredentials.KbCredentialsServiceImpl;
 import org.folio.service.kbcredentials.UserKbCredentialsService;
 import org.folio.service.kbcredentials.UserKbCredentialsServiceImpl;
-import org.folio.service.uc.UCAuthService;
-import org.folio.service.uc.UCSettingsService;
-import org.folio.service.uc.UCSettingsServiceImpl;
 import org.folio.service.uc.UcAuthenticationException;
-import org.folio.service.uc.sorting.UCSortingComparatorProvider;
-import org.folio.service.uc.sorting.UCSortingComparatorProviders;
 
 @Configuration
 @ComponentScan(basePackages = {
@@ -100,6 +90,7 @@ import org.folio.service.uc.sorting.UCSortingComparatorProviders;
   "org.folio.common",
   "org.folio.properties"
 })
+@Import(UCConfig.class)
 public class ApplicationConfig {
 
   @Bean
@@ -305,33 +296,6 @@ public class ApplicationConfig {
       @Value("${kb.ebsco.custom.labels.label.length.max:200}") int labelMaxLength,
       @Value("${kb.ebsco.custom.labels.value.length.max:500}") int valueMaxLength) {
     return new CustomLabelsProperties(labelMaxLength, valueMaxLength);
-  }
-
-  @Bean("securedUCSettingsService")
-  public UCSettingsService securedUCSettingsService(
-    @Qualifier("nonSecuredCredentialsService") KbCredentialsService kbCredentialsService,
-    @Qualifier("securedUCSettingsConverter") Converter<DbUCSettings, UCSettings> fromConverter,
-    @Qualifier("postToUCSettingsConverter") Converter<UCSettingsPostRequest, DbUCSettings> toConverter,
-    UCAuthService authService,
-    UCApigeeEbscoClient ebscoClient,
-    UCSettingsRepository repository) {
-    return new UCSettingsServiceImpl(kbCredentialsService, repository, authService, ebscoClient, fromConverter, toConverter);
-  }
-
-  @Bean("nonSecuredUCSettingsService")
-  public UCSettingsService nonSecuredUCSettingsService(
-    @Qualifier("nonSecuredCredentialsService") KbCredentialsService kbCredentialsService,
-    @Qualifier("nonSecuredUCSettingsConverter") Converter<DbUCSettings, UCSettings> fromConverter,
-    @Qualifier("postToUCSettingsConverter") Converter<UCSettingsPostRequest, DbUCSettings> toConverter,
-    UCAuthService authService,
-    UCApigeeEbscoClient ebscoClient,
-    UCSettingsRepository repository) {
-    return new UCSettingsServiceImpl(kbCredentialsService, repository, authService, ebscoClient, fromConverter, toConverter);
-  }
-
-  @Bean
-  public UCSortingComparatorProvider<ResourceCostPerUseCollectionItem> resourceUCSortingComparatorProvider() {
-    return UCSortingComparatorProviders.forResources();
   }
 
 }

--- a/src/main/java/org/folio/spring/config/UCConfig.java
+++ b/src/main/java/org/folio/spring/config/UCConfig.java
@@ -1,0 +1,74 @@
+package org.folio.spring.config;
+
+import java.util.Map;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+
+import org.folio.client.uc.UCApigeeEbscoClient;
+import org.folio.repository.uc.DbUCSettings;
+import org.folio.repository.uc.UCSettingsRepository;
+import org.folio.rest.converter.uc.UCSettingsConverter;
+import org.folio.rest.jaxrs.model.ResourceCostPerUseCollectionItem;
+import org.folio.rest.jaxrs.model.UCSettings;
+import org.folio.rest.jaxrs.model.UCSettingsDataAttributes;
+import org.folio.rest.jaxrs.model.UCSettingsPostRequest;
+import org.folio.rmapi.result.UCSettingsResult;
+import org.folio.service.kbcredentials.KbCredentialsService;
+import org.folio.service.uc.UCAuthService;
+import org.folio.service.uc.UCSettingsService;
+import org.folio.service.uc.UCSettingsServiceImpl;
+import org.folio.service.uc.sorting.UCSortingComparatorProvider;
+import org.folio.service.uc.sorting.UCSortingComparatorProviders;
+
+@Configuration
+public class UCConfig {
+
+  @Bean
+  public UCSettingsService securedUCSettingsService(KbCredentialsService nonSecuredCredentialsService,
+                                                    UCAuthService authService, UCApigeeEbscoClient ebscoClient,
+                                                    UCSettingsRepository repository,
+                                                    Converter<UCSettingsResult, UCSettings> securedUCSettingsResultConverter,
+                                                    Converter<UCSettingsPostRequest, DbUCSettings> toConverter) {
+    return new UCSettingsServiceImpl(nonSecuredCredentialsService, repository, authService, ebscoClient,
+      securedUCSettingsResultConverter, toConverter);
+  }
+
+  @Bean
+  public UCSettingsService nonSecuredUCSettingsService(KbCredentialsService nonSecuredCredentialsService,
+                                                       UCAuthService authService, UCApigeeEbscoClient ebscoClient,
+                                                       UCSettingsRepository repository,
+                                                       Converter<UCSettingsResult, UCSettings> nonSecuredUCSettingsConverter,
+                                                       Converter<UCSettingsPostRequest, DbUCSettings> toConverter) {
+    return new UCSettingsServiceImpl(nonSecuredCredentialsService, repository, authService, ebscoClient,
+      nonSecuredUCSettingsConverter, toConverter);
+  }
+
+  @Bean
+  public Converter<UCSettingsResult, UCSettings> securedUCSettingsResultConverter(
+    Converter<DbUCSettings, UCSettings> securedUCSettingsConverter,
+    Map<Integer, UCSettingsDataAttributes.MetricType> metricTypeMapper) {
+    return new UCSettingsConverter.UCSettingsResultConverter(securedUCSettingsConverter, metricTypeMapper);
+  }
+
+  @Bean
+  public Converter<UCSettingsResult, UCSettings> nonSecuredUCSettingsConverter(
+    Converter<DbUCSettings, UCSettings> securedUCSettingsConverter,
+    Map<Integer, UCSettingsDataAttributes.MetricType> metricTypeMapper) {
+    return new UCSettingsConverter.UCSettingsResultConverter(securedUCSettingsConverter, metricTypeMapper);
+  }
+
+  @Bean
+  public Map<Integer, UCSettingsDataAttributes.MetricType> metricTypeMapper() {
+    return Map.of(
+      33, UCSettingsDataAttributes.MetricType.TOTAL,
+      36, UCSettingsDataAttributes.MetricType.UNIQUE
+    );
+  }
+
+  @Bean
+  public UCSortingComparatorProvider<ResourceCostPerUseCollectionItem> resourceUCSortingComparatorProvider() {
+    return UCSortingComparatorProviders.forResources();
+  }
+}

--- a/src/test/java/org/folio/util/UCSettingsTestUtil.java
+++ b/src/test/java/org/folio/util/UCSettingsTestUtil.java
@@ -42,6 +42,7 @@ public class UCSettingsTestUtil {
 
   public static final String UC_SETTINGS_ENDPOINT = "eholdings/kb-credentials/%s/uc";
   public static final String UC_SETTINGS_USER_ENDPOINT = "eholdings/uc";
+  public static final String METRIC_TYPE_PARAM_TRUE = "?metrictype=true";
 
   public static final String STUB_CUSTOMER_KEY = "stub-customer-key";
   public static final String STUB_CURRENCY = "USD";


### PR DESCRIPTION
## Purpose
Add usage metric type to UC settings response

## Approach
Add new query parameter `metrictype` to `/uc` and `/<credentialsId>/uc` endpoints. It indicates that metric type should be included or not. It is needed to have the ability to control calling Ebsco endpoint only when usage metric type is needed to UI.
