### PR TITLE
MODKBEKBJ-600: Providers, deny updating tags with empty name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
+## v3.10.0 xxxx-xx-xx
+* MODKBEKBJ-600 Providers, deny updating tags with empty name
+
 ## v3.9.0 2021-10-07
 * MODKBEKBJ-596 Packages, error message when "isCustom" not provided
 * MODKBEKBJ-597 Packages, deny creating package with empty name
-* MODKBEKBJ-600 Providers, deny updating tags with empty name
 
 ## v3.8.0 2021-06-10
 * MODKBEKBJ-570 Filter resources in title

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## v3.9.0 2021-10-07
 * MODKBEKBJ-596 Packages, error message when "isCustom" not provided
 * MODKBEKBJ-597 Packages, deny creating package with empty name
+* MODKBEKBJ-600 Providers, deny updating tags with empty name
 
 ## v3.8.0 2021-06-10
 * MODKBEKBJ-570 Filter resources in title

--- a/src/main/java/org/folio/rest/validator/ProviderTagsPutBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/ProviderTagsPutBodyValidator.java
@@ -3,6 +3,7 @@ package org.folio.rest.validator;
 import org.folio.rest.exception.InputValidationException;
 import org.folio.rest.jaxrs.model.ProviderTagsDataAttributes;
 import org.folio.rest.jaxrs.model.ProviderTagsPutRequest;
+
 import org.springframework.stereotype.Component;
 
 @Component
@@ -18,7 +19,7 @@ public class ProviderTagsPutBodyValidator {
       throw new InputValidationException(INVALID_REQUEST_BODY_TITLE, INVALID_REQUEST_BODY_DETAILS);
     }
 
-    ValidatorUtil.checkIsNotEmpty("name", attributes.getName());
+    ValidatorUtil.checkIsNotBlank("name", attributes.getName());
     ValidatorUtil.checkMaxLength("name", attributes.getName(), 200);
     ValidatorUtil.checkIsNotNull("tags", attributes.getTags());
   }


### PR DESCRIPTION
## Purpose
We should deny updating tags with empty name like "  "

## Approach
Set isNotBlank instead isNotEmpty

## Learning
[MODKBEKBJ-600](https://issues.folio.org/browse/MODKBEKBJ-600)
[Differences between blank end empty](https://stackoverflow.com/questions/23419087/stringutils-isblank-vs-string-isempty)