### PR TITLE
MODKBEKBJ-708 - Missing permission to see and use "Access status type" feature in "eHoldings" app

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -296,7 +296,7 @@
           "methods": ["GET"],
           "pathPattern": "/eholdings/access-types",
           "permissionsRequired": ["kb-ebsco.access-types.collection.get"],
-          "modulePermissions": ["users.item.get"]
+          "modulePermissions": ["users.collection.get"]
         },
         {
           "methods": ["GET"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -295,7 +295,8 @@
         {
           "methods": ["GET"],
           "pathPattern": "/eholdings/access-types",
-          "permissionsRequired": ["kb-ebsco.access-types.collection.get"]
+          "permissionsRequired": ["kb-ebsco.access-types.collection.get"],
+          "modulePermissions": ["users.item.get"]
         },
         {
           "methods": ["GET"],


### PR DESCRIPTION
## Purpose
_Missing permission to see and use "Access status type" feature in "eHoldings" app._

## Approach
_Add "modulePermissions": ["users.collection.get"] to handler GET /eholdings/access-types_

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [X] Permissions changed, added, or removed

### Learning
https://issues.folio.org/browse/MODKBEKBJ-708