### PR TITLE
FOLIO-3045: Replace http by https in http://maven.indexdata.com/

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -651,7 +651,7 @@
     <pluginRepository>
       <id>indexdata</id>
       <name>Index Data</name>
-      <url>http://maven.indexdata.com/</url>
+      <url>https://maven.indexdata.com/</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
A machine-in-the-middle attack can change the download
to contain malware. Using https will prevent this.

Details: https://issues.folio.org/browse/FOLIO-3044