### PR TITLE
MODKBEKBJ-632 FOLIO-3231 Use new api-lint and api-doc CI facilities

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,11 @@ buildMvn {
   publishModDescriptor = 'yes'
   mvnDeploy = 'yes'
   publishAPI = 'yes'
-  runLintRamlCop = 'yes'
   buildNode =  'jenkins-agent-java11'
+
+  doApiLint = true
+  apiTypes = 'RAML'
+  apiDirectories = 'ramls'
 
   doDocker = {
     buildJavaDocker {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
 buildMvn {
   publishModDescriptor = 'yes'
   mvnDeploy = 'yes'
-  publishAPI = 'yes'
   buildNode =  'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML'
   apiDirectories = 'ramls'
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-kb-ebsco-java
 
-Copyright (C) 2018-2019 The Open Library Foundation
+Copyright (C) 2018-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/ramls/types/uc/costperuse/analysisCostAttributes.json
+++ b/ramls/types/uc/costperuse/analysisCostAttributes.json
@@ -9,17 +9,17 @@
     "cost": {
       "type": "number",
       "description": "Cost of resource",
-      "example": "800.00"
+      "example": 800.00
     },
     "usage": {
       "type": "integer",
       "description": "Count of usage",
-      "example": "800"
+      "example": 800
     },
     "costPerUse": {
       "type": "number",
       "description": "Cost-per-use of resource",
-      "example": "1.00"
+      "example": 1.00
     }
   }
 }

--- a/ramls/types/uc/costperuse/platformUsage.json
+++ b/ramls/types/uc/costperuse/platformUsage.json
@@ -12,7 +12,7 @@
       "items": {
         "type": "integer"
       },
-      "example": [100, 0, 100, 0, 0, 0, 0, null, 100, 100, 0, 100]
+      "example": [100, 0, 100, 0, 0, 0, 0, 0, 100, 100, 0, 100]
     },
     "total": {
       "type": "integer",

--- a/ramls/types/uc/costperuse/resourceAnalysisCost.json
+++ b/ramls/types/uc/costperuse/resourceAnalysisCost.json
@@ -22,7 +22,7 @@
     "percent": {
       "type": "number",
       "description": "Percent of usage",
-      "example": "20.5"
+      "example": 20.5
     }
   }
 }


### PR DESCRIPTION
The doApiLint facility replaces runLintRamlCop
https://dev.folio.org/guides/api-lint/

The doApiDoc facility replaces publishAPI
https://dev.folio.org/guides/api-doc/

The https://dev.folio.org/reference/api/#mod-kb-ebsco-java section of API documentation will be automatically reconfigured:
https://dev.folio.org/reference/api/#explain-gather-config
