### PR TITLE
MODKBEKBJ-566 Fix processing include parameter while search titles by access types

### DIFF
--- a/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsTitlesImpl.java
@@ -48,7 +48,6 @@ import org.folio.rest.jaxrs.resource.EholdingsTitles;
 import org.folio.rest.model.filter.Filter;
 import org.folio.rest.util.ErrorUtil;
 import org.folio.rest.util.IdParser;
-import org.folio.rest.util.template.RMAPITemplate;
 import org.folio.rest.util.template.RMAPITemplateContext;
 import org.folio.rest.util.template.RMAPITemplateFactory;
 import org.folio.rest.validator.TitleCommonRequestAttributesValidator;
@@ -110,26 +109,10 @@ public class EholdingsTitlesImpl implements EholdingsTitles {
       .count(count)
       .build();
 
-    boolean includeResource = INCLUDE_RESOURCES_VALUE.equalsIgnoreCase(include);
-    RMAPITemplate template = templateFactory.createTemplate(okapiHeaders, asyncResultHandler);
-    if (filter.isTagsFilter()) {
-      template.requestAction(context ->
-        filteredEntitiesLoader.fetchTitlesByTagFilter(filter.createTagFilter(), context)
-          .thenApply(titles -> toTitleCollectionResult(titles, includeResource))
-      );
-    } else if (filter.isAccessTypeFilter()) {
-      template.requestAction(context -> filteredEntitiesLoader
-        .fetchTitlesByAccessTypeFilter(filter.createAccessTypeFilter(), context)
-      );
-    } else {
-      template
-        .requestAction(context ->
-          context.getTitlesService().retrieveTitles(filter.createFilterQuery(), filter.getSort(), page, count)
-            .thenApply(titles -> toTitleCollectionResult(titles, includeResource)
-            )
-        );
-    }
-    template.executeWithResult(TitleCollection.class);
+    templateFactory.createTemplate(okapiHeaders, asyncResultHandler)
+      .requestAction(context -> fetchTitlesByFilter(filter, context)
+        .thenApply(titles -> toTitleCollectionResult(titles, shouldIncludeResources(include))))
+      .executeWithResult(TitleCollection.class);
   }
 
   @Override
@@ -144,7 +127,7 @@ public class EholdingsTitlesImpl implements EholdingsTitles {
     templateFactory.createTemplate(okapiHeaders, asyncResultHandler)
       .requestAction(context ->
         context.getTitlesService().postTitle(titlePost, packageId)
-          .thenCompose(title -> completedFuture(toTitleResult(false, title)))
+          .thenCompose(title -> completedFuture(toTitleResult(title, false)))
           .thenCompose(titleResult ->
             updateTags(titleResult, context, entity.getData().getAttributes().getTags()))
       )
@@ -156,12 +139,11 @@ public class EholdingsTitlesImpl implements EholdingsTitles {
   public void getEholdingsTitlesByTitleId(String titleId, String include, Map<String, String> okapiHeaders,
                                           Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     long titleIdLong = parseTitleId(titleId);
-    boolean includeResource = INCLUDE_RESOURCES_VALUE.equalsIgnoreCase(include);
 
     templateFactory.createTemplate(okapiHeaders, asyncResultHandler)
       .requestAction(context ->
         context.getTitlesService().retrieveTitle(titleIdLong)
-          .thenCompose(title -> completedFuture(toTitleResult(includeResource, title)))
+          .thenCompose(title -> completedFuture(toTitleResult(title, shouldIncludeResources(include))))
           .thenCompose(result -> loadTags(result, context))
       )
       .addErrorMapper(ResourceNotFoundException.class, exception ->
@@ -194,20 +176,35 @@ public class EholdingsTitlesImpl implements EholdingsTitles {
           })
           .thenCompose(o -> context.getTitlesService().retrieveTitle(parsedTitleId))
           .thenCompose(title ->
-            updateTags(toTitleResult(false, title), context, entity.getData().getAttributes().getTags()))
+            updateTags(toTitleResult(title, false), context, entity.getData().getAttributes().getTags()))
       )
       .executeWithResult(Title.class);
   }
 
+  private CompletableFuture<Titles> fetchTitlesByFilter(Filter filter, RMAPITemplateContext context) {
+    if (filter.isTagsFilter()) {
+      return filteredEntitiesLoader.fetchTitlesByTagFilter(filter.createTagFilter(), context);
+    } else if (filter.isAccessTypeFilter()) {
+      return filteredEntitiesLoader.fetchTitlesByAccessTypeFilter(filter.createAccessTypeFilter(), context);
+    } else {
+      return context.getTitlesService()
+        .retrieveTitles(filter.createFilterQuery(), filter.getSort(), filter.getPage(), filter.getCount());
+    }
+  }
+
   private TitleCollectionResult toTitleCollectionResult(Titles titles, boolean includeResource) {
     return TitleCollectionResult.builder()
-      .titleResults(ListUtils.mapItems(titles.getTitleList(), title -> toTitleResult(includeResource, title)))
+      .titleResults(ListUtils.mapItems(titles.getTitleList(), title -> toTitleResult(title, includeResource)))
       .totalResults(titles.getTotalResults())
       .build();
   }
 
-  private TitleResult toTitleResult(boolean includeResource, org.folio.holdingsiq.model.Title title) {
+  private TitleResult toTitleResult(org.folio.holdingsiq.model.Title title, boolean includeResource) {
     return new TitleResult(title, includeResource);
+  }
+
+  private boolean shouldIncludeResources(String include) {
+    return INCLUDE_RESOURCES_VALUE.equalsIgnoreCase(include);
   }
 
   private CompletableFuture<TitleResult> loadTags(TitleResult result,

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsTitlesTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsTitlesTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -235,6 +236,26 @@ public class EholdingsTitlesTest extends WireMockTestBase {
     assertThat(titles, everyItem(hasProperty("id",
       anyOf(equalTo(STUB_MANAGED_TITLE_ID), equalTo(STUB_MANAGED_TITLE_ID_2))
     )));
+  }
+
+  @Test
+  public void shouldReturnTitlesWithResourcesOnSearchByAccessTypes() throws IOException, URISyntaxException {
+    List<AccessType> accessTypes = insertAccessTypes(testData(configuration.getId()), vertx);
+    insertAccessTypeMapping(STUB_MANAGED_RESOURCE_ID, RESOURCE, accessTypes.get(0).getId(), vertx);
+    insertAccessTypeMapping(STUB_MANAGED_RESOURCE_ID_2, RESOURCE, accessTypes.get(0).getId(), vertx);
+
+    mockGetTitles();
+
+    String resourcePath = EHOLDINGS_TITLES_PATH + "?filter[access-type]=" + STUB_ACCESS_TYPE_NAME + "&include=resources";
+    TitleCollection titleCollection = getWithOk(resourcePath, STUB_TOKEN_HEADER).as(TitleCollection.class);
+    List<TitleCollectionItem> titles = titleCollection.getData();
+
+    assertThat(titles, hasSize(2));
+    assertEquals(2, (int) titleCollection.getMeta().getTotalResults());
+    assertThat(titles, everyItem(hasProperty("id",
+      anyOf(equalTo(STUB_MANAGED_TITLE_ID), equalTo(STUB_MANAGED_TITLE_ID_2))
+    )));
+    assertThat(titles, everyItem(hasProperty("included", not(empty()))));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Add ability to include resources in response while search titles by access types

## Approach
* Return `TitleCollectionResult` when search by access types that has `includeResources` parameter which is processing by `TitleCollectionResultConverter`