### PR TITLE
MODKBEKBJ-602 Validators: Use isBlank instead isEmpty

### DIFF
--- a/src/main/java/org/folio/rest/validator/AccessTypesBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/AccessTypesBodyValidator.java
@@ -31,7 +31,7 @@ public class AccessTypesBodyValidator {
       throw new InputValidationException(INVALID_REQUEST_BODY_TITLE, INVALID_REQUEST_BODY_DETAILS);
     }
     AccessTypeDataAttributes attributes = request.getAttributes();
-    ValidatorUtil.checkIsNotEmpty("name", attributes.getName());
+    ValidatorUtil.checkIsNotBlank("name", attributes.getName());
     ValidatorUtil.checkMaxLength("name", attributes.getName(), maxNameLength);
 
     if (attributes.getDescription() != null) {

--- a/src/main/java/org/folio/rest/validator/CustomPackagePutBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/CustomPackagePutBodyValidator.java
@@ -29,7 +29,7 @@ public class CustomPackagePutBodyValidator {
       endCoverage = attributes.getCustomCoverage().getEndCoverage();
     }
 
-    ValidatorUtil.checkIsNotEmpty("name", name);
+    ValidatorUtil.checkIsNotBlank("name", name);
     ValidatorUtil.checkMaxLength("name", name, 200);
     ValidatorUtil.checkIsNotNull("contentType", contentType);
     ValidatorUtil.checkDateValid("beginCoverage", beginCoverage);

--- a/src/main/java/org/folio/rest/validator/PackageTagsPutBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/PackageTagsPutBodyValidator.java
@@ -19,7 +19,7 @@ public class PackageTagsPutBodyValidator {
     }
     PackageTagsDataAttributes attributes = request.getData().getAttributes();
 
-    ValidatorUtil.checkIsNotEmpty("name", attributes.getName());
+    ValidatorUtil.checkIsNotBlank("name", attributes.getName());
     ValidatorUtil.checkMaxLength("name", attributes.getName(), 200);
     ValidatorUtil.checkIsNotNull("contentType", attributes.getContentType());
     ValidatorUtil.checkIsNotNull("tags", attributes.getTags());

--- a/src/main/java/org/folio/rest/validator/ResourcePostValidator.java
+++ b/src/main/java/org/folio/rest/validator/ResourcePostValidator.java
@@ -17,11 +17,11 @@ public class ResourcePostValidator {
   public void validate(ResourcePostRequest request) {
     ResourcePostDataAttributes attributes = request.getData().getAttributes();
     String url = attributes.getUrl();
-    if (StringUtils.isNotEmpty(url)) {
+    if (StringUtils.isNotBlank(url)) {
       ValidatorUtil.checkUrlFormat("Url", attributes.getUrl());
     }
-    ValidatorUtil.checkIsNotEmpty("Package Id", attributes.getPackageId());
-    ValidatorUtil.checkIsNotEmpty("Title Id", attributes.getTitleId());
+    ValidatorUtil.checkIsNotBlank("Package Id", attributes.getPackageId());
+    ValidatorUtil.checkIsNotBlank("Title Id", attributes.getTitleId());
   }
 
   public void validateRelatedObjects(PackageByIdData packageData, Title title, Titles existingTitles) {

--- a/src/main/java/org/folio/rest/validator/ResourceTagsPutBodyValidator.java
+++ b/src/main/java/org/folio/rest/validator/ResourceTagsPutBodyValidator.java
@@ -19,7 +19,7 @@ public class ResourceTagsPutBodyValidator {
       throw new InputValidationException(INVALID_REQUEST_BODY_TITLE, INVALID_REQUEST_BODY_DETAILS);
     }
 
-    ValidatorUtil.checkIsNotEmpty("name", attributes.getName());
+    ValidatorUtil.checkIsNotBlank("name", attributes.getName());
     ValidatorUtil.checkMaxLength("name", attributes.getName(), 200);
     ValidatorUtil.checkIsNotNull("tags", attributes.getTags());
   }

--- a/src/main/java/org/folio/rest/validator/TitleCommonRequestAttributesValidator.java
+++ b/src/main/java/org/folio/rest/validator/TitleCommonRequestAttributesValidator.java
@@ -23,7 +23,7 @@ public class TitleCommonRequestAttributesValidator {
    */
   public void validate(TitleCommonRequestAttributes attributes) {
     ValidatorUtil.checkIsNotNull(TITLE_NAME, attributes.getName());
-    ValidatorUtil.checkIsNotEmpty(TITLE_NAME, attributes.getName());
+    ValidatorUtil.checkIsNotBlank(TITLE_NAME, attributes.getName());
     ValidatorUtil.checkMaxLength(TITLE_NAME, attributes.getName(), 400);
 
     ValidatorUtil.checkMaxLength("Publisher name", attributes.getPublisherName(), 250);


### PR DESCRIPTION
## Purpose
We can create/update items (packages/resources/tags) with blank name like this " "
But it is forbidden to create empty names like this ""

My suggestion for validation is to use "isBlank()" instead "isEmpty()'

## Approach
Set isNotBlank instead isNotEmpty

## Learning
[MODKBEKBJ-602](https://issues.folio.org/browse/MODKBEKBJ-602)
[Differences between blank end empty](https://stackoverflow.com/questions/23419087/stringutils-isblank-vs-string-isempty)