### PR TITLE
MODKBEKBJ-598: Packages, clarify error message when unselect non-custom package

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## v3.9.0 2021-10-07
 * MODKBEKBJ-596 Packages, error message when "isCustom" not provided
 * MODKBEKBJ-597 Packages, deny creating package with empty name
+* MODKBEKBJ-598 Packages, clarify error message when unselect non-custom package 
 
 ## v3.8.0 2021-06-10
 * MODKBEKBJ-570 Filter resources in title

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
+## v3.10.0 xxxx-xx-xx
+* MODKBEKBJ-598 Packages, clarify error message when unselect non-custom package
+
 ## v3.9.0 2021-10-07
 * MODKBEKBJ-596 Packages, error message when "isCustom" not provided
 * MODKBEKBJ-597 Packages, deny creating package with empty name
-* MODKBEKBJ-598 Packages, clarify error message when unselect non-custom package 
 
 ## v3.8.0 2021-06-10
 * MODKBEKBJ-570 Filter resources in title

--- a/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsPackagesImpl.java
@@ -60,7 +60,6 @@ import org.folio.rest.jaxrs.model.PackageBulkFetchCollection;
 import org.folio.rest.jaxrs.model.PackageCollection;
 import org.folio.rest.jaxrs.model.PackagePostBulkFetchRequest;
 import org.folio.rest.jaxrs.model.PackagePostRequest;
-import org.folio.rest.jaxrs.model.PackagePutDataAttributes;
 import org.folio.rest.jaxrs.model.PackagePutRequest;
 import org.folio.rest.jaxrs.model.PackageTags;
 import org.folio.rest.jaxrs.model.PackageTagsDataAttributes;
@@ -95,8 +94,6 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
 
   private static final String INVALID_PACKAGE_TITLE = "Package cannot be deleted";
   private static final String INVALID_PACKAGE_DETAILS = "Invalid package";
-  private static final String PACKAGE_NOT_UPDATABLE_TITLE = "Package is not updatable";
-  private static final String PACKAGE_NOT_UPDATABLE_DETAILS = "Package's 'isCustom' and 'isSelected' are 'false'";
   private static final String PACKAGE_IS_CUSTOM_NOT_MATCHED = "Package isCustom not matched";
   private static final String PACKAGE_IS_CUSTOM_NOT_MATCHED_DETAILS = "Package isCustom: %s";
 
@@ -239,27 +236,23 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
   public void putEholdingsPackagesByPackageId(String packageId, String contentType, PackagePutRequest entity,
                                               Map<String, String> okapiHeaders,
                                               Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    if (!isPackageUpdatable(entity)) {
-      throw new InputValidationException(PACKAGE_NOT_UPDATABLE_TITLE, PACKAGE_NOT_UPDATABLE_DETAILS);
-    } else {
-      PackageId parsedPackageId = parsePackageId(packageId);
-      templateFactory.createTemplate(okapiHeaders, asyncResultHandler)
-        .requestAction(context -> context.getPackagesService().retrievePackage(parsedPackageId)
-          .thenCompose(packageByIdData -> fetchAccessType(entity, context)
-            .thenCompose(accessType -> processUpdateRequest(entity, packageByIdData, context)
-              .thenCompose(voidEntity -> {
-                CompletableFuture<PackageByIdData> future = context.getPackagesService().retrievePackage(parsedPackageId);
-                return handleDeletedPackage(future, parsedPackageId, context);
-              })
-              .thenApply(packageById -> new PackageResult(packageById, null, null))
-              .thenCompose(packageResult -> updateAccessTypeMapping(accessType, packageResult, context))
-            )
+    PackageId parsedPackageId = parsePackageId(packageId);
+    templateFactory.createTemplate(okapiHeaders, asyncResultHandler)
+      .requestAction(context -> context.getPackagesService().retrievePackage(parsedPackageId)
+        .thenCompose(packageByIdData -> fetchAccessType(entity, context)
+          .thenCompose(accessType -> processUpdateRequest(entity, packageByIdData, context)
+            .thenCompose(voidEntity -> {
+              CompletableFuture<PackageByIdData> future = context.getPackagesService().retrievePackage(parsedPackageId);
+              return handleDeletedPackage(future, parsedPackageId, context);
+            })
+            .thenApply(packageById -> new PackageResult(packageById, null, null))
+            .thenCompose(packageResult -> updateAccessTypeMapping(accessType, packageResult, context))
           )
         )
-        .addErrorMapper(NotFoundException.class, error400NotFoundMapper())
-        .addErrorMapper(InputValidationException.class, error422InputValidationMapper())
-        .executeWithResult(Package.class);
-    }
+      )
+      .addErrorMapper(NotFoundException.class, error400NotFoundMapper())
+      .addErrorMapper(InputValidationException.class, error422InputValidationMapper())
+      .executeWithResult(Package.class);
   }
 
   @Override
@@ -510,19 +503,6 @@ public class EholdingsPackagesImpl implements EholdingsPackages {
       packagePutBody = converter.convertToRMAPIPackagePutRequest(entity);
     }
     return context.getPackagesService().updatePackage(parsePackageId(originalPackage.getFullPackageId()), packagePutBody);
-  }
-
-  private boolean isPackageUpdatable(PackagePutRequest entity) {
-    PackagePutDataAttributes packageData = entity.getData().getAttributes();
-    if (BooleanUtils.isFalse(packageData.getIsCustom()) &&
-      BooleanUtils.isFalse(packageData.getIsSelected())) {
-      try {
-        packagePutBodyValidator.validate(entity);
-      } catch (InputValidationException ex) {
-        return false;
-      }
-    }
-    return true;
   }
 
   private void validateIsCustomMatch(Boolean isOriginalCustom, Boolean isUpdatableCustom) {

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsPackagesTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsPackagesTest.java
@@ -670,7 +670,7 @@ public class EholdingsPackagesTest extends WireMockTestBase {
   }
 
   @Test
-  public void shouldReturn422OnPutWhenPackageIsNotUpdatable() throws URISyntaxException, IOException {
+  public void shouldReturn422OnPutWhenUnselectNonCustomPackageIsHidden() throws URISyntaxException, IOException {
     String putBody = readFile("requests/kb-ebsco/package/put-package-not-selected-non-empty-fields.json");
     mockGet(new RegexPattern(PACKAGE_BY_ID_URL), PACKAGE_STUB_FILE);
     JsonapiError error = putWithStatus(PACKAGES_PATH, putBody, SC_UNPROCESSABLE_ENTITY, CONTENT_TYPE_HEADER,
@@ -678,7 +678,7 @@ public class EholdingsPackagesTest extends WireMockTestBase {
 
     verify(0, putRequestedFor(PACKAGE_URL_PATTERN));
 
-    assertErrorContainsTitle(error, "Package is not updatable");
+    assertErrorContainsTitle(error, "Invalid visibilityData.isHidden");
   }
 
   @Test

--- a/src/test/resources/requests/kb-ebsco/package/put-package-not-selected-non-empty-fields.json
+++ b/src/test/resources/requests/kb-ebsco/package/put-package-not-selected-non-empty-fields.json
@@ -8,7 +8,7 @@
       },
       "isSelected": false,
       "isCustom":false,
-      "allowKbToAddTitles": true,
+      "allowKbToAddTitles": false,
       "visibilityData": {
         "isHidden": true,
         "reason": ""


### PR DESCRIPTION
## Purpose
When isCustom and isSelected are false, we need to met this five conditions:
```
allowKbToAddTitles should be false,
visibilityData.isHidden should be false,
customCoverage should be empty,
packageToken.value should be null.
```
And when one of this conditions not met, server respond with message like: "Package's 'isCustom' and 'isSelected' are 'false'".
the error message is very strict, we need to remove it and display the parameter that prevents the update


## Approach
Remove pointless message and display real condition that fall

## Learning
[MODKBEKBJ-598](https://issues.folio.org/browse/MODKBEKBJ-598)
