### PR TITLE
MODKBEKBJ-668 Loading holdings failed with NullPointer

### DIFF
--- a/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
@@ -59,6 +59,8 @@ public class DefaultLoadServiceFacade extends AbstractLoadServiceFacade {
   }
 
   private HoldingsStatus mapToStatus(HoldingsLoadStatus status) {
+    if (status == null) return null;
+
     return HoldingsStatus.builder()
       .created(status.getCreated())
       .status(LoadStatus.fromValue(status.getStatus()))

--- a/src/test/java/org/folio/service/holdings/AbstractLoadServiceFacadeTest.java
+++ b/src/test/java/org/folio/service/holdings/AbstractLoadServiceFacadeTest.java
@@ -1,0 +1,99 @@
+package org.folio.service.holdings;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.folio.repository.holdings.LoadStatus.COMPLETED;
+import static org.folio.repository.holdings.LoadStatus.IN_PROGRESS;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.vertx.core.Vertx;
+import lombok.SneakyThrows;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import org.folio.holdingsiq.service.LoadService;
+import org.folio.holdingsiq.service.impl.LoadServiceImpl;
+import org.folio.repository.holdings.LoadStatus;
+import org.folio.service.holdings.message.LoadHoldingsMessage;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractLoadServiceFacadeTest {
+
+  private static final String TEST = "test";
+
+  @Mock
+  private LoadServiceImpl loadService;
+
+  private final Vertx vertx = Vertx.vertx();
+
+  private final AbstractLoadServiceFacade loadServiceFacadeSpy =
+    Mockito.spy(new AbstractLoadServiceFacade(1L, 5, 1,
+      1, 1,vertx) {
+      @Override
+      protected CompletableFuture<String> populateHoldings(LoadService loadingService) {
+        return CompletableFuture.completedFuture(TEST);
+      }
+
+      @Override
+      protected CompletableFuture<HoldingsStatus> getLastLoadingStatus(LoadService loadingService) {
+        return null;
+      }
+
+      @Override
+      protected CompletableFuture<HoldingsStatus> getLoadingStatus(LoadService loadingService, String transactionId) {
+        return null;
+      }
+
+      @Override
+      protected CompletableFuture<Void> loadHoldings(LoadHoldingsMessage message, LoadService loadingService) {
+        return null;
+      }
+
+      @Override
+      protected int getMaxPageSize() {
+        return 0;
+      }
+    });
+
+  @Test
+  @SneakyThrows
+  public void shouldRetryOnEmptyStatusFromHoldingsIQ() {
+    doReturn(getHoldingsStatusFuture(null), getHoldingsStatusFuture(null), getHoldingsStatusFuture(getHoldingsStatus(IN_PROGRESS)))
+      .when(loadServiceFacadeSpy)
+      .getLastLoadingStatus(any());
+    when(loadServiceFacadeSpy.getLoadingStatus(any(), any()))
+      .thenReturn(getHoldingsStatusFuture(getHoldingsStatus(COMPLETED)));
+
+    var holdingsStatusFuture = ReflectionTestUtils.<CompletableFuture<HoldingsStatus>>invokeMethod(
+      loadServiceFacadeSpy, "populateHoldingsIfNecessary", loadService);
+
+    assertNotNull(holdingsStatusFuture);
+    assertEquals(COMPLETED, holdingsStatusFuture.get().getStatus());
+    verify(loadServiceFacadeSpy, times(3))
+      .getLastLoadingStatus(any());
+    verify(loadServiceFacadeSpy, times(1))
+      .getLoadingStatus(any(), any());
+  }
+
+  private HoldingsStatus getHoldingsStatus(LoadStatus loadStatus) {
+    return HoldingsStatus.builder()
+      .status(loadStatus)
+      .build();
+  }
+
+  private CompletableFuture<HoldingsStatus> getHoldingsStatusFuture(HoldingsStatus holdingsStatus) {
+    return CompletableFuture.completedFuture(holdingsStatus);
+  }
+
+}

--- a/src/test/java/org/folio/service/holdings/DefaultLoadServiceFacadeTest.java
+++ b/src/test/java/org/folio/service/holdings/DefaultLoadServiceFacadeTest.java
@@ -1,0 +1,40 @@
+package org.folio.service.holdings;
+
+import static org.junit.Assert.assertNull;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.vertx.core.Vertx;
+import lombok.SneakyThrows;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.folio.holdingsiq.service.impl.LoadServiceImpl;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultLoadServiceFacadeTest {
+
+  @Mock
+  private LoadServiceImpl loadService;
+
+  private final Vertx vertx = Vertx.vertx();
+
+  private final DefaultLoadServiceFacade defaultLoadServiceFacade =
+    new DefaultLoadServiceFacade(1L, 1, 1,
+      1, 1, 1,
+      vertx);
+
+  @Test
+  @SneakyThrows
+  public void shouldNotFailOnEmptyStatusFromHoldingsIQ() {
+    Mockito.when(loadService.getLoadingStatus())
+      .thenReturn(CompletableFuture.completedFuture(null));
+
+    var result = defaultLoadServiceFacade.getLastLoadingStatus(loadService);
+    assertNull(result.get());
+  }
+
+}


### PR DESCRIPTION
## Purpose
Avoid saving 'Error' status for load holdings job in case holdingsIQ doesn't return status.

## Approach
- Add 'null' holdingsIQ response handling
- Add retries for querying 'lastHoldingsStatus' for 'null' response

### Learning
[MODKBEKBJ-668](https://issues.folio.org/browse/MODKBEKBJ-668)
I was unable to reproduce the issue so supposingly holdingsIQ returns 2xx status with empty body in some cases at the start of loading holdings job.