### PR TITLE
MODKBEKBJ-744: Ignored additional fields in proxy and added related test

### DIFF
--- a/ramls/types/proxy.json
+++ b/ramls/types/proxy.json
@@ -4,7 +4,7 @@
   "description": "Proxy Schema",
   "javaType": "org.folio.rest.jaxrs.model.Proxy",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "id": {
       "type": "string",

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsResourcesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsResourcesImplTest.java
@@ -387,6 +387,23 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
   }
 
   @Test
+  public void shouldAcceptValuesCustomResourceWithUnrecognizedFieldInProxy()
+    throws IOException, URISyntaxException, JSONException {
+    String stubResponseFile = "responses/rmapi/resources/get-custom-resource-updated-response.json";
+    String expectedResourceFile = "responses/kb-ebsco/resources/expected-custom-resource.json";
+
+    String actualResponse =
+      mockUpdateResourceScenario(stubResponseFile, CUSTOM_RESOURCE_ENDPOINT, STUB_CUSTOM_RESOURCE_ID,
+        readFile("requests/kb-ebsco/resource/put-custom-resource-with-proxied-url.json"));
+
+    JSONAssert.assertEquals(readFile(expectedResourceFile), actualResponse, false);
+
+    verify(1, putRequestedFor(new UrlPathPattern(new RegexPattern(CUSTOM_RESOURCE_ENDPOINT), true))
+      .withRequestBody(
+        equalToJson(readFile("requests/rmapi/resources/put-custom-resource-is-selected-multiple-attributes.json"))));
+  }
+
+  @Test
   public void shouldUpdateTagsOnSuccessfulTagsPut() throws IOException, URISyntaxException {
     List<String> tags = Collections.singletonList(STUB_TAG_VALUE);
     sendPutTags(tags);
@@ -447,7 +464,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
     mockResource(stubTitleResponseFile);
 
     EqualToJsonPattern putRequestBodyPattern =
-      new EqualToJsonPattern(readFile("requests/rmapi/resources/select-resource-request.json"),
+      new EqualToJsonPattern(readFile("requests/rmapi/resources/"),
         true, true);
     mockPut(new RegexPattern(MANAGED_RESOURCE_ENDPOINT), putRequestBodyPattern, SC_NO_CONTENT);
 

--- a/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsResourcesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/integrationsuite/EholdingsResourcesImplTest.java
@@ -464,7 +464,7 @@ public class EholdingsResourcesImplTest extends WireMockTestBase {
     mockResource(stubTitleResponseFile);
 
     EqualToJsonPattern putRequestBodyPattern =
-      new EqualToJsonPattern(readFile("requests/rmapi/resources/"),
+      new EqualToJsonPattern(readFile("requests/rmapi/resources/select-resource-request.json"),
         true, true);
     mockPut(new RegexPattern(MANAGED_RESOURCE_ENDPOINT), putRequestBodyPattern, SC_NO_CONTENT);
 

--- a/src/test/resources/requests/kb-ebsco/resource/put-custom-resource-with-proxied-url.json
+++ b/src/test/resources/requests/kb-ebsco/resource/put-custom-resource-with-proxied-url.json
@@ -1,0 +1,65 @@
+{
+  "data": {
+    "id": "123356-3157070-19412030",
+    "type": "resources",
+    "attributes": {
+      "isTitleCustom": true,
+      "titleId": 19412030,
+      "name" : "Test Title",
+      "coverageStatement": "My test statement",
+      "customEmbargoPeriod": {
+        "embargoValue": 30,
+        "embargoUnit": "Weeks"
+      },
+      "isSelected": true,
+      "managedEmbargoPeriod": {
+        "embargoUnit": null,
+        "embargoValue": 0
+      },
+      "packageId": "123356-3157070",
+      "packageName": "Andrii custom package ",
+      "url": "https://hello",
+      "providerId": 123356,
+      "providerName": "API DEV GOVERNMENT CUSTOMER",
+      "visibilityData": {
+        "isHidden": false,
+        "reason": ""
+      },
+      "managedCoverages": [],
+      "customCoverages": [
+        {
+          "beginCoverage": "2018-01-10",
+          "endCoverage": "2018-01-11"
+        }
+      ],
+      "proxy": {
+        "id": "Proxy-ID-234",
+        "inherited": false,
+        "proxiedUrl": "https://example-url.com/"
+      },
+      "publisherName": "Test publisher",
+      "edition": "Test edition",
+      "publicationType": "Thesis & Dissertation",
+      "subjects": [],
+      "contributors": [
+        {
+          "type":"author",
+          "contributor":"smith, john"
+        },
+        {
+          "type":"illustrator",
+          "contributor":"smith, ralph"
+        }
+      ],
+      "identifiers": [
+        {
+          "id": "1111-2222-3333",
+          "type":"ISSN",
+          "subtype":"Online"
+        }
+      ],
+      "isPeerReviewed": true,
+      "description": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
Avoid an error message when trying to add a title in a package to holdings

## Approach
Ignore unknown fields in proxy part of the request

### Learning
[MODKBEKBJ-744](https://issues.folio.org/browse/MODKBEKBJ-744)
