### PR TITLE
MODKBEKBJ-697 Load Holdings: increase size of publication_title field

### DIFF
--- a/src/main/resources/liquibase/tenant/changelog-3.12.0.xml
+++ b/src/main/resources/liquibase/tenant/changelog-3.12.0.xml
@@ -1,0 +1,7 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+  <include file="liquibase/tenant/scripts/v3.12.0/increase-holdings-title-size.xml"/>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/tenant/changelog-3.12.0.xml
+++ b/src/main/resources/liquibase/tenant/changelog-3.12.0.xml
@@ -3,5 +3,5 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-  <include file="liquibase/tenant/scripts/v3.12.0/increase-holdings-title-size.xml"/>
+  <include file="liquibase/tenant/scripts/v3.12.0/increase-holdings-publication-title-size.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/liquibase/tenant/changelog.xml
+++ b/src/main/resources/liquibase/tenant/changelog.xml
@@ -9,4 +9,5 @@
   <include file="liquibase/tenant/changelog-3.6.0.xml"/>
   <include file="liquibase/tenant/changelog-3.6.6.xml"/>
   <include file="liquibase/tenant/changelog-3.11.0.xml"/>
+  <include file="liquibase/tenant/changelog-3.12.0.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/liquibase/tenant/scripts/v3.12.0/increase-holdings-publication-title-size.xml
+++ b/src/main/resources/liquibase/tenant/scripts/v3.12.0/increase-holdings-publication-title-size.xml
@@ -3,7 +3,7 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 
-  <changeSet id="MODKBEKBJ-697@@increase-size-of-publication_title-field" author="Shans-Kaluhin">
+  <changeSet id="MODKBEKBJ-697@@increase-size-of-publication-title-field" author="Shans-Kaluhin">
     <modifyDataType tableName="holdings" columnName="publication_title" newDataType="varchar(400)"/>
   </changeSet>
 

--- a/src/main/resources/liquibase/tenant/scripts/v3.12.0/increase-holdings-title-size.xml
+++ b/src/main/resources/liquibase/tenant/scripts/v3.12.0/increase-holdings-title-size.xml
@@ -1,0 +1,10 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+  <changeSet id="MODKBEKBJ-697@@increase-size-of-publication_title-field" author="Shans-Kaluhin">
+    <modifyDataType tableName="holdings" columnName="publication_title" newDataType="varchar(400)"/>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Purpose
While downloading loaded holdings some of holdings have a large publication_title value. (less then 400 characters).

## Approach
- increase size of publication_title field to 400 characters (was 300)

### Learning
https://issues.folio.org/browse/MODKBEKBJ-697
