### PR TITLE
MODKBEKBJ-601: User-assigment, deny assign user with empty name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## v3.10.0 xxxx-xx-xx
 * MODKBEKBJ-600 Providers, deny updating tags with empty name
+* MODKBEKBJ-601 User-assigment, deny assign user with empty name
 
 ## v3.9.0 2021-10-07
 * MODKBEKBJ-596 Packages, error message when "isCustom" not provided

--- a/src/main/java/org/folio/rest/impl/EholdingsAssignedUsersImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsAssignedUsersImpl.java
@@ -18,11 +18,14 @@ import org.folio.rest.jaxrs.model.AssignedUserPostRequest;
 import org.folio.rest.jaxrs.model.AssignedUserPutRequest;
 import org.folio.rest.jaxrs.resource.EholdingsKbCredentialsIdUsers;
 import org.folio.rest.util.ErrorHandler;
+import org.folio.rest.validator.AssignedUsersBodyValidator;
 import org.folio.service.assignedusers.AssignedUsersService;
 import org.folio.spring.SpringContextUtil;
 
 public class EholdingsAssignedUsersImpl implements EholdingsKbCredentialsIdUsers {
 
+  @Autowired
+  private AssignedUsersBodyValidator assignedUsersBodyValidator;
   @Autowired
   private AssignedUsersService assignedUsersService;
   @Autowired
@@ -49,6 +52,7 @@ public class EholdingsAssignedUsersImpl implements EholdingsKbCredentialsIdUsers
   public void postEholdingsKbCredentialsUsersById(String credentialsId, String contentType, AssignedUserPostRequest entity,
                                                   Map<String, String> okapiHeaders,
                                                   Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    assignedUsersBodyValidator.validate(entity.getData());
     assignedUsersService.save(entity, okapiHeaders)
       .thenAccept(assignedUser -> asyncResultHandler.handle(succeededFuture(
         PostEholdingsKbCredentialsUsersByIdResponse.respond201WithApplicationVndApiJson(assignedUser))))
@@ -62,6 +66,7 @@ public class EholdingsAssignedUsersImpl implements EholdingsKbCredentialsIdUsers
                                                           Map<String, String> okapiHeaders,
                                                           Handler<AsyncResult<Response>> asyncResultHandler,
                                                           Context vertxContext) {
+    assignedUsersBodyValidator.validate(entity.getData());
     assignedUsersService.update(credentialsId, userId, entity, okapiHeaders)
       .thenAccept(o -> asyncResultHandler.handle(succeededFuture(
         PutEholdingsKbCredentialsUsersByIdAndUserIdResponse.respond204())))

--- a/src/main/java/org/folio/rest/validator/AssignedUsersBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/AssignedUsersBodyValidator.java
@@ -1,0 +1,44 @@
+package org.folio.rest.validator;
+
+import java.util.Objects;
+import javax.validation.ValidationException;
+
+import org.springframework.stereotype.Component;
+
+import org.folio.rest.exception.InputValidationException;
+import org.folio.rest.jaxrs.model.AssignedUser;
+import org.folio.rest.jaxrs.model.AssignedUserDataAttributes;
+
+@Component
+public class AssignedUsersBodyValidator {
+
+  private static final String INVALID_POST_BODY = "Invalid request body";
+
+  /**
+   * Provides validation for the data attributes
+   *
+   * @throws ValidationException if validation fails
+   */
+  public void validate(AssignedUser data) {
+
+    if (Objects.isNull(data) || Objects.isNull(data.getAttributes())) {
+      throw new InputValidationException(INVALID_POST_BODY, "");
+    }
+
+    AssignedUserDataAttributes attributes = data.getAttributes();
+
+    ValidatorUtil.checkIsNotBlank("userName", attributes.getUserName());
+    ValidatorUtil.checkMaxLength("userName", attributes.getUserName(), 200);
+
+    ValidatorUtil.checkIsNotBlank("lastName", attributes.getLastName());
+    ValidatorUtil.checkMaxLength("lastName", attributes.getLastName(), 200);
+
+    ValidatorUtil.checkIsNotBlank("patronGroup", attributes.getPatronGroup());
+    ValidatorUtil.checkMaxLength("patronGroup", attributes.getPatronGroup(), 200);
+
+    if (!Objects.isNull(attributes.getFirstName())) {
+      ValidatorUtil.checkIsNotBlank("firstName", attributes.getFirstName());
+      ValidatorUtil.checkMaxLength("firstName", attributes.getFirstName(), 200);
+    }
+  }
+}

--- a/src/test/java/org/folio/rest/validator/AssignedUsersBodyValidatorTest.java
+++ b/src/test/java/org/folio/rest/validator/AssignedUsersBodyValidatorTest.java
@@ -1,0 +1,74 @@
+package org.folio.rest.validator;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.folio.rest.exception.InputValidationException;
+import org.folio.rest.jaxrs.model.AssignedUser;
+import org.folio.rest.jaxrs.model.AssignedUserDataAttributes;
+import org.folio.rest.jaxrs.model.AssignedUserPostRequest;
+
+public class AssignedUsersBodyValidatorTest {
+
+  private static final int MAX_CHARACTERS = 200;
+  private final AssignedUsersBodyValidator validator = new AssignedUsersBodyValidator();
+
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  @Test(expected = InputValidationException.class)
+  public void shouldThrowExceptionWhenNoData() {
+    AssignedUserPostRequest request = new AssignedUserPostRequest().withData(null);
+    validator.validate(request.getData());
+  }
+
+  @Test(expected = InputValidationException.class)
+  public void shouldThrowExceptionWhenUserNameIsEmpty() {
+    AssignedUser data = new AssignedUser().withAttributes(
+      new AssignedUserDataAttributes()
+        .withUserName(""));
+    validator.validate(data);
+  }
+
+  @Test(expected = InputValidationException.class)
+  public void shouldThrowExceptionWhenLastNameIsBlank() {
+    AssignedUser data = new AssignedUser().withAttributes(
+      new AssignedUserDataAttributes()
+        .withUserName("userName")
+        .withLastName(" "));
+    validator.validate(data);
+  }
+
+  @Test(expected = InputValidationException.class)
+  public void shouldThrowExceptionWhenFirstNameIsTooLong() {
+    AssignedUser data = new AssignedUser().withAttributes(
+      new AssignedUserDataAttributes()
+        .withUserName("userName")
+        .withFirstName("n".repeat(MAX_CHARACTERS + 1))
+        .withLastName("lastName")
+        .withPatronGroup("patronGroup"));
+    validator.validate(data);
+  }
+
+  @Test(expected = InputValidationException.class)
+  public void shouldThrowExceptionWhenPatronGroupIsEmpty() {
+    AssignedUser data = new AssignedUser().withAttributes(
+      new AssignedUserDataAttributes()
+        .withUserName("userName")
+        .withLastName("lastName")
+        .withPatronGroup(""));
+    validator.validate(data);
+  }
+
+  @Test
+  public void shouldNotThrowExceptionWhenFirstNameIsNull() {
+    AssignedUser data = new AssignedUser().withAttributes(
+      new AssignedUserDataAttributes()
+        .withUserName("userName")
+        .withFirstName(null)
+        .withLastName("lastName")
+        .withPatronGroup("patronGroup"));
+    validator.validate(data);
+  }
+}


### PR DESCRIPTION
## Purpose
We should deny assign with empty name like "  "

## Approach
- Added body validator for user-assigment
- Wrote tests

## Learning
[MODKBEKBJ-601](https://issues.folio.org/browse/MODKBEKBJ-601)

