### PR TITLE
MODKBEKBJ-646 Fix GET request for '/kb-credentials/{kb-credentials-id}/users'

### DIFF
--- a/src/main/java/org/folio/service/users/UsersLookUpService.java
+++ b/src/main/java/org/folio/service/users/UsersLookUpService.java
@@ -135,7 +135,7 @@ public class UsersLookUpService {
     Promise<HttpResponse<JsonObject>> promise = Promise.promise();
     webClient.getAbs(headers.get(XOkapiHeaders.URL) + usersEndpoint)
       .putHeaders(headers)
-      .addQueryParam(CQL_QUERY_PARAM, StringUtil.urlEncode(query))
+      .addQueryParam(CQL_QUERY_PARAM, query)
       .as(BodyCodec.jsonObject())
       .expect(ResponsePredicate.create(ResponsePredicate.SC_OK, errorConverter()))
       .send(promise);

--- a/src/main/java/org/folio/service/users/UsersLookUpService.java
+++ b/src/main/java/org/folio/service/users/UsersLookUpService.java
@@ -50,7 +50,7 @@ public class UsersLookUpService {
   private static final String CQL_QUERY_PARAM = "query";
   private static final String AUTHORIZATION_FAIL_ERROR_MESSAGE = "Authorization failure";
   private static final String USER_NOT_FOUND_ERROR_MESSAGE = "User not found";
-  private static final String CANNOT_GET_USER_DATA_ERROR_MESSAGE = "Cannot get user data: %s";
+  private static final String CANNOT_GET_USER_DATA_ERROR_MESSAGE = "Cannot get user data: {}. Server response: {}";
   private static final String USER_INFO_IS_NOT_COMPLETE_ERROR_MESSAGE = "User info is not complete";
 
   private final WebClient webClient;
@@ -153,8 +153,8 @@ public class UsersLookUpService {
         throw new NotFoundException(USER_NOT_FOUND_ERROR_MESSAGE);
       } else {
         String message = result.message();
-        String msg = String.format(CANNOT_GET_USER_DATA_ERROR_MESSAGE, message);
-        LOG.error(msg);
+        String serverResponse = response.bodyAsString();
+        LOG.error(CANNOT_GET_USER_DATA_ERROR_MESSAGE, message, serverResponse);
         throw new IllegalStateException(message);
       }
     });

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsAccessTypesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsAccessTypesImplTest.java
@@ -9,7 +9,6 @@ import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.apache.http.HttpStatus.SC_OK;
-import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -44,7 +43,6 @@ import static org.folio.util.KbCredentialsTestUtil.STUB_API_URL;
 import static org.folio.util.KbCredentialsTestUtil.STUB_CREDENTIALS_NAME;
 import static org.folio.util.KbCredentialsTestUtil.STUB_TOKEN_HEADER;
 import static org.folio.util.KbCredentialsTestUtil.saveKbCredentials;
-import static org.folio.util.StringUtil.urlEncode;
 import static org.folio.util.TokenTestUtils.generateToken;
 
 import java.io.IOException;
@@ -53,7 +51,6 @@ import java.util.List;
 import java.util.UUID;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
@@ -255,7 +252,7 @@ public class EholdingsAccessTypesImplTest extends WireMockTestBase {
   public void shouldReturn404OnGetByIdAndCredentialsIfCredentialsIsMissing() {
     String id = UUID.randomUUID().toString();
     String resourcePath = String.format(KB_CREDENTIALS_ACCESS_TYPE_ID_ENDPOINT,
-      UUID.randomUUID().toString(), id);
+      UUID.randomUUID(), id);
     JsonapiError error = getWithStatus(resourcePath, SC_NOT_FOUND, STUB_TOKEN_HEADER).as(JsonapiError.class);
 
     assertErrorContainsTitle(error, String.format("Access type not found: id = %s", id));
@@ -294,7 +291,7 @@ public class EholdingsAccessTypesImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn204OnDeleteIfNotFound() {
-    String resourcePath = String.format(KB_CREDENTIALS_ACCESS_TYPE_ID_ENDPOINT, credentialsId, UUID.randomUUID().toString());
+    String resourcePath = String.format(KB_CREDENTIALS_ACCESS_TYPE_ID_ENDPOINT, credentialsId, UUID.randomUUID());
     int statusCode = deleteWithNoContent(resourcePath).response().statusCode();
 
     assertEquals(SC_NO_CONTENT, statusCode);
@@ -492,7 +489,7 @@ public class EholdingsAccessTypesImplTest extends WireMockTestBase {
     accessType.setId("invalid-id-format");
 
     String putBody = Json.encode(new AccessTypePutRequest().withData(accessType));
-    String resourcePath = String.format(KB_CREDENTIALS_ACCESS_TYPE_ID_ENDPOINT, credentialsId, UUID.randomUUID().toString());
+    String resourcePath = String.format(KB_CREDENTIALS_ACCESS_TYPE_ID_ENDPOINT, credentialsId, UUID.randomUUID());
     Errors errors = putWithStatus(resourcePath, putBody, SC_UNPROCESSABLE_ENTITY, USER9_TOKEN).as(Errors.class);
 
     assertThat(errors.getErrors().get(0).getParameters().get(0).getKey(), equalTo("data.id"));

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsAssignedUsersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsAssignedUsersImplTest.java
@@ -24,7 +24,6 @@ import static org.folio.util.KbCredentialsTestUtil.KB_CREDENTIALS_ENDPOINT;
 import static org.folio.util.KbCredentialsTestUtil.STUB_API_URL;
 import static org.folio.util.KbCredentialsTestUtil.STUB_CREDENTIALS_NAME;
 import static org.folio.util.KbCredentialsTestUtil.saveKbCredentials;
-import static org.folio.util.StringUtil.urlEncode;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -225,7 +224,7 @@ public class EholdingsAssignedUsersImplTest extends WireMockTestBase {
 
     stubFor(
       get(new UrlPathPattern(new RegexPattern(GET_USERS_ENDPOINT), true))
-        .withQueryParam(QUERY_PARAM, WireMock.equalTo(urlEncode(query)))
+        .withQueryParam(QUERY_PARAM, WireMock.equalTo(query))
         .willReturn(new ResponseDefinitionBuilder()
           .withBody(TestUtil.readFile(USERDATA_COLLECTION_INFO_STUB_FILE))));
 
@@ -236,7 +235,7 @@ public class EholdingsAssignedUsersImplTest extends WireMockTestBase {
 
     stubFor(
       get(new UrlPathPattern(new RegexPattern("/groups"), true))
-        .withQueryParam(QUERY_PARAM, WireMock.equalTo(urlEncode(cqlQuery)))
+        .withQueryParam(QUERY_PARAM, WireMock.equalTo(cqlQuery))
         .willReturn(new ResponseDefinitionBuilder()
           .withBody(TestUtil.readFile(GROUP_INFO_STUB_FILE))));
   }

--- a/src/test/java/org/folio/service/users/UsersLookUpServiceTest.java
+++ b/src/test/java/org/folio/service/users/UsersLookUpServiceTest.java
@@ -9,7 +9,6 @@ import static org.folio.rest.impl.WireMockTestBase.JANE_ID;
 import static org.folio.rest.impl.WireMockTestBase.JOHN_GROUP_ID;
 import static org.folio.rest.impl.WireMockTestBase.JOHN_ID;
 import static org.folio.test.util.TestUtil.STUB_TENANT;
-import static org.folio.util.StringUtil.urlEncode;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -156,7 +155,7 @@ public class UsersLookUpServiceTest {
 
     stubFor(
       get(new UrlPathPattern(new RegexPattern(GET_USERS_ENDPOINT), true))
-        .withQueryParam(QUERY_PARAM, equalTo(urlEncode(query)))
+        .withQueryParam(QUERY_PARAM, equalTo(query))
         .willReturn(new ResponseDefinitionBuilder()
           .withBody(TestUtil.readFile(USERDATA_COLLECTION_INFO_STUB_FILE))));
 
@@ -194,7 +193,7 @@ public class UsersLookUpServiceTest {
 
     stubFor(
       get(new UrlPathPattern(new RegexPattern("/groups"), true))
-        .withQueryParam(QUERY_PARAM, equalTo(urlEncode(cqlQuery)))
+        .withQueryParam(QUERY_PARAM, equalTo(cqlQuery))
         .willReturn(new ResponseDefinitionBuilder()
           .withBody(TestUtil.readFile(GROUP_INFO_STUB_FILE))));
 


### PR DESCRIPTION
## Approach
- remove cql query encoding]
- add server response to errorConverter

## Learning
[MODKBEKBJ-646](https://issues.folio.org/browse/MODKBEKBJ-646)
