### PR TITLE
MODKBEKBJ-557 - CostPerUse API - APIGEE returns error "Unresolved variable : customerownerid"

### DIFF
--- a/src/main/java/org/folio/spring/config/UCConfig.java
+++ b/src/main/java/org/folio/spring/config/UCConfig.java
@@ -2,6 +2,7 @@ package org.folio.spring.config;
 
 import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
@@ -39,10 +40,10 @@ public class UCConfig {
   public UCSettingsService nonSecuredUCSettingsService(KbCredentialsService nonSecuredCredentialsService,
                                                        UCAuthService authService, UCApigeeEbscoClient ebscoClient,
                                                        UCSettingsRepository repository,
-                                                       Converter<UCSettingsResult, UCSettings> nonSecuredUCSettingsConverter,
+                                                       Converter<UCSettingsResult, UCSettings> nonSecuredUCSettingsResultConverter,
                                                        Converter<UCSettingsPostRequest, DbUCSettings> toConverter) {
     return new UCSettingsServiceImpl(nonSecuredCredentialsService, repository, authService, ebscoClient,
-      nonSecuredUCSettingsConverter, toConverter);
+      nonSecuredUCSettingsResultConverter, toConverter);
   }
 
   @Bean
@@ -53,10 +54,11 @@ public class UCConfig {
   }
 
   @Bean
-  public Converter<UCSettingsResult, UCSettings> nonSecuredUCSettingsConverter(
-    Converter<DbUCSettings, UCSettings> securedUCSettingsConverter,
+  public Converter<UCSettingsResult, UCSettings> nonSecuredUCSettingsResultConverter(
+    @Qualifier("nonSecuredUCSettingsConverter")
+      Converter<DbUCSettings, UCSettings> nonSecuredUCSettingsConverter,
     Map<Integer, UCSettingsDataAttributes.MetricType> metricTypeMapper) {
-    return new UCSettingsConverter.UCSettingsResultConverter(securedUCSettingsConverter, metricTypeMapper);
+    return new UCSettingsConverter.UCSettingsResultConverter(nonSecuredUCSettingsConverter, metricTypeMapper);
   }
 
   @Bean


### PR DESCRIPTION
## Purpose
Fix for https://issues.folio.org/browse/MODKBEKBJ-557

## Approach
There are two converters that are used inside the mod-kb-ebsco-java module to convert usage consolidation settings -  secured and non-secured. It was a tiny typo in their names, which leads to their misuse.
* fixed usage of converter used for calling APIGEE service