### PR TITLE
MODKBEKBJ-596: Packages, error message when "isCustom" not provided

### DIFF
--- a/src/main/java/org/folio/rest/validator/CustomPackagePutBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/CustomPackagePutBodyValidator.java
@@ -8,8 +8,7 @@ import org.folio.rest.jaxrs.model.PackagePutDataAttributes;
 import org.folio.rest.jaxrs.model.PackagePutRequest;
 
 @Component
-public class CustomPackagePutBodyValidator
-{
+public class CustomPackagePutBodyValidator {
   private static final String INVALID_REQUEST_BODY_TITLE = "Invalid request body";
   private static final String INVALID_REQUEST_BODY_DETAILS = "Json body must contain data.attributes";
 
@@ -25,8 +24,8 @@ public class CustomPackagePutBodyValidator
 
     String beginCoverage = null;
     String endCoverage = null;
-    if(attributes.getCustomCoverage() !=null){
-      beginCoverage =attributes.getCustomCoverage().getBeginCoverage();
+    if (attributes.getCustomCoverage() != null) {
+      beginCoverage = attributes.getCustomCoverage().getBeginCoverage();
       endCoverage = attributes.getCustomCoverage().getEndCoverage();
     }
 

--- a/src/main/java/org/folio/rest/validator/PackagePutBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/PackagePutBodyValidator.java
@@ -11,6 +11,8 @@ public class PackagePutBodyValidator {
 
   private static final String INVALID_REQUEST_BODY_TITLE = "Invalid request body";
   private static final String INVALID_REQUEST_BODY_DETAILS = "Json body must contain data.attributes";
+  private static final String PACKAGE_NOT_UPDATABLE_TITLE = "Package is not updatable";
+  private static final String PACKAGE_NOT_UPDATABLE_DETAILS = "Non-custom packages must be selected";
   private static final int MAX_TOKEN_LENGTH = 500;
 
   public void validate(PackagePutRequest request) {
@@ -21,9 +23,7 @@ public class PackagePutBodyValidator {
     }
     PackagePutDataAttributes attributes = request.getData().getAttributes();
     Boolean isSelected = attributes.getIsSelected();
-    Boolean allowKbToAddTitles = attributes.getAllowKbToAddTitles();
 
-    Boolean isHidden = attributes.getVisibilityData() != null ? attributes.getVisibilityData().getIsHidden() : null;
     String beginCoverage = null;
     String endCoverage = null;
     if (attributes.getCustomCoverage() != null) {
@@ -34,11 +34,7 @@ public class PackagePutBodyValidator {
     String value = attributes.getPackageToken() != null ? attributes.getPackageToken().getValue() : null;
 
     if (isSelected == null || !isSelected) {
-      ValidatorUtil.checkFalseOrNull("allowKbToAddTitles", allowKbToAddTitles);
-      ValidatorUtil.checkFalseOrNull("visibilityData.isHidden", isHidden);
-      ValidatorUtil.checkIsEmpty("customCoverage.beginCoverage", beginCoverage);
-      ValidatorUtil.checkIsEmpty("customCoverage.endCoverage", endCoverage);
-      ValidatorUtil.checkIsNull("packageToken.value", value);
+      throw new InputValidationException(PACKAGE_NOT_UPDATABLE_TITLE, PACKAGE_NOT_UPDATABLE_DETAILS);
     }
     ValidatorUtil.checkMaxLength("value", value, MAX_TOKEN_LENGTH);
     ValidatorUtil.checkDateValid("beginCoverage", beginCoverage);

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsPackagesTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsPackagesTest.java
@@ -896,6 +896,7 @@ public class EholdingsPackagesTest extends WireMockTestBase {
   @Test
   public void shouldReturn400OnPutPackageWithNotExistedAccessType() throws URISyntaxException, IOException {
     String requestBody = readFile("requests/kb-ebsco/package/put-package-with-not-existed-access-type.json");
+    mockGet(new RegexPattern(PACKAGE_BY_ID_URL), CUSTOM_PACKAGE_STUB_FILE);
 
     JsonapiError error = putWithStatus(PACKAGES_PATH, requestBody, SC_BAD_REQUEST, CONTENT_TYPE_HEADER, STUB_TOKEN_HEADER)
       .as(JsonapiError.class);
@@ -968,6 +969,7 @@ public class EholdingsPackagesTest extends WireMockTestBase {
   @Test
   public void shouldReturn400OnPostPackageWithNotExistedAccessType() throws URISyntaxException, IOException {
     String requestBody = readFile("requests/kb-ebsco/package/post-package-with-not-existed-access-type-request.json");
+    mockUpdateScenario(readFile(CUSTOM_PACKAGE_STUB_FILE));
 
     JsonapiError error = postWithStatus(PACKAGES_ENDPOINT, requestBody, SC_BAD_REQUEST, CONTENT_TYPE_HEADER,
       STUB_TOKEN_HEADER).as(JsonapiError.class);

--- a/src/test/java/org/folio/rest/validator/PackagePutBodyValidatorTest.java
+++ b/src/test/java/org/folio/rest/validator/PackagePutBodyValidatorTest.java
@@ -34,17 +34,6 @@ public class PackagePutBodyValidatorTest {
   }
 
   @Test
-  public void shouldThrowExceptionWhenPackageIsNotSelectedAndIsHiddenIsTrue() {
-    expectedEx.expect(InputValidationException.class);
-    expectedEx.expectMessage(containsString("isHidden"));
-    validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackagePutDataAttributes()
-      .withIsSelected(false)
-      .withVisibilityData(new VisibilityData()
-        .withIsHidden(true))));
-  }
-
-  @Test
   public void shouldThrowExceptionWhenPackageIsNotSelectedAndCoverageIsNotEmpty() {
     expectedEx.expect(InputValidationException.class);
     expectedEx.expectMessage(containsString("beginCoverage"));
@@ -56,16 +45,6 @@ public class PackagePutBodyValidatorTest {
   }
 
   @Test
-  public void shouldThrowExceptionWhenPackageIsNotSelectedAndAllowToAddTitlesTrue() {
-    expectedEx.expect(InputValidationException.class);
-    expectedEx.expectMessage(containsString("allowKbToAddTitles"));
-    validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackagePutDataAttributes()
-        .withIsSelected(false)
-        .withAllowKbToAddTitles(true)));
-  }
-
-  @Test
   public void shouldThrowExceptionWhenPackageIsNotSelectedAndTokenIsNotEmpty() {
     expectedEx.expect(InputValidationException.class);
     expectedEx.expectMessage(containsString("value"));
@@ -73,27 +52,6 @@ public class PackagePutBodyValidatorTest {
       new PackagePutDataAttributes()
         .withIsSelected(false)
         .withPackageToken(new Token().withValue("tokenValue"))));
-  }
-
-  @Test
-  public void shouldThrowExceptionWhenPackageIsSelectedAndTokenIsTooLong() {
-    expectedEx.expect(InputValidationException.class);
-    expectedEx.expectMessage(containsString("value"));
-    validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackagePutDataAttributes()
-        .withIsSelected(true)
-        .withPackageToken(new Token().withValue(StringUtils.repeat("tokenvalue",200)))));
-  }
-
-  @Test
-  public void shouldThrowExceptionWhenPackageIsSelectedAndCoverageDateIsInvalid() {
-    expectedEx.expect(InputValidationException.class);
-    expectedEx.expectMessage(containsString("beginCoverage"));
-    validator.validate(PackagesTestData.getPackagePutRequest(
-      new PackagePutDataAttributes()
-        .withIsSelected(true)
-        .withCustomCoverage(new Coverage()
-          .withBeginCoverage("abcd-ab-ab"))));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Endpoint PUT eholding/packages/{id}
If "isCustom" field is missing, server responds with error message like
"Attribute PackageName is missing."

The error message is not valid and entity doesn't even have an attribute "packageName".
So we need to improve error message.

## Approach
- If package "isCustom" not matched with origin package. Than you can see message like this
![image](https://user-images.githubusercontent.com/88006020/136163000-db25432c-9744-4cc3-9b76-d60a83260a9d.png)

## Learning
[MODKBEKBJ-596](https://issues.folio.org/browse/MODKBEKBJ-596)
