### PR TITLE
MODKBEKBJ-732: Update the module for Java 17 & the latest dependencies

### DIFF
--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -2,7 +2,7 @@ stages:
   - name: Build
     steps:
       - runScriptConfig:
-          image: maven:3-openjdk-11
+          image: maven:3-openjdk-17
           shellScript: mvn package -DskipTests
   - name: Build Docker with DIND
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM folioci/alpine-jre-openjdk17:latest
 
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
+
 ENV VERTICLE_FILE mod-kb-ebsco-java-fat.jar
 
 # Set the location of the verticles

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 FROM folioci/alpine-jre-openjdk17:latest
 
-# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
-USER root
-RUN apk upgrade --no-cache
-USER folio
-
 ENV VERTICLE_FILE mod-kb-ebsco-java-fat.jar
 
 # Set the location of the verticles

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM folioci/alpine-jre-openjdk11:latest
+FROM folioci/alpine-jre-openjdk17:latest
+
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
 
 ENV VERTICLE_FILE mod-kb-ebsco-java-fat.jar
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ buildMvn {
     buildJavaDocker {
       publishMaster = 'yes'
       healthChk = 'yes'
-      healthChkCmd = 'curl -sS --fail -o /dev/null  http://localhost:8081/apidocs/ || exit 1'
+      healthChkCmd = 'wget --no-verbose --tries=1 --spider http://localhost:8081/admin/health || exit 1'
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 buildMvn {
   publishModDescriptor = 'yes'
   mvnDeploy = 'yes'
-  buildNode =  'jenkins-agent-java11'
+  buildNode =  'jenkins-agent-java17'
 
   doApiLint = true
   doApiDoc = true
@@ -12,7 +12,7 @@ buildMvn {
     buildJavaDocker {
       publishMaster = 'yes'
       healthChk = 'yes'
-      healthChkCmd = 'curl -sS --fail -o /dev/null  http://localhost:8081/apidocs/ || exit 1'
+      healthChkCmd = 'wget --no-verbose --tries=1 --spider http://localhost:8081/admin/health || exit 1'
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ buildMvn {
     buildJavaDocker {
       publishMaster = 'yes'
       healthChk = 'yes'
-      healthChkCmd = 'wget --no-verbose --tries=1 --spider http://localhost:8081/admin/health || exit 1'
+      healthChkCmd = 'curl -sS --fail -o /dev/null  http://localhost:8081/apidocs/ || exit 1'
     }
   }
 }

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+## v3.14.0 2023-03-22
+### Plugins
+* Bump `aspectj-maven-plugin` from `com.nickwongdev` to `dev.aspectj`
+
+### Dependencies
+* Bump `folio-holdingsiq-client` from `2.3.0` to `2.4.0-SNAPSHOT`
+* Bump `folio-liquibase-util` from `1.6.0` to `1.7.0-SNAPSHOT`
+* Bump `folio-di-support` from `1.7.0` to `1.8.0-SNAPSHOT`
+* Bump `vertx` from `4.3.8` to `4.4.0`
+* Bump `spring` from `5.3.25` to `6.0.6`
+* Bump `postgresql` from `42.5.3` to `42.6.0`
+* Bump `jetbrains-annotations` from `24.0.0` to `24.0.1`
+
+
 ## v3.13.0 2023-02-15
 ### Bug Fixes
 * Missing module permission for access status types ([MODKBEKBJ-708](https://issues.folio.org/browse/MODKBEKBJ-708))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,16 +1,24 @@
 ## v3.14.0 2023-03-22
-### Plugins
-* Bump `aspectj-maven-plugin` from `com.nickwongdev` to `dev.aspectj`
+### Breaking changes
+* Update the module for Java 17 & the latest dependencies ([MODKBEKBJ-732](https://issues.folio.org/browse/MODKBEKBJ-732))
+
+### Tech Dept
+* Logging improvement ([MODKBEKBJ-626](https://issues.folio.org/browse/MODKBEKBJ-626))
+
+### Bug fixes
+* Load holdings process failing after exceeding status request retries ([MODKBEKBJ-713](https://issues.folio.org/browse/MODKBEKBJ-713))
 
 ### Dependencies
-* Bump `folio-holdingsiq-client` from `2.3.0` to `2.4.0-SNAPSHOT`
-* Bump `folio-liquibase-util` from `1.6.0` to `1.7.0-SNAPSHOT`
-* Bump `folio-di-support` from `1.7.0` to `1.8.0-SNAPSHOT`
+* Bump `java` from `11` to `17`
+* Bump `folio-holdingsiq-client` from `2.3.0` to `3.0.0-SNAPSHOT`
+* Bump `folio-liquibase-util` from `1.6.0` to `2.0.0-SNAPSHOT`
+* Bump `folio-di-support` from `1.7.0` to `3.0.0-SNAPSHOT`
 * Bump `vertx` from `4.3.8` to `4.4.0`
 * Bump `spring` from `5.3.25` to `6.0.6`
 * Bump `postgresql` from `42.5.3` to `42.6.0`
 * Bump `jetbrains-annotations` from `24.0.0` to `24.0.1`
-
+* Remove `aspectj-maven-plugin` with groupId `com.nickwongdev` & version `1.12.6`
+* Add `aspectj-maven-plugin` with groupId `dev.aspectj` & version `1.13.1`
 
 ## v3.13.0 2023-02-15
 ### Bug Fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,6 @@
 * Bump `folio-holdingsiq-client` from `2.3.0` to `3.0.0-SNAPSHOT`
 * Bump `folio-service-tools` from `1.10.1` to `3.1.0-SNAPSHOT`
 * Bump `folio-di-support` from `1.7.0` to `2.0.0-SNAPSHOT`
-* Bump `vertx` from `4.3.8` to `4.4.0`
 * Bump `spring` from `5.3.25` to `6.0.6`
 * Bump `jetbrains-annotations` from `24.0.0` to `24.0.1`
 * Bump `log4j` from `2.19.0` to `2.20.0`

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * Bump `vertx` from `4.3.8` to `4.4.0`
 * Bump `spring` from `5.3.25` to `6.0.6`
 * Bump `jetbrains-annotations` from `24.0.0` to `24.0.1`
+* Bump `log4j` from `2.19.0` to `2.20.0`
 * Remove `aspectj-maven-plugin` with groupId `com.nickwongdev` & version `1.12.6`
 * Add `aspectj-maven-plugin` with groupId `dev.aspectj` & version `1.13.1`
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## v3.14.0 2023-03-22
+## v4.0.0 in progress
 ### Breaking changes
 * Update the module for Java 17 & the latest dependencies ([MODKBEKBJ-732](https://issues.folio.org/browse/MODKBEKBJ-732))
 
@@ -11,11 +11,10 @@
 ### Dependencies
 * Bump `java` from `11` to `17`
 * Bump `folio-holdingsiq-client` from `2.3.0` to `3.0.0-SNAPSHOT`
-* Bump `folio-liquibase-util` from `1.6.0` to `2.0.0-SNAPSHOT`
-* Bump `folio-di-support` from `1.7.0` to `3.0.0-SNAPSHOT`
+* Bump `folio-service-tools` from `1.10.1` to `3.1.0-SNAPSHOT`
+* Bump `folio-di-support` from `1.7.0` to `2.0.0-SNAPSHOT`
 * Bump `vertx` from `4.3.8` to `4.4.0`
 * Bump `spring` from `5.3.25` to `6.0.6`
-* Bump `postgresql` from `42.5.3` to `42.6.0`
 * Bump `jetbrains-annotations` from `24.0.0` to `24.0.1`
 * Remove `aspectj-maven-plugin` with groupId `com.nickwongdev` & version `1.12.6`
 * Add `aspectj-maven-plugin` with groupId `dev.aspectj` & version `1.13.1`

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-kb-ebsco-java</artifactId>
-  <version>3.14.0-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>EBSCO KB Broker</name>
@@ -39,16 +39,16 @@
 
     <rmb.version>35.0.6</rmb.version>
     <folio-di-support.version>2.0.0-SNAPSHOT</folio-di-support.version>
-    <folio-service-tools.version>1.10.1</folio-service-tools.version>
+    <folio-service-tools.version>3.1.0-SNAPSHOT</folio-service-tools.version>
     <folio-holdingsiq-client.version>3.0.0-SNAPSHOT</folio-holdingsiq-client.version>
-    <folio-liquibase-util.version>2.0.0-SNAPSHOT</folio-liquibase-util.version>
+    <folio-liquibase-util.version>1.7.0-SNAPSHOT</folio-liquibase-util.version>
     <mod-configuration-client.version>5.9.1</mod-configuration-client.version>
 
     <vertx.version>4.4.0</vertx.version>
     <aspectj.version>1.9.9.1</aspectj.version>
     <spring.version>6.0.6</spring.version>
     <jackson.version>2.14.2</jackson.version>
-    <postgresql.version>42.6.0</postgresql.version>
+    <postgresql.version>42.5.3</postgresql.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-configuration2.version>2.8.0</commons-configuration2.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
@@ -72,6 +72,7 @@
     <assertj.version>3.24.2</assertj.version>
     <jsonassert.version>1.5.1</jsonassert.version>
     <easy-random-core.version>5.0.0</easy-random-core.version>
+    <jetty.version>9.4.49.v20220914</jetty.version>
 
     <!-- Plugins versions   -->
     <versions-maven-plugin.version>2.12.0</versions-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,27 +35,27 @@
 
 
   <properties>
-    <java.version>11</java.version>
+    <java.version>17</java.version>
 
     <rmb.version>35.0.6</rmb.version>
-    <folio-di-support.version>1.7.0</folio-di-support.version>
+    <folio-di-support.version>1.8.0-SNAPSHOT</folio-di-support.version>
     <folio-service-tools.version>1.10.1</folio-service-tools.version>
-    <folio-holdingsiq-client.version>2.3.0</folio-holdingsiq-client.version>
-    <folio-liquibase-util.version>1.6.0</folio-liquibase-util.version>
+    <folio-holdingsiq-client.version>2.4.0-SNAPSHOT</folio-holdingsiq-client.version>
+    <folio-liquibase-util.version>1.7.0-SNAPSHOT</folio-liquibase-util.version>
     <mod-configuration-client.version>5.9.1</mod-configuration-client.version>
 
-    <vertx.version>4.3.8</vertx.version>
+    <vertx.version>4.4.0</vertx.version>
     <aspectj.version>1.9.9.1</aspectj.version>
-    <spring.version>5.3.25</spring.version>
+    <spring.version>6.0.6</spring.version>
     <jackson.version>2.14.2</jackson.version>
-    <postgresql.version>42.5.3</postgresql.version>
+    <postgresql.version>42.6.0</postgresql.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-configuration2.version>2.8.0</commons-configuration2.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <lombok.version>1.18.26</lombok.version>
     <httpcore.version>4.4.16</httpcore.version>
-    <log4j.version>2.19.0</log4j.version>
-    <jetbrains-annotations.version>24.0.0</jetbrains-annotations.version>
+    <log4j.version>2.20.0</log4j.version>
+    <jetbrains-annotations.version>24.0.1</jetbrains-annotations.version>
     <opencsv.version>5.7.1</opencsv.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <validation-api.version>2.0.1.Final</validation-api.version>
@@ -85,7 +85,7 @@
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
     <properties-maven-plugin.version>1.1.0</properties-maven-plugin.version>
     <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
-    <aspectj-maven-plugin.version>1.12.6</aspectj-maven-plugin.version>
+    <aspectj-maven-plugin.version>1.13.1</aspectj-maven-plugin.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
   </properties>
@@ -468,7 +468,7 @@
       </plugin>
 
       <plugin>
-        <groupId>com.nickwongdev</groupId>
+        <groupId>dev.aspectj</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>${aspectj-maven-plugin.version}</version>
         <configuration>
@@ -641,6 +641,7 @@
                   <artifact>*:*</artifact>
                   <excludes>
                     <exclude>**/Log4j2Plugins.dat</exclude>
+                    <exclude>module-info.class</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -642,7 +642,6 @@
                   <artifact>*:*</artifact>
                   <excludes>
                     <exclude>**/Log4j2Plugins.dat</exclude>
-                    <exclude>module-info.class</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <folio-liquibase-util.version>1.7.0-SNAPSHOT</folio-liquibase-util.version>
     <mod-configuration-client.version>5.9.1</mod-configuration-client.version>
 
-    <vertx.version>4.4.0</vertx.version>
+    <vertx.version>4.3.8</vertx.version>
     <aspectj.version>1.9.9.1</aspectj.version>
     <spring.version>6.0.6</spring.version>
     <jackson.version>2.14.2</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@
     <assertj.version>3.24.2</assertj.version>
     <jsonassert.version>1.5.1</jsonassert.version>
     <easy-random-core.version>5.0.0</easy-random-core.version>
-    <jetty.version>9.4.49.v20220914</jetty.version>
 
     <!-- Plugins versions   -->
     <versions-maven-plugin.version>2.12.0</versions-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,10 @@
     <java.version>17</java.version>
 
     <rmb.version>35.0.6</rmb.version>
-    <folio-di-support.version>1.8.0-SNAPSHOT</folio-di-support.version>
+    <folio-di-support.version>2.0.0-SNAPSHOT</folio-di-support.version>
     <folio-service-tools.version>1.10.1</folio-service-tools.version>
-    <folio-holdingsiq-client.version>2.4.0-SNAPSHOT</folio-holdingsiq-client.version>
-    <folio-liquibase-util.version>1.7.0-SNAPSHOT</folio-liquibase-util.version>
+    <folio-holdingsiq-client.version>3.0.0-SNAPSHOT</folio-holdingsiq-client.version>
+    <folio-liquibase-util.version>2.0.0-SNAPSHOT</folio-liquibase-util.version>
     <mod-configuration-client.version>5.9.1</mod-configuration-client.version>
 
     <vertx.version>4.4.0</vertx.version>

--- a/src/main/java/org/folio/rest/converter/costperuse/export/PackageTitleCostPerUseConverter.java
+++ b/src/main/java/org/folio/rest/converter/costperuse/export/PackageTitleCostPerUseConverter.java
@@ -44,6 +44,11 @@ public class PackageTitleCostPerUseConverter {
     if (cost == null) {
       cost = DOUBLE_ZERO;
     }
-    return currencyFormatter.format(cost).replace("\u00a0", " ").trim();
+    return currencyFormatter
+      .format(cost)
+      .replace(" ", " ")
+      .replace("\u00a0", " ")
+      .trim();
+
   }
 }

--- a/src/main/java/org/folio/rest/converter/costperuse/export/PackageTitleCostPerUseConverter.java
+++ b/src/main/java/org/folio/rest/converter/costperuse/export/PackageTitleCostPerUseConverter.java
@@ -46,7 +46,6 @@ public class PackageTitleCostPerUseConverter {
     }
     return currencyFormatter
       .format(cost)
-      .replace(" ", " ")
       .replace("\u00a0", " ")
       .trim();
 


### PR DESCRIPTION
## Purpose
_Preparing module for next version of java 17 and updating dependecies._

## Approach
_Updated java to 17_
_Updated folio-di-support version to 2.0.0-SNAPSHOT_
_Updated folio-holdingsiq-client version to 3.0.0-SNAPSHOT_
_Updated spring framework version to 6.0.6_
_Updated log4j version to 2.20.0_
_Updated jetbrains-annotations version to 24.0.1_
_Removed aspectj-maven-plugin groupId com.nickwongdev & v1.12.6_
_Added aspectj-maven-plugin groupId dev.aspectj & v1.13.1_


### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [x] Interface versions changes
- [x] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
