### PR TITLE
MODKBEKBJ-536 - Load holdings by id doesn't load when there are more than one credentials	

### DIFF
--- a/src/main/java/org/folio/service/kbcredentials/UserKbCredentialsServiceImpl.java
+++ b/src/main/java/org/folio/service/kbcredentials/UserKbCredentialsServiceImpl.java
@@ -29,7 +29,8 @@ import org.folio.util.UserInfo;
 
 public class UserKbCredentialsServiceImpl implements UserKbCredentialsService {
 
-  private static final String USER_CREDS_NOT_FOUND_MESSAGE = "User credentials not found: userId = %s";
+  private static final String USER_CREDS_NOT_FOUND_MESSAGE = "KB Credentials do not exist or user with userId = %s " +
+    "is not assigned to any available knowledgebase.";
 
   private final KbCredentialsRepository credentialsRepository;
   private final AssignedUserRepository assignedUserRepository;

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EHoldingsProxyTypesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EHoldingsProxyTypesImplTest.java
@@ -99,7 +99,7 @@ public class EHoldingsProxyTypesImplTest extends WireMockTestBase {
 
     JsonapiError error = getWithStatus(EHOLDINGS_PROXY_TYPES_URL, SC_NOT_FOUND, JANE_TOKEN_HEADER).as(JsonapiError.class);
 
-    assertErrorContainsTitle(error, "User credentials not found: userId = " + JANE_ID);
+    assertErrorContainsTitle(error, "KB Credentials do not exist or user with userId = " + JANE_ID + " is not assigned to any available knowledgebase.");
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EHoldingsRootProxyImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EHoldingsRootProxyImplTest.java
@@ -101,7 +101,7 @@ public class EHoldingsRootProxyImplTest extends WireMockTestBase {
 
     JsonapiError error = getWithStatus(EHOLDINGS_ROOT_PROXY_URL, SC_NOT_FOUND, JANE_TOKEN_HEADER).as(JsonapiError.class);
 
-    assertErrorContainsTitle(error, "User credentials not found: userId = " + JANE_ID);
+    assertErrorContainsTitle(error, "KB Credentials do not exist or user with userId = " + JANE_ID + " is not assigned to any available knowledgebase.");
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsKbCredentialsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsKbCredentialsImplTest.java
@@ -42,6 +42,7 @@ import static org.folio.util.KbCredentialsTestUtil.STUB_TOKEN_HEADER;
 import static org.folio.util.KbCredentialsTestUtil.STUB_TOKEN_OTHER_HEADER;
 import static org.folio.util.KbCredentialsTestUtil.STUB_USERNAME;
 import static org.folio.util.KbCredentialsTestUtil.STUB_USER_ID;
+import static org.folio.util.KbCredentialsTestUtil.STUB_USER_OTHER_ID;
 import static org.folio.util.KbCredentialsTestUtil.USER_KB_CREDENTIAL_ENDPOINT;
 import static org.folio.util.KbCredentialsTestUtil.getKbCredentials;
 import static org.folio.util.KbCredentialsTestUtil.getKbCredentialsNonSecured;
@@ -640,7 +641,7 @@ public class EholdingsKbCredentialsImplTest extends WireMockTestBase {
   public void shouldReturn404OnGetByUserWhenAssignedUserIsMissingAndNoKBCredentialsAtAll() {
     JsonapiError error = getWithStatus(USER_KB_CREDENTIAL_ENDPOINT, SC_NOT_FOUND, STUB_TOKEN_HEADER).as(JsonapiError.class);
 
-    assertErrorContainsTitle(error, "User credentials not found");
+    assertErrorContainsTitle(error, "KB Credentials do not exist ");
   }
 
   @Test
@@ -651,7 +652,7 @@ public class EholdingsKbCredentialsImplTest extends WireMockTestBase {
     JsonapiError error = getWithStatus(USER_KB_CREDENTIAL_ENDPOINT, SC_NOT_FOUND, STUB_TOKEN_OTHER_HEADER).as(
       JsonapiError.class);
 
-    assertErrorContainsTitle(error, "User credentials not found");
+    assertErrorContainsTitle(error, "KB Credentials do not exist or user with userId = " + STUB_USER_OTHER_ID + " is not assigned to any available knowledgebase.");
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/integrationsuite/LoadHoldingsStatusImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/LoadHoldingsStatusImplTest.java
@@ -190,7 +190,7 @@ public class LoadHoldingsStatusImplTest extends WireMockTestBase {
   public void shouldReturn404WhenNoKbCredentialsFound() {
     final String url = String.format(HOLDINGS_LOAD_STATUS_BY_ID_URL, UUID.randomUUID().toString());
     final JsonapiError error = getWithStatus(url, SC_NOT_FOUND, JOHN_TOKEN_HEADER).as(JsonapiError.class);
-    assertThat(error.getErrors().get(0).getTitle(), containsString("not found"));
+    assertThat(error.getErrors().get(0).getTitle(), containsString("not exist"));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
The message "User credentials not found: userId = <id>"should be changed to provide more information about the reason for the error occurred. There are two situations that can happen to see this error:
 * no KB Credentials at all for the system
 * there are several KB Credentials created in the system and the user, who is trying to perform a load of holdings is not assigned any credentials.

For more information see a corresponding story - https://issues.folio.org/browse/MODKBEKBJ-536
## Approach
* changed message to be more informative - "KB Credentials do not exist or user with userId = %s  is not assigned to any available knowledgebase." 
