### PR TITLE
MODKBEKBJ-680 Fix holdings_status migration

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,12 @@
+COMPOSE_PROJECT_NAME=folio-mod-kb-ebsco-java
+DB_HOST=postgres
+DB_PORT=5432
+DB_DATABASE=okapi_modules
+DB_USERNAME=folio_admin
+DB_PASSWORD=folio_admin
+PGADMIN_DEFAULT_EMAIL=user@domain.com
+PGADMIN_DEFAULT_PASSWORD=admin
+PGADMIN_PORT=5050
+ENV=folio
+DEBUG_PORT=5005
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,60 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:12-alpine
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/data/postgres
+    environment:
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_DATABASE}
+      PGDATA: "/data/postgres"
+    networks:
+      - mod-kb-ebsco-java-local
+
+  pgadmin:
+    image: dpage/pgadmin4:6.7
+    ports:
+      - ${PGADMIN_PORT}:80
+    volumes:
+      - "pgadmin-data:/var/lib/pgadmin"
+    environment:
+      PGADMIN_CONFIG_SERVER_MODE: "False"
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
+    networks:
+      - mod-kb-ebsco-java-local
+
+  mod-kb-ebsco-java:
+    image: dev.folio/mod-kb-ebsco-java
+    build:
+      context: ..\
+      dockerfile: Dockerfile
+    ports:
+      - "8081:8081"
+      - "5005:5005"
+    environment:
+      ENV: ${ENV}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PORT: ${DB_PORT}
+      DB_HOST: ${DB_HOST}
+      DB_DATABASE: ${DB_DATABASE}
+      DB_PASSWORD: ${DB_PASSWORD}
+      JAVA_OPTIONS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:${DEBUG_PORT}"
+    depends_on:
+      - "postgres"
+    networks:
+      - mod-kb-ebsco-java-local
+
+networks:
+  mod-kb-ebsco-java-local:
+    driver: "bridge"
+
+volumes:
+  pgadmin-data:
+    driver: "local"
+  postgres-data:
+    driver: "local"

--- a/src/main/resources/liquibase/tenant/scripts/v3.6.6/populate-holdings-and-retry-status.xml
+++ b/src/main/resources/liquibase/tenant/scripts/v3.6.6/populate-holdings-and-retry-status.xml
@@ -23,12 +23,6 @@
     </createProcedure>
   </changeSet>
 
-  <changeSet id="MODKBEKBJ-680@@create-pgcrypto-extension" author="psmahin">
-    <sql>
-      CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA public;
-    </sql>
-  </changeSet>
-
   <changeSet id="MODKBEKBJ-680@@add-unique-constraint-for-credentialsid-in-retry-status" author="psmahin">
     <preConditions onFail="MARK_RAN"
                    onFailMessage="[WARN] Unique constraint already exist: unq_retry_status_credentialsid">

--- a/src/main/resources/liquibase/tenant/scripts/v3.6.6/populate-holdings-and-retry-status.xml
+++ b/src/main/resources/liquibase/tenant/scripts/v3.6.6/populate-holdings-and-retry-status.xml
@@ -112,7 +112,7 @@
   <changeSet id="MODKBEKBJ-556@@save-status-not-started-for-dummy-credentials" author="psmagin" runOnChange="true">
     <sql>
       INSERT INTO ${database.defaultSchemaName}.holdings_status(id, jsonb, lock, process_id, credentials_id)
-	    SELECT public.gen_random_uuid(),
+	    SELECT id,
 	    		'{
 	    			"data": {
 	    				"type": "status",
@@ -128,7 +128,7 @@
 	    			}
 	    		}'
 	    		, 'true',
-          public.gen_random_uuid(),
+          id,
 	    		id
       FROM ${database.defaultSchemaName}.kb_credentials
       ON CONFLICT DO NOTHING;
@@ -138,7 +138,7 @@
   <changeSet id="MODKBEKBJ-556@@save-retry-status-for-dummy-credentials" author="psmagin" runOnChange="true">
     <sql>
       INSERT INTO ${database.defaultSchemaName}.retry_status(id, attempts_left, credentials_id)
-      SELECT public.gen_random_uuid(), 5, id
+      SELECT id, 5, id
       FROM ${database.defaultSchemaName}.kb_credentials
       ON CONFLICT DO NOTHING;
     </sql>

--- a/src/main/resources/liquibase/tenant/scripts/v3.6.6/populate-holdings-and-retry-status.xml
+++ b/src/main/resources/liquibase/tenant/scripts/v3.6.6/populate-holdings-and-retry-status.xml
@@ -23,15 +23,96 @@
     </createProcedure>
   </changeSet>
 
-  <changeSet id="MODKBEKBJ-556@@save-status-not-started-for-dummy-credentials" author="psmagin">
-    <preConditions onFail="MARK_RAN">
+  <changeSet id="MODKBEKBJ-680@@create-pgcrypto-extension" author="psmahin">
+    <sql>
+      CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA public;
+    </sql>
+  </changeSet>
+
+  <changeSet id="MODKBEKBJ-680@@add-unique-constraint-for-credentialsid-in-retry-status" author="psmahin">
+    <preConditions onFail="MARK_RAN"
+                   onFailMessage="[WARN] Unique constraint already exist: unq_retry_status_credentialsid">
       <sqlCheck expectedResult="0">
-        SELECT count(*) FROM ${database.defaultSchemaName}.holdings_status WHERE credentials_id = (SELECT ${database.defaultSchemaName}.get_single_credentials_id());
+        SELECT COUNT(1) from pg_constraint
+        WHERE conname = 'unq_retry_status_credentialsid'
+        AND contype = 'u'
+        AND conrelid = '${database.defaultSchemaName}.retry_status'::regclass;
+      </sqlCheck>
+    </preConditions>
+    <addUniqueConstraint
+      constraintName="unq_retry_status_credentialsid"
+      tableName="retry_status"
+      columnNames="credentials_id"
+      schemaName="${database.defaultSchemaName}"
+      deferrable="false"/>
+  </changeSet>
+
+  <changeSet id="MODKBEKBJ-680@@drop-holdings-status-lock-key" author="psmahin">
+    <preConditions onFail="MARK_RAN" onFailMessage="[WARN] Unique constraint doesn't exist: holdings_status_lock_key">
+      <sqlCheck expectedResult="1">
+        SELECT COUNT(1) from pg_constraint
+        WHERE conname = 'holdings_status_lock_key'
+        AND contype = 'u'
+        AND conrelid = '${database.defaultSchemaName}.holdings_status'::regclass;
+      </sqlCheck>
+    </preConditions>
+    <dropUniqueConstraint
+      tableName="holdings_status"
+      constraintName="holdings_status_lock_key"
+      schemaName="${database.defaultSchemaName}"/>
+  </changeSet>
+
+  <changeSet id="MODKBEKBJ-680@@drop-unq-holdings-status-credentialsid-lock" author="psmahin">
+    <preConditions onFail="MARK_RAN"
+                   onFailMessage="[WARN] Unique constraint doesn't exist: unq_holdings_status_credentialsid_lock">
+      <sqlCheck expectedResult="1">
+        SELECT COUNT(1) from pg_constraint
+        WHERE conname = 'unq_holdings_status_credentialsid_lock'
+        AND contype = 'u'
+        AND conrelid = '${database.defaultSchemaName}.holdings_status'::regclass;
+      </sqlCheck>
+    </preConditions>
+    <dropUniqueConstraint tableName="holdings_status"
+                          constraintName="unq_holdings_status_credentialsid_lock"
+                          schemaName="${database.defaultSchemaName}"/>
+  </changeSet>
+
+  <changeSet id="MODKBEKBJ-680@@drop-holdings-status-lock-check" author="psmahin">
+    <preConditions onFail="MARK_RAN" onFailMessage="[WARN] Check constraint doesn't exist: holdings_status_lock_check">
+      <sqlCheck expectedResult="1">
+        SELECT COUNT(1) from pg_constraint
+        WHERE conname = 'holdings_status_lock_check'
+        AND contype = 'c'
+        AND conrelid = '${database.defaultSchemaName}.holdings_status'::regclass;
       </sqlCheck>
     </preConditions>
     <sql>
+      ALTER TABLE ${database.defaultSchemaName}.holdings_status DROP CONSTRAINT holdings_status_lock_check;
+    </sql>
+  </changeSet>
+
+  <changeSet id="MODKBEKBJ-680@@add-unique-constraint-for-credentialsid-in-holdings-status" author="psmahin">
+    <preConditions onFail="MARK_RAN"
+                   onFailMessage="[WARN] Unique constraint already exist: unq_holdings_status_credentialsid">
+      <sqlCheck expectedResult="0">
+        SELECT COUNT(1) from pg_constraint
+        WHERE conname = 'unq_holdings_status_credentialsid'
+        AND contype = 'u'
+        AND conrelid = '${database.defaultSchemaName}.holdings_status'::regclass;
+      </sqlCheck>
+    </preConditions>
+    <addUniqueConstraint
+      constraintName="unq_holdings_status_credentialsid"
+      tableName="holdings_status"
+      columnNames="credentials_id"
+      schemaName="${database.defaultSchemaName}"
+      deferrable="false"/>
+  </changeSet>
+
+  <changeSet id="MODKBEKBJ-556@@save-status-not-started-for-dummy-credentials" author="psmagin" runOnChange="true">
+    <sql>
       INSERT INTO ${database.defaultSchemaName}.holdings_status(id, jsonb, lock, process_id, credentials_id)
-	    VALUES ('9e12026a-6e7c-46e0-bc60-4ef6fc9b19e2',
+	    SELECT public.gen_random_uuid(),
 	    		'{
 	    			"data": {
 	    				"type": "status",
@@ -47,21 +128,19 @@
 	    			}
 	    		}'
 	    		, 'true',
-	    		'ab6e433b-dcaa-404a-a89c-d4c1cfaef658',
-	    		(SELECT ${database.defaultSchemaName}.get_single_credentials_id())
-      );
+          public.gen_random_uuid(),
+	    		id
+      FROM ${database.defaultSchemaName}.kb_credentials
+      ON CONFLICT DO NOTHING;
     </sql>
   </changeSet>
 
-  <changeSet id="MODKBEKBJ-556@@save-retry-status-for-dummy-credentials" author="psmagin">
-    <preConditions onFail="MARK_RAN">
-      <sqlCheck expectedResult="0">
-        SELECT count(*) FROM ${database.defaultSchemaName}.retry_status WHERE credentials_id = (SELECT ${database.defaultSchemaName}.get_single_credentials_id());
-      </sqlCheck>
-    </preConditions>
+  <changeSet id="MODKBEKBJ-556@@save-retry-status-for-dummy-credentials" author="psmagin" runOnChange="true">
     <sql>
       INSERT INTO ${database.defaultSchemaName}.retry_status(id, attempts_left, credentials_id)
-      VALUES ('9e12026a-6e7c-46e0-bc60-4ef6fc9b19e2', 5, (SELECT ${database.defaultSchemaName}.get_single_credentials_id()));
+      SELECT public.gen_random_uuid(), 5, id
+      FROM ${database.defaultSchemaName}.kb_credentials
+      ON CONFLICT DO NOTHING;
     </sql>
   </changeSet>
 

--- a/src/main/resources/templates/db_scripts/create-holdings-status-table.sql
+++ b/src/main/resources/templates/db_scripts/create-holdings-status-table.sql
@@ -1,8 +1,4 @@
 ALTER TABLE holdings_status
--- Add unique column with value true to ensure that only one row can be created in holdings_status
-ADD COLUMN IF NOT EXISTS lock BOOL NOT NULL UNIQUE DEFAULT TRUE CHECK (lock);
-
-ALTER TABLE holdings_status
 ADD COLUMN IF NOT EXISTS process_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000';
 ALTER TABLE holdings_status
 ALTER COLUMN process_id DROP DEFAULT;

--- a/src/main/resources/templates/db_scripts/create-holdings-status-table.sql
+++ b/src/main/resources/templates/db_scripts/create-holdings-status-table.sql
@@ -1,4 +1,8 @@
 ALTER TABLE holdings_status
+-- Add unique column with value true to ensure that only one row can be created in holdings_status
+ADD COLUMN IF NOT EXISTS lock BOOL NOT NULL UNIQUE DEFAULT TRUE CHECK (lock);
+
+ALTER TABLE holdings_status
 ADD COLUMN IF NOT EXISTS process_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000';
 ALTER TABLE holdings_status
 ALTER COLUMN process_id DROP DEFAULT;


### PR DESCRIPTION
## Purpose
Fix holdings_status migration

## Approach
* Insert default values into holdings_status and retry_status tables for each kb_credentials
* Update constraints for holdings_status and retry_status tables
* Add docker-compose for testing purposes 

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [x] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
