### PR TITLE
MODKBEKBJ-604 Return managed embargo in /costperuse endpoint

### DIFF
--- a/src/main/java/org/folio/rest/converter/costperuse/TitleCostPerUseConverter.java
+++ b/src/main/java/org/folio/rest/converter/costperuse/TitleCostPerUseConverter.java
@@ -128,9 +128,7 @@ public class TitleCostPerUseConverter implements Converter<TitleCostPerUseResult
 
   private EmbargoPeriod defineEmbargoType(org.folio.holdingsiq.model.CustomerResources customerResource) {
     var customEmbargoPeriod = customerResource.getCustomEmbargoPeriod();
-    if (customEmbargoPeriod != null
-        && customEmbargoPeriod.getEmbargoUnit() != null
-        && customEmbargoPeriod.getEmbargoValue() > 0) {
+    if (customEmbargoPeriod != null && customEmbargoPeriod.getEmbargoUnit() != null) {
       return customEmbargoPeriod;
     } else {
       return customerResource.getManagedEmbargoPeriod();

--- a/src/main/java/org/folio/rest/converter/costperuse/TitleCostPerUseConverter.java
+++ b/src/main/java/org/folio/rest/converter/costperuse/TitleCostPerUseConverter.java
@@ -60,14 +60,14 @@ public class TitleCostPerUseConverter implements Converter<TitleCostPerUseResult
       case PUBLISHER:
         setPublisherUsage(specificPlatformUsages, usage);
         PlatformUsage publisherPlatformUsage = usage.getTotals().getPublisher();
-        if (publisherPlatformUsage!= null) {
+        if (publisherPlatformUsage != null) {
           totalUsage = publisherPlatformUsage.getTotal();
         }
         break;
       case NON_PUBLISHER:
         setNonPublisherUsage(specificPlatformUsages, usage);
         PlatformUsage nonPublisherPlatformUsage = usage.getTotals().getNonPublisher();
-        if (nonPublisherPlatformUsage!= null) {
+        if (nonPublisherPlatformUsage != null) {
           totalUsage = nonPublisherPlatformUsage.getTotal();
         }
         break;
@@ -108,8 +108,7 @@ public class TitleCostPerUseConverter implements Converter<TitleCostPerUseResult
     var titlePackageId = titleId + "." + packageId;
     var ucCostAnalysis = titlePackageCostMap.get(titlePackageId).getCurrent();
 
-    var embargoPeriod =
-      defaultIfNull(customerResource.getCustomEmbargoPeriod(), customerResource.getManagedEmbargoPeriod());
+    var embargoPeriod = defineEmbargoType(customerResource);
 
     var customCoverageList = emptyIfNull(customerResource.getCustomCoverageList());
     var managedCoverageList = emptyIfNull(customerResource.getManagedCoverageList());
@@ -125,5 +124,16 @@ public class TitleCostPerUseConverter implements Converter<TitleCostPerUseResult
       .withCoverageStatement(customerResource.getCoverageStatement())
       .withEmbargoPeriod(embargoPeriodConverter.convert(embargoPeriod))
       .withCoverages(coveragesConverter.convert(coverageDates));
+  }
+
+  private EmbargoPeriod defineEmbargoType(org.folio.holdingsiq.model.CustomerResources customerResource) {
+    var customEmbargoPeriod = customerResource.getCustomEmbargoPeriod();
+    if (customEmbargoPeriod != null
+        && customEmbargoPeriod.getEmbargoUnit() != null
+        && customEmbargoPeriod.getEmbargoValue() > 0) {
+      return customEmbargoPeriod;
+    } else {
+      return customerResource.getManagedEmbargoPeriod();
+    }
   }
 }

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsCostperuseImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsCostperuseImplTest.java
@@ -191,6 +191,29 @@ public class EholdingsCostperuseImplTest extends WireMockTestBase {
     assertEquals(expected, actual);
   }
 
+  @Test
+  public void shouldReturnTitleCostPerUseWithManagedEmbargoPeriod() {
+    int titleId = 1111111111;
+    int packageId = 222222;
+    String year = "2019";
+    String platform = "nonPublisher";
+    String stubRmapiResponseFile = "responses/rmapi/titles/get-custom-title-with-managed-embargo.json";
+
+    mockRmApiGetTitle(titleId, stubRmapiResponseFile);
+    String stubApigeeGetTitleResponseFile = "responses/uc/titles/get-empty-title-cost-per-use-response.json";
+    String stubApigeeGetTitlePackageResponseFile =
+      "responses/uc/title-packages/get-title-packages-cost-per-use-response.json";
+    mockSuccessfulTitleCostPerUse(titleId, packageId, stubApigeeGetTitleResponseFile);
+    mockSuccessfulTitlePackageCostPerUse(stubApigeeGetTitlePackageResponseFile);
+
+    String kbEbscoResponseFile = "responses/kb-ebsco/costperuse/titles/expected-title-cost-per-use-with-no-usage.json";
+    TitleCostPerUse expected = Json.decodeValue(readFile(kbEbscoResponseFile), TitleCostPerUse.class);
+
+    TitleCostPerUse actual = getWithOk(titleEndpoint(titleId, year, platform), JOHN_TOKEN_HEADER)
+      .as(TitleCostPerUse.class);
+
+    assertEquals(expected, actual);
+  }
 
   @Test
   public void shouldReturnEmptyTitleCostPerUseWhenNoCostPerUseDataAvailable() {

--- a/src/test/resources/responses/rmapi/titles/get-custom-title-with-managed-embargo.json
+++ b/src/test/resources/responses/rmapi/titles/get-custom-title-with-managed-embargo.json
@@ -1,0 +1,69 @@
+{
+  "titleId": 1111111111,
+  "titleName": "test-custom-title-132a648d",
+  "publisherName": "test publisher",
+  "identifiersList": [
+
+  ],
+  "subjectsList": [
+
+  ],
+  "isTitleCustom": true,
+  "pubType": "Database",
+  "customerResourcesList": [
+    {
+      "titleId": 1111111111,
+      "packageId": 222222,
+      "packageName": "test-custom-title-132a648d",
+      "packageType": "Custom",
+      "proxy": {
+        "id": "<n>",
+        "inherited": true
+      },
+      "isPackageCustom": true,
+      "vendorId": 19,
+      "vendorName": "TEST CUSTOMER",
+      "locationId": 0,
+      "isSelected": true,
+      "isTokenNeeded": false,
+      "visibilityData": {
+        "isHidden": false,
+        "reason": ""
+      },
+      "managedCoverageList": [
+
+      ],
+      "customCoverageList": [
+        {
+          "beginCoverage": "2001-01-01",
+          "endCoverage": "2004-02-01"
+        },
+        {
+          "beginCoverage": "2004-03-01",
+          "endCoverage": "2004-03-04"
+        }
+      ],
+      "coverageStatement": "Test Coverage Statement",
+      "managedEmbargoPeriod": {
+        "embargoUnit": "Months",
+        "embargoValue": 5
+      },
+      "customEmbargoPeriod": {
+        "embargoUnit": null,
+        "embargoValue": 0
+      },
+      "url": null,
+      "userDefinedField1": null,
+      "userDefinedField2": null,
+      "userDefinedField3": null,
+      "userDefinedField4": null,
+      "userDefinedField5": null
+    }
+  ],
+  "description": "This is the sample description for test",
+  "edition": "test edition",
+  "isPeerReviewed": true,
+  "contributorsList": [
+
+  ]
+}


### PR DESCRIPTION
/costperuse endpoint returns holdingsSгmmary object which doesn't include managed embargo when a resource has it
embargoPeriod object should contain one of:

managed embargo if it exists and custom embargo doesn't exist
custom embargo if it exists
embargoPeriod object should have embargoUnit and embargoValue properties

### Learn
Task - https://issues.folio.org/browse/MODKBEKBJ-604
Use for verification - https://bugfest-kiwi.folio.ebsco.com/eholdings/resources/19-166-60764