### PR TITLE
MODKBEKBJ-702: Vert.x 4.3.4, RMB 35.0.3, Jackson 2.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,17 +34,17 @@
   </licenses>
 
   <properties>
-    <rmb.version>35.0.0</rmb.version>
+    <rmb.version>35.0.3</rmb.version>
     <folio-di-support.version>1.8.0-SNAPSHOT</folio-di-support.version>
     <folio-service-tools.version>1.10.0</folio-service-tools.version>
     <folio-holdingsiq-client.version>2.3.0-SNAPSHOT</folio-holdingsiq-client.version>
     <folio-liquibase-util.version>1.6.0-SNAPSHOT</folio-liquibase-util.version>
     <mod-configuration-client.version>5.9.1-SNAPSHOT</mod-configuration-client.version>
 
-    <vertx.version>4.3.3</vertx.version>
+    <vertx.version>4.3.4</vertx.version>
     <aspectj.version>1.9.9.1</aspectj.version>
     <spring.version>5.3.23</spring.version>
-    <jackson.version>2.13.4</jackson.version>
+    <jackson.version>2.14.0</jackson.version>
     <postgresql.version>42.5.0</postgresql.version>
     <commons-configuration2.version>2.8.0</commons-configuration2.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
@@ -113,6 +113,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>${vertx.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -135,22 +142,18 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
-      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-service-proxy</artifactId>
-      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
-      <version>${vertx.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -259,7 +262,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>${vertx.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
On some machines the build of master fails:

```
[ERROR] Errors:
[ERROR]   IntegrationTestSuite.setUpClass:57 ? NoClassDefFound io/vertx/core/net/impl/NetClientBuilder
[ERROR]   TransactionLoadHoldingsImplTest.setUpClass:128->WireMockTestBase.setUpClass:82->TestBase.setUpClass:76 ? NoClassDefFound io/vertx/core/net/impl/NetClientBuilder
[ERROR]   LocaleSettingsServiceImplTest>WireMockTestBase.setUpClass:82->TestBase.setUpClass:76 ? NoClassDefFound io/vertx/core/net/impl/NetClientBuilder
[ERROR]   UcAuthServiceImplTest>WireMockTestBase.setUpClass:82->TestBase.setUpClass:76 ? NoClassDefFound io/vertx/core/net/impl/NetClientBuilder
[INFO]
[ERROR] Tests run: 195, Failures: 0, Errors: 4, Skipped: 0
```

This is fixed by bumping Vert.x from 4.3.3 to 4.3.4. The bug might be caused by mixing Vertx versions:

```
mvn dependency:tree -Dincludes=io.vertx

[INFO] org.folio:mod-kb-ebsco-java:jar:3.13.0-SNAPSHOT
[INFO] +- org.folio:domain-models-runtime:jar:35.0.0:compile
[INFO] |  +- io.vertx:vertx-web-client:jar:4.3.4:compile
[INFO] |  |  \- io.vertx:vertx-uri-template:jar:4.3.4:compile
[INFO] |  +- io.vertx:vertx-micrometer-metrics:jar:4.3.4:compile
[INFO] |  \- io.vertx:vertx-pg-client:jar:4.3.4:compile
[INFO] |     \- io.vertx:vertx-sql-client:jar:4.3.4:compile
[INFO] +- io.vertx:vertx-core:jar:4.3.3:compile
[INFO] +- io.vertx:vertx-web:jar:4.3.3:compile
[INFO] |  +- io.vertx:vertx-web-common:jar:4.3.3:compile
[INFO] |  +- io.vertx:vertx-auth-common:jar:4.3.3:compile
[INFO] |  \- io.vertx:vertx-bridge-common:jar:4.3.3:compile
[INFO] +- io.vertx:vertx-service-proxy:jar:4.3.3:compile
[INFO] +- io.vertx:vertx-codegen:jar:4.3.3:provided
[INFO] \- io.vertx:vertx-unit:jar:4.3.3:test
```

https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md#rmb-945-vertx-434 warns that RMB 35.0.0 is NOT compatible with Vert.x 4.3.4. Therefore we need to bump RMB from 35.0.0 to 35.0.3.

Upgrade jackson from 2.13.4 to 2.14.0 to fix this vulnerability: Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2022-42003