### PR TITLE
MODKBEKBJ-673 User with permission "Settings (eHoldings): Can assign/unassign a user from a KB" can't assign users to KB credentials

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -50,8 +50,10 @@
           "methods": ["GET"],
           "pathPattern": "/eholdings/kb-credentials/{credentialsId}/users",
           "permissionsRequired": ["kb-ebsco.kb-credentials.users.collection.get"],
-          "modulePermissions": ["users.collection.get",
-          "usergroups.collection.get"]
+          "modulePermissions": [
+            "users.collection.get",
+            "usergroups.collection.get"
+          ]
         },
         {
           "methods": ["POST"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -49,17 +49,15 @@
         {
           "methods": ["GET"],
           "pathPattern": "/eholdings/kb-credentials/{credentialsId}/users",
-          "permissionsRequired": ["kb-ebsco.kb-credentials.users.collection.get"]
+          "permissionsRequired": ["kb-ebsco.kb-credentials.users.collection.get"],
+          "modulePermissions": ["users.collection.get",
+          "usergroups.collection.get"]
         },
         {
           "methods": ["POST"],
           "pathPattern": "/eholdings/kb-credentials/{credentialsId}/users",
-          "permissionsRequired": ["kb-ebsco.kb-credentials.users.collection.post"]
-        },
-        {
-          "methods": ["PUT"],
-          "pathPattern": "/eholdings/kb-credentials/{credentialsId}/users/{userId}",
-          "permissionsRequired": ["kb-ebsco.kb-credentials.users.item.put"]
+          "permissionsRequired": ["kb-ebsco.kb-credentials.users.collection.post"],
+          "modulePermissions": ["users.item.get"]
         },
         {
           "methods": ["DELETE"],


### PR DESCRIPTION
## Purpose
Fix assigning users to KB credentials error.

## Approach
- Add "users.item.get" permission to POST "/eholdings/kb-credentials/<credentialsId>/users" endpoint modulePermissions
- Add "users.collection.get" and "usergroups.collection.get" permissions to GET "/eholdings/kb-credentials/<credentialsId>/users" endpoint modulePermissions
- Remove PUT "/eholdings/kb-credentials/<credentialsId>/users/<userId>" enpoint from module description

### Learning
[MODKBEKBJ-673](https://issues.folio.org/browse/MODKBEKBJ-673)