### PR TITLE
MODKBEKBJ-713 Load holdings: process failing after exceeding status request retries

### DIFF
--- a/src/main/java/org/folio/service/holdings/AbstractLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/AbstractLoadServiceFacade.java
@@ -6,6 +6,7 @@ import static org.folio.repository.holdings.HoldingsServiceMessagesFactory.getSn
 import static org.folio.repository.holdings.HoldingsServiceMessagesFactory.getSnapshotFailedMessage;
 import static org.folio.repository.holdings.LoadStatus.COMPLETED;
 import static org.folio.repository.holdings.LoadStatus.IN_PROGRESS;
+import static org.folio.repository.holdings.LoadStatus.NONE;
 import static org.folio.service.holdings.HoldingConstants.HOLDINGS_SERVICE_ADDRESS;
 
 import io.vertx.core.Vertx;
@@ -137,7 +138,7 @@ public abstract class AbstractLoadServiceFacade implements LoadServiceFacade {
           } else {
             future.complete(loadStatus);
           }
-        } else if (IN_PROGRESS.equals(status)) {
+        } else if (IN_PROGRESS.equals(status) || NONE.equals(status)) {
           if (retries <= 1) {
             throw new IllegalStateException("Failed to get status with status response: " + loadStatus.getStatus());
           }

--- a/src/main/java/org/folio/service/holdings/AbstractLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/AbstractLoadServiceFacade.java
@@ -98,14 +98,14 @@ public abstract class AbstractLoadServiceFacade implements LoadServiceFacade {
   protected abstract CompletableFuture<Void> loadHoldings(LoadHoldingsMessage message, LoadService loadingService);
 
   private CompletableFuture<HoldingsStatus> populateHoldingsIfNecessary(LoadService loadingService) {
-    return waitForStatus(statusRetryCount, loadingService).thenCompose(loadStatus -> {
+    return getLastLoadingStatus(loadingService).thenCompose(loadStatus -> {
       if (IN_PROGRESS.equals(loadStatus.getStatus())) {
         return waitForCompleteStatus(statusRetryCount, loadStatus.getTransactionId(), loadingService);
       } else if (snapshotCreatedRecently(loadStatus)) {
         logger.info("Snapshot created recently: {}", loadStatus);
         final Integer totalCount = loadStatus.getTotalCount();
         if (INTEGER_ZERO.equals(totalCount)) {
-          throw new IllegalStateException("Snapshot created with invalid totalCount:" + loadStatus);
+          throw new IllegalStateException("Snapshot created with invalid totalCount: " + loadStatus);
         } else {
           return CompletableFuture.completedFuture(loadStatus);
         }
@@ -115,30 +115,6 @@ public abstract class AbstractLoadServiceFacade implements LoadServiceFacade {
           .thenCompose(transactionId -> waitForCompleteStatus(statusRetryCount, transactionId, loadingService));
       }
     });
-  }
-
-  private CompletableFuture<HoldingsStatus> waitForStatus(int retryCount, LoadService loadingService) {
-    var future = new CompletableFuture<HoldingsStatus>();
-    waitForStatus(retryCount, future, loadingService);
-    return future;
-  }
-
-  private void waitForStatus(int retries, CompletableFuture<HoldingsStatus> future, LoadService loadingService) {
-    vertx.setTimer(statusRetryDelay, timerId -> getLastLoadingStatus(loadingService)
-      .thenAccept(loadStatus -> {
-        if (loadStatus == null) {
-          logger.info("Received null status of stage snapshot. Retrying...");
-          if (retries <= 1) {
-            throw new IllegalStateException("Retries exceeded but status is still null");
-          }
-          waitForStatus(retries - 1, future, loadingService);
-        } else {
-          future.complete(loadStatus);
-        }
-      }).exceptionally(throwable -> {
-        future.completeExceptionally(throwable);
-        return null;
-      }));
   }
 
   private CompletableFuture<HoldingsStatus> waitForCompleteStatus(int retryCount, String transactionId,
@@ -153,22 +129,22 @@ public abstract class AbstractLoadServiceFacade implements LoadServiceFacade {
     vertx.setTimer(statusRetryDelay, timerId -> getLoadingStatus(loadingService, transactionId)
       .thenAccept(loadStatus -> {
         final LoadStatus status = loadStatus.getStatus();
-        logger.info("Getting status of stage snapshot: {}.", status);
+        logger.info("Getting status of stage snapshot: {}", status);
         if (COMPLETED.equals(status)) {
           final Integer totalCount = loadStatus.getTotalCount();
           if (INTEGER_ZERO.equals(totalCount)) {
-            throw new IllegalStateException("Snapshot created with invalid totalCount:" + loadStatus);
+            throw new IllegalStateException("Snapshot created with invalid totalCount: " + loadStatus);
           } else {
             future.complete(loadStatus);
           }
         } else if (IN_PROGRESS.equals(status)) {
           if (retries <= 1) {
-            throw new IllegalStateException("Failed to get status with status response:" + loadStatus.getStatus());
+            throw new IllegalStateException("Failed to get status with status response: " + loadStatus.getStatus());
           }
           waitForCompleteStatus(retries - 1, transactionId, future, loadingService);
         } else {
           future.completeExceptionally(
-            new IllegalStateException("Failed to get status with status response:" + loadStatus));
+            new IllegalStateException("Failed to get status with status response: " + loadStatus));
         }
       }).exceptionally(throwable -> {
         future.completeExceptionally(throwable);

--- a/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
@@ -59,13 +59,19 @@ public class DefaultLoadServiceFacade extends AbstractLoadServiceFacade {
 
   private HoldingsStatus mapToStatus(HoldingsLoadStatus status) {
     if (status == null) {
-      return null;
+      return createNoneStatus();
     }
 
     return HoldingsStatus.builder()
       .created(status.getCreated())
       .status(LoadStatus.fromValue(status.getStatus()))
       .totalCount(status.getTotalCount())
+      .build();
+  }
+
+  private HoldingsStatus createNoneStatus() {
+    return HoldingsStatus.builder()
+      .status(LoadStatus.NONE)
       .build();
   }
 }

--- a/src/test/java/org/folio/rest/impl/integrationsuite/DefaultLoadHoldingsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/DefaultLoadHoldingsImplTest.java
@@ -174,7 +174,8 @@ public class DefaultLoadHoldingsImplTest extends WireMockTestBase {
   }
 
   @Test
-  public void shouldSaveMultiHoldingsWhenSnapshotNotCreated(TestContext context) throws IOException, URISyntaxException {
+  public void shouldSaveMultiHoldingsWhenSnapshotNotCreated(TestContext context)
+    throws IOException, URISyntaxException {
     setupDefaultLoadKbConfiguration();
     Async async = context.async();
     handleStatusChange(COMPLETED, holdingsStatusRepository, o -> async.complete());

--- a/src/test/java/org/folio/rest/impl/integrationsuite/DefaultLoadHoldingsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/DefaultLoadHoldingsImplTest.java
@@ -174,6 +174,32 @@ public class DefaultLoadHoldingsImplTest extends WireMockTestBase {
   }
 
   @Test
+  public void shouldSaveMultiHoldingsWhenSnapshotNotCreated(TestContext context) throws IOException, URISyntaxException {
+    setupDefaultLoadKbConfiguration();
+    Async async = context.async();
+    handleStatusChange(COMPLETED, holdingsStatusRepository, o -> async.complete());
+
+    ResponseDefinitionBuilder emptyResponse = new ResponseDefinitionBuilder()
+      .withBody("");
+    ResponseDefinitionBuilder successfulResponse = new ResponseDefinitionBuilder()
+      .withBody(readFile(RMAPI_RESPONSE_HOLDINGS_STATUS_COMPLETED));
+
+    mockResponseList(new UrlPathPattern(new EqualToPattern(RMAPI_HOLDINGS_STATUS_URL), false),
+      emptyResponse,
+      successfulResponse);
+
+    mockPostHoldings();
+    mockGet(new RegexPattern(RMAPI_POST_HOLDINGS_URL), RMAPI_RESPONSE_HOLDINGS);
+
+    postWithStatus(HOLDINGS_LOAD_URL, "", SC_NO_CONTENT, STUB_TOKEN_HEADER);
+
+    async.await(TIMEOUT);
+
+    final List<DbHoldingInfo> holdingsList = HoldingsTestUtil.getHoldings(vertx);
+    assertThat(holdingsList.size(), Matchers.notNullValue());
+  }
+
+  @Test
   public void shouldNotStartLoadingWhenStatusInProgress() {
     saveKbCredentials(STUB_CREDENTIALS_ID, getWiremockUrl(), vertx);
     saveStatus(STUB_CREDENTIALS_ID, getStatusLoadingHoldings(1000, 500, 10, 5), PROCESS_ID, vertx);

--- a/src/test/java/org/folio/rest/impl/integrationsuite/DefaultLoadHoldingsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/DefaultLoadHoldingsImplTest.java
@@ -180,12 +180,15 @@ public class DefaultLoadHoldingsImplTest extends WireMockTestBase {
     Async async = context.async();
     handleStatusChange(COMPLETED, holdingsStatusRepository, o -> async.complete());
 
+    ResponseDefinitionBuilder errorResponse = new ResponseDefinitionBuilder()
+      .withStatus(500);
     ResponseDefinitionBuilder emptyResponse = new ResponseDefinitionBuilder()
       .withBody("");
     ResponseDefinitionBuilder successfulResponse = new ResponseDefinitionBuilder()
       .withBody(readFile(RMAPI_RESPONSE_HOLDINGS_STATUS_COMPLETED));
 
     mockResponseList(new UrlPathPattern(new EqualToPattern(RMAPI_HOLDINGS_STATUS_URL), false),
+      errorResponse,
       emptyResponse,
       successfulResponse);
 

--- a/src/test/java/org/folio/service/holdings/DefaultLoadServiceFacadeTest.java
+++ b/src/test/java/org/folio/service/holdings/DefaultLoadServiceFacadeTest.java
@@ -1,6 +1,7 @@
 package org.folio.service.holdings;
 
-import static org.junit.Assert.assertNull;
+import static org.folio.repository.holdings.LoadStatus.NONE;
+import static org.junit.Assert.assertEquals;
 
 import io.vertx.core.Vertx;
 import java.util.concurrent.CompletableFuture;
@@ -32,7 +33,6 @@ public class DefaultLoadServiceFacadeTest {
       .thenReturn(CompletableFuture.completedFuture(null));
 
     var result = defaultLoadServiceFacade.getLastLoadingStatus(loadService);
-    assertNull(result.get());
+    assertEquals(NONE, result.get().getStatus());
   }
-
 }


### PR DESCRIPTION
## Purpose
If job was not started, HoldingsIQ will response with empty status body

## Approach
Return NONE status if status is null. So the job can be started

### Learning
https://issues.folio.org/browse/MODKBEKBJ-713
