### PR TITLE
MODKBEKBJ-681 Full text requests by platform usage display error

### DIFF
--- a/src/main/java/org/folio/rest/converter/costperuse/CostPerUseConverterUtils.java
+++ b/src/main/java/org/folio/rest/converter/costperuse/CostPerUseConverterUtils.java
@@ -63,10 +63,14 @@ final class CostPerUseConverterUtils {
       && ucTitleCostPerUse.getAnalysis().getCurrent() != null
       && ucTitleCostPerUse.getAnalysis().getCurrent().getCost() != null) {
       analysisAttributes.setCost(ucTitleCostPerUse.getAnalysis().getCurrent().getCost());
-      analysisAttributes.setUsage(publisher.getTotal());
-      analysisAttributes.setCostPerUse(analysisAttributes.getCost() / analysisAttributes.getUsage());
+      analysisAttributes.setUsage(publisher == null ? null : publisher.getTotal());
+      analysisAttributes.setCostPerUse(getCostPerUse(analysisAttributes));
     }
     return analysisAttributes;
+  }
+
+  static Double getCostPerUse(CostAnalysisAttributes analysisAttributes){
+    return analysisAttributes.getUsage() == null ? null : analysisAttributes.getCost() / analysisAttributes.getUsage();
   }
 
   static void setNonPublisherUsage(List<SpecificPlatformUsage> specificPlatformUsages, Usage usage) {

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsCostperuseImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsCostperuseImplTest.java
@@ -130,6 +130,24 @@ public class EholdingsCostperuseImplTest extends WireMockTestBase {
   }
 
   @Test
+  public void shouldReturnResourceCostPerUseWithEmptyNonPublisher() {
+    int titleId = 356;
+    int packageId = 473;
+    String year = "2019";
+    String platform = "all";
+    String stubApigeeResponseFile = "responses/uc/titles/get-title-cost-per-use-response-with-empty-non-publisher.json";
+    mockSuccessfulTitleCostPerUse(titleId, packageId, stubApigeeResponseFile);
+
+    String kbEbscoResponseFile = "responses/kb-ebsco/costperuse/resources/expected-resource-cost-per-use-with-empty-non-publisher.json";
+    ResourceCostPerUse expected = Json.decodeValue(readFile(kbEbscoResponseFile), ResourceCostPerUse.class);
+
+    ResourceCostPerUse actual = getWithOk(resourceEndpoint(titleId, packageId, year, platform), JOHN_TOKEN_HEADER)
+      .as(ResourceCostPerUse.class);
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
   public void shouldReturn422OnGetResourceCPUWhenYearIsNull() {
     int titleId = 356;
     int packageId = 473;

--- a/src/test/resources/responses/kb-ebsco/costperuse/resources/expected-resource-cost-per-use-with-empty-non-publisher.json
+++ b/src/test/resources/responses/kb-ebsco/costperuse/resources/expected-resource-cost-per-use-with-empty-non-publisher.json
@@ -1,0 +1,106 @@
+{
+  "resourceId": "1-473-356",
+  "type": "resourceCostPerUse",
+  "attributes": {
+    "usage": {
+      "platforms": [
+        {
+          "name": "Wiley Online Library",
+          "isPublisherPlatform": true,
+          "counts": [
+            0,
+            1,
+            3,
+            1,
+            3,
+            1,
+            16,
+            1,
+            null,
+            null,
+            null,
+            null
+          ],
+          "total": 26
+        },
+        {
+          "name": "EBSCOhost",
+          "isPublisherPlatform": false,
+          "counts": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "total": 0
+        }
+      ],
+      "totals": {
+        "publisher": {
+          "counts": [
+            0,
+            1,
+            3,
+            1,
+            3,
+            1,
+            16,
+            1,
+            null,
+            null,
+            null,
+            null
+          ],
+          "total": 26
+        },
+        "nonPublisher": null,
+        "all": {
+          "counts": [
+            0,
+            1,
+            3,
+            1,
+            3,
+            1,
+            16,
+            1,
+            null,
+            null,
+            null,
+            null
+          ],
+          "total": 26
+        }
+      }
+    },
+    "analysis": {
+      "publisherPlatforms": {
+        "cost": 100.0,
+        "usage": 26,
+        "costPerUse": 3.8461538461538463
+      },
+      "nonPublisherPlatforms": {
+        "cost": 100.0,
+        "usage": null,
+        "costPerUse": null
+      },
+      "allPlatforms": {
+        "cost": 100.0,
+        "usage": 26,
+        "costPerUse": 3.8461538461538463
+      }
+    },
+    "parameters": {
+      "startMonth": "apr",
+      "currency": "USD"
+    }
+  }
+}

--- a/src/test/resources/responses/uc/titles/get-title-cost-per-use-response-with-empty-non-publisher.json
+++ b/src/test/resources/responses/uc/titles/get-title-cost-per-use-response-with-empty-non-publisher.json
@@ -1,0 +1,50 @@
+{
+  "usage": {
+    "platforms": {
+      "Wiley Online Library": {
+        "counts": [
+          0,
+          1,
+          3,
+          1,
+          3,
+          1,
+          16,
+          1,
+          null,
+          null,
+          null,
+          null
+        ],
+        "publisherPlatform": true
+      },
+      "EBSCOhost": {
+        "counts": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "publisherPlatform": false
+      }
+    }
+  },
+  "analysis": {
+    "current": {
+      "cost": 100.0,
+      "usage": 26,
+      "costPerUse": 3.8461538461538463
+    },
+    "previous": {
+      "usage": 52
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
Fix an error of full text requests by platform usage not displaying when selecting an option, that retrieves empty usage data. The cause of the error was null publisher value which led to NullPointerException.
[MODKBEKBJ-681](https://issues.folio.org/browse/MODKBEKBJ-681)

## Approach
- null checks when setting usage and cost per use values added
- Test to reflect corresponding changes added
