### PR TITLE
MODKBEKBJ-618 Null "Custom embargo period"

### DIFF
--- a/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
+++ b/src/main/java/org/folio/rest/impl/EholdingsResourcesImpl.java
@@ -185,7 +185,10 @@ public class EholdingsResourcesImpl implements EholdingsResources {
     templateFactory.createTemplate(okapiHeaders, asyncResultHandler)
       .requestAction(context -> fetchAccessType(entity, context)
         .thenCompose(accessType -> processResourceUpdate(entity, parsedResourceId, context)
-          .thenCompose(resourceResult -> updateAccessType(resourceId, resourceResult, accessType, context))
+          .thenCompose(resourceResult -> {
+            context.getTitlesService().updateCache(resourceResult);
+            return updateAccessType(resourceId, resourceResult, accessType, context);
+          })
         ))
       .addErrorMapper(InputValidationException.class, error422InputValidationMapper())
       .addErrorMapper(ResourceNotFoundException.class, error404ResourceNotFoundMapper())

--- a/src/main/java/org/folio/rmapi/TitlesServiceImpl.java
+++ b/src/main/java/org/folio/rmapi/TitlesServiceImpl.java
@@ -2,6 +2,7 @@ package org.folio.rmapi;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -12,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.folio.cache.VertxCache;
 import org.folio.holdingsiq.model.Configuration;
+import org.folio.holdingsiq.model.CustomerResources;
 import org.folio.holdingsiq.model.Title;
 import org.folio.holdingsiq.model.Titles;
 import org.folio.holdingsiq.service.impl.TitlesHoldingsIQServiceImpl;
@@ -22,53 +24,80 @@ public class TitlesServiceImpl extends TitlesHoldingsIQServiceImpl {
 
   private static final Logger LOG = LogManager.getLogger(TitlesServiceImpl.class);
 
-  private VertxCache<TitleCacheKey, Title> titleCache;
-  private Configuration configuration;
-  private String tenantId;
+  private final VertxCache<TitleCacheKey, Title> titleCache;
+  private final Configuration configuration;
+  private final String tenantId;
 
   public TitlesServiceImpl(Configuration config, Vertx vertx,
-                           String tenantId, VertxCache<TitleCacheKey, Title> titleCache ) {
+                           String tenantId, VertxCache<TitleCacheKey, Title> titleCache) {
     super(config, vertx);
 
     this.configuration = config;
     this.tenantId = tenantId;
     this.titleCache = titleCache;
   }
+  
+  @Override
+  public CompletableFuture<Title> retrieveTitle(long titleId) {
+    var titleFuture = super.retrieveTitle(titleId);
+    var cacheKey = buildTitleCacheKey(titleId);
+    titleFuture.thenAccept(title -> titleCache.putValue(cacheKey, title));
+    return titleFuture;
+  }
 
-   public CompletableFuture<Title> retrieveTitle(long titleId, boolean useCache) {
+  public CompletableFuture<Title> retrieveTitle(long titleId, boolean useCache) {
     CompletableFuture<Title> titleFuture;
-    if(useCache){
+    if (useCache) {
       titleFuture = retrieveTitleWithCache(titleId);
-    }else{
+    } else {
       titleFuture = super.retrieveTitle(titleId);
     }
     return titleFuture;
   }
 
   private CompletableFuture<Title> retrieveTitleWithCache(long titleId) {
-    TitleCacheKey cacheKey = TitleCacheKey.builder()
-      .titleId(titleId)
-      .rmapiConfiguration(configuration)
-      .tenant(tenantId)
-      .build();
-    return titleCache.getValueOrLoad(cacheKey, () -> retrieveTitle(titleId));
+    var cacheKey = buildTitleCacheKey(titleId);
+    return titleCache.getValueOrLoad(cacheKey, () -> super.retrieveTitle(titleId));
   }
 
   public CompletableFuture<Titles> retrieveTitles(List<Long> titleIds) {
     Set<CompletableFuture<Title>> futures = titleIds.stream()
-      .map(id -> retrieveTitle(id,true))
+      .map(id -> retrieveTitle(id, true))
       .collect(Collectors.toSet());
     return FutureUtils.allOfSucceeded(futures, throwable -> LOG.warn(throwable.getMessage(), throwable))
       .thenApply(this::mapToTitles);
+  }
+
+  public void updateCache(Title title) {
+    var cacheKey = buildTitleCacheKey(title.getTitleId());
+
+    List<CustomerResources> customerResources = title.getCustomerResourcesList();
+    if (!customerResources.isEmpty()) {
+      var updatedCustomerResourceId = customerResources.get(0).getPackageId();
+      var oldCustomerResources = titleCache.getValue(cacheKey)
+        .getCustomerResourcesList().stream()
+        .filter(resource -> !Objects.equals(resource.getPackageId(), updatedCustomerResourceId))
+        .collect(Collectors.toList());
+      customerResources.addAll(oldCustomerResources);
+    }
+    titleCache.putValue(cacheKey, title);
   }
 
   private Titles mapToTitles(List<Title> titles) {
     return Titles.builder()
       .titleList(
         titles.stream()
-        .sorted(Comparator.comparing(Title::getTitleName))
-        .collect(Collectors.toList())
+          .sorted(Comparator.comparing(Title::getTitleName))
+          .collect(Collectors.toList())
       )
+      .build();
+  }
+
+  private TitleCacheKey buildTitleCacheKey(long titleId) {
+    return TitleCacheKey.builder()
+      .titleId(titleId)
+      .rmapiConfiguration(configuration)
+      .tenant(tenantId)
       .build();
   }
 }

--- a/src/main/java/org/folio/rmapi/TitlesServiceImpl.java
+++ b/src/main/java/org/folio/rmapi/TitlesServiceImpl.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 
 import org.folio.cache.VertxCache;
 import org.folio.holdingsiq.model.Configuration;
-import org.folio.holdingsiq.model.CustomerResources;
 import org.folio.holdingsiq.model.Title;
 import org.folio.holdingsiq.model.Titles;
 import org.folio.holdingsiq.service.impl.TitlesHoldingsIQServiceImpl;
@@ -70,15 +69,18 @@ public class TitlesServiceImpl extends TitlesHoldingsIQServiceImpl {
 
   public void updateCache(Title title) {
     var cacheKey = buildTitleCacheKey(title.getTitleId());
-    mergeCustomerResources(cacheKey, title);
+    Title cachedTitle = titleCache.getValue(cacheKey);
+    if (!Objects.isNull(cachedTitle)) {
+      mergeCustomerResources(cachedTitle, title);
+    }
     titleCache.putValue(cacheKey, title);
   }
 
-  private void mergeCustomerResources(TitleCacheKey cacheKey, Title title) {
-    List<CustomerResources> updatedCustomerResources = title.getCustomerResourcesList();
-    List<CustomerResources> customerResources = titleCache.getValue(cacheKey).getCustomerResourcesList();
+  private void mergeCustomerResources(Title cachedTitle, Title title) {
+    var updatedCustomerResources = title.getCustomerResourcesList();
+    var customerResources = cachedTitle.getCustomerResourcesList();
 
-    if (!updatedCustomerResources.isEmpty() && !Objects.isNull(customerResources)) {
+    if (!updatedCustomerResources.isEmpty()) {
       var updatedCustomerResourceId = updatedCustomerResources.get(0).getPackageId();
       var oldCustomerResources = customerResources.stream()
         .filter(resource -> !Objects.equals(resource.getPackageId(), updatedCustomerResourceId))

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,7 +39,7 @@ currencies.cache.expire=86400
 configuration.cache.expire=120
 package.cache.expire=86400
 resource.cache.expire=86400
-title.cache.expire=86400
+title.cache.expire=43200
 vendor.cache.expire=86400
 vendor.id.cache.expire=600
 


### PR DESCRIPTION
Despite the fact that EBSCO HoldingsIQ returns resources with customEmbargoPeriod, kb-ebsco returns null for the same resource

### REASON:
kb-ebsco use cache for fetch TitleSelectedResources.
And cache lives 24 hours, so we get resources with updated customEmbargo after 24 hours

### Approach:

Cache title before user request costperuse
Cut time cache in half
Update cache after resource update

### Learning
[MODKBEKBJ-618](https://issues.folio.org/browse/MODKBEKBJ-618)