### PR TITLE
MODKBEKBJ-711: Upgrade netty, postgresql, opencsv fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,12 @@
     <mod-configuration-client.version>5.9.1-SNAPSHOT</mod-configuration-client.version>
 
     <vertx.version>4.3.4</vertx.version>
+    <!-- remove the netty.version dependency after upgrading to vertx.version >= 4.3.7 -->
+    <netty.version>4.1.86.Final</netty.version>
     <aspectj.version>1.9.9.1</aspectj.version>
     <spring.version>5.3.23</spring.version>
     <jackson.version>2.14.0</jackson.version>
-    <postgresql.version>42.5.0</postgresql.version>
+    <postgresql.version>42.5.1</postgresql.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-configuration2.version>2.8.0</commons-configuration2.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
@@ -53,7 +55,7 @@
     <httpcore.version>4.4.15</httpcore.version>
     <log4j.version>2.19.0</log4j.version>
     <jetbrains-annotations.version>23.0.0</jetbrains-annotations.version>
-    <opencsv.version>5.7.0</opencsv.version>
+    <opencsv.version>5.7.1</opencsv.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <validation-api.version>2.0.1.Final</validation-api.version>
 
@@ -107,6 +109,14 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- remove the netty-bom dependency after upgrading to vertx.version >= 4.3.7 -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
@@ -164,6 +174,11 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.opencsv</groupId>
+      <artifactId>opencsv</artifactId>
+      <version>${opencsv.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
@@ -247,11 +262,6 @@
       <artifactId>annotations</artifactId>
       <version>${jetbrains-annotations.version}</version>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.opencsv</groupId>
-      <artifactId>opencsv</artifactId>
-      <version>${opencsv.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Upgrade netty from 4.1.82.Final to 4.1.86.Final fixing HTTP Response Splitting:

https://nvd.nist.gov/vuln/detail/CVE-2022-41915

Upgrade opencsv from 5.7.0 to 5.7.1.

The opencsv upgrade indirectly upgrades commons-text from 1.9 to 1.10.0. The opencsv dependencies is moved before the commons-configuration2 dependency that would otherwise enforce commons-text 1.9.

The commons-text upgrade fixes Arbitrary Code Execution:

https://nvd.nist.gov/vuln/detail/CVE-2022-42889

Upgrading postgresql from 42.5.0 to 42.5.1 fixes Information Exposure:

https://nvd.nist.gov/vuln/detail/CVE-2022-41946 