### PR TITLE
MODKBEKBJ-326: Increased -Xmx memory & MaxRAMPercentage in launchDescriptor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 ### Tech Dept
 * Logging improvement ([MODKBEKBJ-626](https://issues.folio.org/browse/MODKBEKBJ-626))
+* Increase memory allocation in default LaunchDescriptor ([MODKBEKBJ-326](https://issues.folio.org/browse/MODKBEKBJ-326))
 
 ### Bug fixes
 * Load holdings process failing after exceeding status request retries ([MODKBEKBJ-713](https://issues.folio.org/browse/MODKBEKBJ-713))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -919,13 +919,13 @@
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 357913941,
+        "Memory": 536870912,
         "PortBindings": { "8081/tcp": [ { "HostPort": "%p" } ] }
       }
     },
     "env": [
       { "name": "JAVA_OPTIONS",
-        "value": "-XX:MaxRAMPercentage=66.0"
+        "value": "-XX:MaxRAMPercentage=85.0"
       },
       { "name": "DB_HOST", "value": "postgres" },
       { "name": "DB_PORT", "value": "5432" },


### PR DESCRIPTION
## Purpose
_Re-assess the container Memory allocation in default LaunchDescriptor._

## Approach
_Increased configs values by -Xmx to 512m & MaxRAMPercentage to 85%_

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
