### PR TITLE
MODKBEKBJ-695 Load Holdings: Add support for old statuses date format

### DIFF
--- a/src/main/java/org/folio/repository/holdings/status/HoldingsLoadingStatusFactory.java
+++ b/src/main/java/org/folio/repository/holdings/status/HoldingsLoadingStatusFactory.java
@@ -1,9 +1,8 @@
 package org.folio.repository.holdings.status;
 
+import static org.folio.rest.util.DateTimeUtil.getTimeNow;
 import static org.folio.rest.util.RestConstants.JSONAPI;
-import static org.folio.service.holdings.HoldingsServiceImpl.POSTGRES_TIMESTAMP_FORMATTER;
 
-import java.time.OffsetDateTime;
 import java.util.List;
 import org.folio.rest.jaxrs.model.HoldingsLoadingStatus;
 import org.folio.rest.jaxrs.model.JsonapiErrorResponse;
@@ -84,9 +83,5 @@ public final class HoldingsLoadingStatusFactory {
           .withUpdated(getTimeNow())
           .withErrors(errors)))
       .withJsonapi(JSONAPI);
-  }
-
-  private static String getTimeNow() {
-    return POSTGRES_TIMESTAMP_FORMATTER.format(OffsetDateTime.now());
   }
 }

--- a/src/main/java/org/folio/rest/util/DateTimeUtil.java
+++ b/src/main/java/org/folio/rest/util/DateTimeUtil.java
@@ -1,12 +1,13 @@
 package org.folio.rest.util;
 
+import lombok.experimental.UtilityClass;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
-import lombok.experimental.UtilityClass;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
  * Utility class to work with DateTime.

--- a/src/main/java/org/folio/rest/util/DateTimeUtil.java
+++ b/src/main/java/org/folio/rest/util/DateTimeUtil.java
@@ -1,0 +1,52 @@
+package org.folio.rest.util;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import lombok.experimental.UtilityClass;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Utility class to work with DateTime.
+ */
+@UtilityClass
+public class DateTimeUtil {
+
+  private static final Logger logger = LogManager.getLogger(DateTimeUtil.class);
+  private static final String PARSE_EXCEPTION_MESSAGE = "Error parsing string: {}. Trying to parse the old format";
+
+  public static final DateTimeFormatter POSTGRES_TIMESTAMP_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+  public static final DateTimeFormatter POSTGRES_OLD_TIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
+      .parseCaseInsensitive()
+      .append(DateTimeFormatter.ISO_LOCAL_DATE)
+      .appendLiteral(' ')
+      .append(DateTimeFormatter.ISO_LOCAL_TIME)
+      .appendOffset("+HH", "Z")
+      .toFormatter();
+
+  /**
+   * Retrieves current date time by default time-zone.
+   *
+   * @return String
+   */
+  public static String getTimeNow() {
+    return POSTGRES_TIMESTAMP_FORMATTER.format(OffsetDateTime.now());
+  }
+
+  /**
+   * Retrieves zoned date time. Supporting old format
+   *
+   * @param stringToParse date time string
+   * @return OffsetDateTime parsed from string
+   */
+  public static OffsetDateTime getZonedDateTime(String stringToParse) {
+    try {
+      return OffsetDateTime.parse(stringToParse, POSTGRES_TIMESTAMP_FORMATTER);
+    } catch (DateTimeParseException parseException) {
+      logger.warn(PARSE_EXCEPTION_MESSAGE, stringToParse);
+      return OffsetDateTime.parse(stringToParse, POSTGRES_OLD_TIMESTAMP_FORMATTER);
+    }
+  }
+}

--- a/src/main/java/org/folio/rest/util/DateTimeUtil.java
+++ b/src/main/java/org/folio/rest/util/DateTimeUtil.java
@@ -15,7 +15,7 @@ import org.apache.logging.log4j.Logger;
 public class DateTimeUtil {
 
   public static final DateTimeFormatter POSTGRES_TIMESTAMP_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-  public static final DateTimeFormatter POSTGRES_OLD_TIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
+  public static final DateTimeFormatter POSTGRES_TIMESTAMP_OLD_FORMATTER = new DateTimeFormatterBuilder()
       .parseCaseInsensitive()
       .append(DateTimeFormatter.ISO_LOCAL_DATE)
       .appendLiteral(' ')
@@ -47,7 +47,7 @@ public class DateTimeUtil {
       return OffsetDateTime.parse(stringToParse, POSTGRES_TIMESTAMP_FORMATTER);
     } catch (DateTimeParseException parseException) {
       logger.warn(PARSE_EXCEPTION_MESSAGE, stringToParse);
-      return OffsetDateTime.parse(stringToParse, POSTGRES_OLD_TIMESTAMP_FORMATTER);
+      return OffsetDateTime.parse(stringToParse, POSTGRES_TIMESTAMP_OLD_FORMATTER);
     }
   }
 }

--- a/src/main/java/org/folio/rest/util/DateTimeUtil.java
+++ b/src/main/java/org/folio/rest/util/DateTimeUtil.java
@@ -1,22 +1,18 @@
 package org.folio.rest.util;
 
-import lombok.experimental.UtilityClass;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import lombok.experimental.UtilityClass;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Utility class to work with DateTime.
  */
 @UtilityClass
 public class DateTimeUtil {
-
-  private static final Logger logger = LogManager.getLogger(DateTimeUtil.class);
-  private static final String PARSE_EXCEPTION_MESSAGE = "Error parsing string: {}. Trying to parse the old format";
 
   public static final DateTimeFormatter POSTGRES_TIMESTAMP_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
   public static final DateTimeFormatter POSTGRES_OLD_TIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
@@ -27,20 +23,24 @@ public class DateTimeUtil {
       .appendOffset("+HH", "Z")
       .toFormatter();
 
+  private static final Logger logger = LogManager.getLogger(DateTimeUtil.class);
+  private static final String PARSE_EXCEPTION_MESSAGE = "Error parsing string: {}. Trying to parse the old format";
+
   /**
    * Retrieves current date time by default time-zone.
    *
-   * @return String
+   * @return {@link String} of current date time
    */
   public static String getTimeNow() {
     return POSTGRES_TIMESTAMP_FORMATTER.format(OffsetDateTime.now());
   }
 
   /**
-   * Retrieves zoned date time. Supporting old format
+   * Parse string to zoned date time.
+   * Supporting old format.
    *
-   * @param stringToParse date time string
-   * @return OffsetDateTime parsed from string
+   * @param stringToParse - date time string
+   * @return {@link OffsetDateTime} parsed from string
    */
   public static OffsetDateTime getZonedDateTime(String stringToParse) {
     try {

--- a/src/main/java/org/folio/service/holdings/HoldingsServiceImpl.java
+++ b/src/main/java/org/folio/service/holdings/HoldingsServiceImpl.java
@@ -13,6 +13,7 @@ import static org.folio.repository.holdings.status.HoldingsLoadingStatusFactory.
 import static org.folio.repository.holdings.status.HoldingsLoadingStatusFactory.getStatusLoadingHoldings;
 import static org.folio.repository.holdings.status.HoldingsLoadingStatusFactory.getStatusNotStarted;
 import static org.folio.repository.holdings.status.HoldingsLoadingStatusFactory.getStatusPopulatingStagingArea;
+import static org.folio.rest.util.DateTimeUtil.getZonedDateTime;
 import static org.folio.rest.util.ErrorUtil.createError;
 import static org.folio.util.FutureUtils.failedFuture;
 import static org.folio.util.FutureUtils.mapVertxFuture;
@@ -24,7 +25,6 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.shareddata.Lock;
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
@@ -71,8 +71,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class HoldingsServiceImpl implements HoldingsService {
-
-  public static final DateTimeFormatter POSTGRES_TIMESTAMP_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
   private static final Logger logger = LogManager.getLogger(HoldingsServiceImpl.class);
   private static final String START_LOADING_LOCK = "getStatus";
@@ -488,9 +486,5 @@ public class HoldingsServiceImpl implements HoldingsService {
     OffsetDateTime updated = getZonedDateTime(updatedString);
     return isInProgress(status)
       && OffsetDateTime.now().isAfter(updated.plus(loadHoldingsTimeout, ChronoUnit.MILLIS));
-  }
-
-  private OffsetDateTime getZonedDateTime(String stringToParse) {
-    return OffsetDateTime.parse(stringToParse, POSTGRES_TIMESTAMP_FORMATTER);
   }
 }

--- a/src/test/java/org/folio/rest/impl/TransactionLoadHoldingsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/TransactionLoadHoldingsImplTest.java
@@ -27,7 +27,6 @@ import static org.folio.test.util.TestUtil.mockResponseList;
 import static org.folio.test.util.TestUtil.readFile;
 import static org.folio.util.HoldingsRetryStatusTestUtil.insertRetryStatus;
 import static org.folio.util.HoldingsStatusUtil.saveStatusNotStarted;
-import static org.folio.util.KbCredentialsTestUtil.STUB_CREDENTIALS_NAME;
 import static org.folio.util.KbCredentialsTestUtil.STUB_TOKEN_HEADER;
 import static org.folio.util.KbCredentialsTestUtil.saveKbCredentials;
 import static org.folio.util.KbTestUtil.clearDataFromTable;
@@ -372,8 +371,7 @@ public class TransactionLoadHoldingsImplTest extends WireMockTestBase {
   }
 
   public void setupDefaultLoadKbConfiguration() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveStatusNotStarted(STUB_CREDENTIALS_ID, vertx);
     insertRetryStatus(STUB_CREDENTIALS_ID, vertx);
   }

--- a/src/test/java/org/folio/rest/impl/integrationsuite/DefaultLoadHoldingsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/DefaultLoadHoldingsImplTest.java
@@ -12,13 +12,13 @@ import static org.folio.repository.kbcredentials.KbCredentialsTableConstants.KB_
 import static org.folio.rest.impl.RmApiConstants.RMAPI_HOLDINGS_STATUS_URL;
 import static org.folio.rest.impl.RmApiConstants.RMAPI_POST_HOLDINGS_URL;
 import static org.folio.rest.jaxrs.model.LoadStatusNameEnum.COMPLETED;
+import static org.folio.rest.util.DateTimeUtil.POSTGRES_TIMESTAMP_FORMATTER;
 import static org.folio.service.holdings.HoldingConstants.CREATE_SNAPSHOT_ACTION;
 import static org.folio.service.holdings.HoldingConstants.HOLDINGS_SERVICE_ADDRESS;
 import static org.folio.service.holdings.HoldingConstants.LOAD_FACADE_ADDRESS;
 import static org.folio.service.holdings.HoldingConstants.SAVE_HOLDINGS_ACTION;
 import static org.folio.service.holdings.HoldingConstants.SNAPSHOT_CREATED_ACTION;
 import static org.folio.service.holdings.HoldingConstants.SNAPSHOT_FAILED_ACTION;
-import static org.folio.service.holdings.HoldingsServiceImpl.POSTGRES_TIMESTAMP_FORMATTER;
 import static org.folio.test.util.TestUtil.STUB_TENANT;
 import static org.folio.test.util.TestUtil.mockGet;
 import static org.folio.test.util.TestUtil.mockResponseList;

--- a/src/test/java/org/folio/rest/impl/integrationsuite/DefaultLoadServiceFacadeTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/DefaultLoadServiceFacadeTest.java
@@ -16,7 +16,6 @@ import static org.folio.test.util.TestUtil.readFile;
 import static org.folio.test.util.TestUtil.readJsonFile;
 import static org.folio.util.HoldingsRetryStatusTestUtil.insertRetryStatus;
 import static org.folio.util.HoldingsStatusUtil.saveStatusNotStarted;
-import static org.folio.util.KbCredentialsTestUtil.STUB_CREDENTIALS_NAME;
 import static org.folio.util.KbCredentialsTestUtil.saveKbCredentials;
 import static org.folio.util.KbTestUtil.clearDataFromTable;
 import static org.folio.util.KbTestUtil.interceptAndStop;
@@ -120,8 +119,7 @@ public class DefaultLoadServiceFacadeTest extends WireMockTestBase {
   }
 
   private void setupDefaultLoadKbConfiguration() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveStatusNotStarted(STUB_CREDENTIALS_ID, vertx);
     insertRetryStatus(STUB_CREDENTIALS_ID, vertx);
   }

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsProxyTypesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsProxyTypesImplTest.java
@@ -44,8 +44,7 @@ public class EholdingsProxyTypesImplTest extends WireMockTestBase {
   @Test
   public void shouldReturnProxyTypesWhenUserAssignedToKbCredentials()
     throws IOException, URISyntaxException, JSONException {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveAssignedUser(JOHN_ID, STUB_CREDENTIALS_ID, vertx);
 
     mockGet(new RegexPattern(RMAPI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-response.json");
@@ -59,8 +58,7 @@ public class EholdingsProxyTypesImplTest extends WireMockTestBase {
   @Test
   public void shouldReturnProxyTypesWhenOneCredentialsExistsAndUserNotAssigned()
     throws IOException, URISyntaxException, JSONException {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
 
     mockGet(new RegexPattern(RMAPI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-response.json");
 
@@ -73,8 +71,7 @@ public class EholdingsProxyTypesImplTest extends WireMockTestBase {
   @Test
   public void shouldReturnEmptyProxyTypesFromEmptyRmApiResponse()
     throws IOException, URISyntaxException, JSONException {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveAssignedUser(JOHN_ID, STUB_CREDENTIALS_ID, vertx);
     mockGet(new RegexPattern(RMAPI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-empty-response.json");
 
@@ -86,8 +83,7 @@ public class EholdingsProxyTypesImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn404WhenUserNotAssignedToKbCredentials() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveAssignedUser(JOHN_ID, STUB_CREDENTIALS_ID, vertx);
     KbCredentialsTestUtil
       .saveKbCredentials(getWiremockUrl(), STUB_CREDENTIALS_NAME + "1", STUB_API_KEY, "OTHER_CUSTOMER_ID", vertx);
@@ -108,8 +104,7 @@ public class EholdingsProxyTypesImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn401WhenRmApiRequestCompletesWith401ErrorStatus() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveAssignedUser(JOHN_ID, STUB_CREDENTIALS_ID, vertx);
 
     mockGet(new RegexPattern(RMAPI_PROXIES_URL), SC_UNAUTHORIZED);
@@ -120,8 +115,7 @@ public class EholdingsProxyTypesImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn403WhenRmApiRequestCompletesWith403ErrorStatus() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveAssignedUser(JOHN_ID, STUB_CREDENTIALS_ID, vertx);
 
     mockGet(new RegexPattern(RMAPI_PROXIES_URL), SC_FORBIDDEN);
@@ -132,8 +126,7 @@ public class EholdingsProxyTypesImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturnProxyTypesCollection() throws IOException, URISyntaxException, JSONException {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
 
     mockGet(new RegexPattern(RMAPI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-response.json");
 
@@ -146,8 +139,7 @@ public class EholdingsProxyTypesImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturnEmptyCollection() throws IOException, URISyntaxException, JSONException {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
 
     mockGet(new RegexPattern(RMAPI_PROXIES_URL), "responses/rmapi/proxytypes/get-proxy-types-response.json");
 
@@ -160,8 +152,7 @@ public class EholdingsProxyTypesImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn401WhenRmApiReturns401ErrorStatus() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveAssignedUser(JOHN_ID, STUB_CREDENTIALS_ID, vertx);
 
     mockGet(new RegexPattern(RMAPI_PROXIES_URL), SC_UNAUTHORIZED);
@@ -172,8 +163,7 @@ public class EholdingsProxyTypesImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn403WhenRmApiReturns403ErrorStatus() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveAssignedUser(JOHN_ID, STUB_CREDENTIALS_ID, vertx);
 
     mockGet(new RegexPattern(RMAPI_PROXIES_URL), SC_FORBIDDEN);

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsRootProxyImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsRootProxyImplTest.java
@@ -59,8 +59,7 @@ public class EholdingsRootProxyImplTest extends WireMockTestBase {
   @Test
   public void shouldReturnRootProxyWhenUserAssignedToKbCredentials()
     throws IOException, URISyntaxException, JSONException {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveAssignedUser(JOHN_ID, STUB_CREDENTIALS_ID, vertx);
 
     mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), RMAPI_ROOT_PROXY_CUSTOM_LABELS_RESPONSE);
@@ -74,8 +73,7 @@ public class EholdingsRootProxyImplTest extends WireMockTestBase {
   @Test
   public void shouldReturnRootProxyWhenOneCredentialsExistsAndUserNotAssigned()
     throws IOException, URISyntaxException, JSONException {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
 
     mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), RMAPI_ROOT_PROXY_CUSTOM_LABELS_RESPONSE);
 
@@ -87,8 +85,7 @@ public class EholdingsRootProxyImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn404WhenUserNotAssignedToKbCredentials() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveAssignedUser(JOHN_ID, STUB_CREDENTIALS_ID, vertx);
     saveKbCredentials(getWiremockUrl(), STUB_CREDENTIALS_NAME + "1", STUB_API_KEY, "OTHER_CUSTOMER_ID", vertx);
 
@@ -108,8 +105,7 @@ public class EholdingsRootProxyImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn401WhenRmApiRequestCompletesWith401ErrorStatus() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveAssignedUser(JOHN_ID, STUB_CREDENTIALS_ID, vertx);
 
     mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), SC_UNAUTHORIZED);
@@ -120,8 +116,7 @@ public class EholdingsRootProxyImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn403WhenRmApiRequestCompletesWith403ErrorStatus() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveAssignedUser(JOHN_ID, STUB_CREDENTIALS_ID, vertx);
 
     mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), SC_FORBIDDEN);
@@ -133,8 +128,7 @@ public class EholdingsRootProxyImplTest extends WireMockTestBase {
   @Test
   public void shouldReturnRootProxyWhenUserAssignedToCredentials()
     throws IOException, URISyntaxException, JSONException {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveAssignedUser(JOHN_ID, STUB_CREDENTIALS_ID, vertx);
 
     mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), RMAPI_ROOT_PROXY_CUSTOM_LABELS_RESPONSE);
@@ -148,8 +142,7 @@ public class EholdingsRootProxyImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn401WhenRmApiReturns401ErrorStatus() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveAssignedUser(JOHN_ID, STUB_CREDENTIALS_ID, vertx);
 
     mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), SC_UNAUTHORIZED);
@@ -160,8 +153,7 @@ public class EholdingsRootProxyImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn403WhenRmApiReturns403ErrorStatus() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveAssignedUser(JOHN_ID, STUB_CREDENTIALS_ID, vertx);
 
     mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), SC_FORBIDDEN);
@@ -180,8 +172,7 @@ public class EholdingsRootProxyImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturnUpdatedProxyOnSuccessfulPut() throws IOException, URISyntaxException, JSONException {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     String stubResponseFile = "responses/rmapi/proxiescustomlabels/get-updated-response.json";
 
     mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), stubResponseFile);
@@ -204,8 +195,7 @@ public class EholdingsRootProxyImplTest extends WireMockTestBase {
     String stubGetResponseFile = "responses/rmapi/proxiescustomlabels/get-updated-response.json";
     String stubPutResponseFile = "responses/rmapi/proxiescustomlabels/put-400-error-response.json";
 
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
 
     mockGet(new EqualToPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), stubGetResponseFile);
     stubFor(
@@ -230,8 +220,7 @@ public class EholdingsRootProxyImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn401WhenRmApiReturns401() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
 
     mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), SC_UNAUTHORIZED);
     final String path = String.format(EHOLDINGS_ROOT_PROXY_BY_CREDENTIALS_ID_URL, STUB_CREDENTIALS_ID);
@@ -241,8 +230,7 @@ public class EholdingsRootProxyImplTest extends WireMockTestBase {
 
   @Test
   public void shouldReturn403WhenRmApiReturns403() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
 
     mockGet(new RegexPattern(RMAPI_ROOT_PROXY_CUSTOM_LABELS_URL), SC_FORBIDDEN);
     final String path = String.format(EHOLDINGS_ROOT_PROXY_BY_CREDENTIALS_ID_URL, STUB_CREDENTIALS_ID);

--- a/src/test/java/org/folio/rest/impl/integrationsuite/LoadHoldingsStatusImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/LoadHoldingsStatusImplTest.java
@@ -14,11 +14,11 @@ import static org.folio.rest.impl.integrationsuite.DefaultLoadHoldingsImplTest.H
 import static org.folio.rest.impl.integrationsuite.DefaultLoadHoldingsImplTest.handleStatusChange;
 import static org.folio.rest.jaxrs.model.LoadStatusNameEnum.COMPLETED;
 import static org.folio.rest.jaxrs.model.LoadStatusNameEnum.FAILED;
+import static org.folio.rest.util.DateTimeUtil.POSTGRES_TIMESTAMP_FORMATTER;
 import static org.folio.service.holdings.HoldingConstants.CREATE_SNAPSHOT_ACTION;
 import static org.folio.service.holdings.HoldingConstants.HOLDINGS_SERVICE_ADDRESS;
 import static org.folio.service.holdings.HoldingConstants.LOAD_FACADE_ADDRESS;
 import static org.folio.service.holdings.HoldingConstants.SNAPSHOT_CREATED_ACTION;
-import static org.folio.service.holdings.HoldingsServiceImpl.POSTGRES_TIMESTAMP_FORMATTER;
 import static org.folio.test.util.TestUtil.mockGet;
 import static org.folio.test.util.TestUtil.mockResponseList;
 import static org.folio.test.util.TestUtil.readFile;

--- a/src/test/java/org/folio/rest/impl/integrationsuite/LoadHoldingsStatusImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/LoadHoldingsStatusImplTest.java
@@ -24,7 +24,6 @@ import static org.folio.test.util.TestUtil.mockResponseList;
 import static org.folio.test.util.TestUtil.readFile;
 import static org.folio.util.HoldingsRetryStatusTestUtil.insertRetryStatus;
 import static org.folio.util.HoldingsStatusUtil.saveStatusNotStarted;
-import static org.folio.util.KbCredentialsTestUtil.STUB_CREDENTIALS_NAME;
 import static org.folio.util.KbCredentialsTestUtil.STUB_TOKEN_HEADER;
 import static org.folio.util.KbCredentialsTestUtil.saveKbCredentials;
 import static org.folio.util.KbTestUtil.clearDataFromTable;
@@ -197,8 +196,7 @@ public class LoadHoldingsStatusImplTest extends WireMockTestBase {
   }
 
   public void setupDefaultLoadKbConfiguration() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveStatusNotStarted(STUB_CREDENTIALS_ID, vertx);
     insertRetryStatus(STUB_CREDENTIALS_ID, vertx);
   }

--- a/src/test/java/org/folio/rest/impl/integrationsuite/TransactionLoadServiceFacadeTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/TransactionLoadServiceFacadeTest.java
@@ -17,7 +17,6 @@ import static org.folio.test.util.TestUtil.readFile;
 import static org.folio.test.util.TestUtil.readJsonFile;
 import static org.folio.util.HoldingsRetryStatusTestUtil.insertRetryStatus;
 import static org.folio.util.HoldingsStatusUtil.saveStatusNotStarted;
-import static org.folio.util.KbCredentialsTestUtil.STUB_CREDENTIALS_NAME;
 import static org.folio.util.KbCredentialsTestUtil.saveKbCredentials;
 import static org.folio.util.KbTestUtil.clearDataFromTable;
 import static org.folio.util.KbTestUtil.interceptAndStop;
@@ -182,8 +181,7 @@ public class TransactionLoadServiceFacadeTest extends WireMockTestBase {
   }
 
   private void setupDefaultLoadKbConfiguration() {
-    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID,
-      vertx);
+    saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveStatusNotStarted(STUB_CREDENTIALS_ID, vertx);
     insertRetryStatus(STUB_CREDENTIALS_ID, vertx);
   }

--- a/src/test/java/org/folio/util/KbCredentialsTestUtil.java
+++ b/src/test/java/org/folio/util/KbCredentialsTestUtil.java
@@ -74,6 +74,10 @@ public class KbCredentialsTestUtil {
     return saveKbCredentials(UUID.randomUUID().toString(), url, name, apiKey, customerId, vertx);
   }
 
+  public static String saveKbCredentials(String id, String url, Vertx vertx) {
+    return saveKbCredentials(id, url, STUB_CREDENTIALS_NAME, STUB_API_KEY, STUB_CUSTOMER_ID, vertx);
+  }
+
   public static String saveKbCredentials(String id, String url, String name, String apiKey, String customerId,
                                          Vertx vertx) {
     CompletableFuture<ResultSet> future = new CompletableFuture<>();


### PR DESCRIPTION
## Purpose
The POSTGRES_TIMESTAMP_FORMATTER was updated in this PR: [MODKBEKBJ-440](https://github.com/folio-org/mod-kb-ebsco-java/pull/279/files#diff-051a7849d7c856add5af3e74e03a2f09949f32dc49c55c6cd83e6cf187fbc4b8R77).
But some of the clients still have saved old date format in their data bases. So we should support this old format

## Approach
- Add utility class to works with DateTime
- Trying to parse date by old format if there is parse exception  

### Learning
https://issues.folio.org/browse/MODKBEKBJ-695
