### PR TITLE
fix(load-holdings) Reduce the size of the page by half after failed retry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <rmb.version>35.0.6</rmb.version>
     <folio-di-support.version>2.0.0-SNAPSHOT</folio-di-support.version>
-    <folio-service-tools.version>3.1.0</folio-service-tools.version>
+    <folio-service-tools.version>3.1.0-SNAPSHOT</folio-service-tools.version>
     <folio-holdingsiq-client.version>3.0.0-SNAPSHOT</folio-holdingsiq-client.version>
     <folio-liquibase-util.version>1.7.0-SNAPSHOT</folio-liquibase-util.version>
     <mod-configuration-client.version>5.9.1</mod-configuration-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <rmb.version>35.0.6</rmb.version>
     <folio-di-support.version>2.0.0-SNAPSHOT</folio-di-support.version>
-    <folio-service-tools.version>3.0.2</folio-service-tools.version>
+    <folio-service-tools.version>3.1.0</folio-service-tools.version>
     <folio-holdingsiq-client.version>3.0.0-SNAPSHOT</folio-holdingsiq-client.version>
     <folio-liquibase-util.version>1.7.0-SNAPSHOT</folio-liquibase-util.version>
     <mod-configuration-client.version>5.9.1</mod-configuration-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,10 @@
     <java.version>17</java.version>
 
     <rmb.version>35.0.6</rmb.version>
-    <folio-di-support.version>2.0.0-SNAPSHOT</folio-di-support.version>
-    <folio-service-tools.version>3.1.0-SNAPSHOT</folio-service-tools.version>
-    <folio-holdingsiq-client.version>3.0.0-SNAPSHOT</folio-holdingsiq-client.version>
-    <folio-liquibase-util.version>1.7.0-SNAPSHOT</folio-liquibase-util.version>
+    <folio-di-support.version>2.0.0</folio-di-support.version>
+    <folio-service-tools.version>3.1.0</folio-service-tools.version>
+    <folio-holdingsiq-client.version>3.0.0</folio-holdingsiq-client.version>
+    <folio-liquibase-util.version>1.7.0</folio-liquibase-util.version>
     <mod-configuration-client.version>5.9.1</mod-configuration-client.version>
 
     <vertx.version>4.3.8</vertx.version>

--- a/pom.xml
+++ b/pom.xml
@@ -450,6 +450,30 @@
       </plugin>
 
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>${exec-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>git submodule update</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>git</executable>
+              <arguments>
+                <argument>submodule</argument>
+                <argument>update</argument>
+                <argument>--init</argument>
+                <argument>--recursive</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>dev.aspectj</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>${aspectj-maven-plugin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <rmb.version>35.0.6</rmb.version>
     <folio-di-support.version>2.0.0-SNAPSHOT</folio-di-support.version>
-    <folio-service-tools.version>3.1.0-SNAPSHOT</folio-service-tools.version>
+    <folio-service-tools.version>3.0.2</folio-service-tools.version>
     <folio-holdingsiq-client.version>3.0.0-SNAPSHOT</folio-holdingsiq-client.version>
     <folio-liquibase-util.version>1.7.0-SNAPSHOT</folio-liquibase-util.version>
     <mod-configuration-client.version>5.9.1</mod-configuration-client.version>
@@ -47,7 +47,7 @@
     <vertx.version>4.3.8</vertx.version>
     <aspectj.version>1.9.9.1</aspectj.version>
     <spring.version>6.0.7</spring.version>
-    <jackson.version>2.14.2</jackson.version>
+    <jackson.version>2.15.2</jackson.version>
     <postgresql.version>42.5.3</postgresql.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-configuration2.version>2.8.0</commons-configuration2.version>
@@ -444,30 +444,6 @@
                   <value>${project.baseUri}src/main/resources/log4j2.xml</value>
                 </property>
               </properties>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>${exec-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>git submodule update</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>git</executable>
-              <arguments>
-                <argument>submodule</argument>
-                <argument>update</argument>
-                <argument>--init</argument>
-                <argument>--recursive</argument>
-              </arguments>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/org/folio/repository/holdings/status/HoldingsLoadingStatusFactory.java
+++ b/src/main/java/org/folio/repository/holdings/status/HoldingsLoadingStatusFactory.java
@@ -42,22 +42,6 @@ public final class HoldingsLoadingStatusFactory {
       .withJsonapi(JSONAPI);
   }
 
-  public static HoldingsLoadingStatus getStatusLoadingHoldings(int totalCount, int totalPages) {
-    return new HoldingsLoadingStatus()
-      .withData(new LoadStatusData()
-        .withType(LoadStatusData.Type.STATUS)
-        .withAttributes(new LoadStatusAttributes()
-          .withStarted(getTimeNow())
-          .withStatus(new LoadStatusInformation()
-            .withName(LoadStatusNameEnum.IN_PROGRESS)
-            .withDetail(LoadStatusNameDetailEnum.LOADING_HOLDINGS))
-          .withUpdated(getTimeNow())
-          .withTotalCount(totalCount)
-          .withTotalPages(totalPages))
-      )
-      .withJsonapi(JSONAPI);
-  }
-
   public static HoldingsLoadingStatus getStatusLoadingHoldings(int totalCount, int importedCount, int totalPages,
                                                                int importedPages) {
     return new HoldingsLoadingStatus()

--- a/src/main/java/org/folio/repository/holdings/status/HoldingsLoadingStatusFactory.java
+++ b/src/main/java/org/folio/repository/holdings/status/HoldingsLoadingStatusFactory.java
@@ -42,6 +42,22 @@ public final class HoldingsLoadingStatusFactory {
       .withJsonapi(JSONAPI);
   }
 
+  public static HoldingsLoadingStatus getStatusLoadingHoldings(int totalCount, int totalPages) {
+    return new HoldingsLoadingStatus()
+      .withData(new LoadStatusData()
+        .withType(LoadStatusData.Type.STATUS)
+        .withAttributes(new LoadStatusAttributes()
+          .withStarted(getTimeNow())
+          .withStatus(new LoadStatusInformation()
+            .withName(LoadStatusNameEnum.IN_PROGRESS)
+            .withDetail(LoadStatusNameDetailEnum.LOADING_HOLDINGS))
+          .withUpdated(getTimeNow())
+          .withTotalCount(totalCount)
+          .withTotalPages(totalPages))
+      )
+      .withJsonapi(JSONAPI);
+  }
+
   public static HoldingsLoadingStatus getStatusLoadingHoldings(int totalCount, int importedCount, int totalPages,
                                                                int importedPages) {
     return new HoldingsLoadingStatus()

--- a/src/main/java/org/folio/service/holdings/AbstractLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/AbstractLoadServiceFacade.java
@@ -253,8 +253,8 @@ public abstract class AbstractLoadServiceFacade implements LoadServiceFacade {
     CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
     List<Integer> pagesToLoad = IntStream.range(1, totalPages + 1).boxed().toList();
     for (Integer page : pagesToLoad) {
-      future = future.thenCompose(o -> retryOnFailure(loadPageRetries, loadPageDelay,
-        (retries) -> calculatePage(pageLoader, page, retries)));
+      future = future.thenCompose(
+        o -> retryOnFailure(loadPageRetries, loadPageDelay, retries -> calculatePage(pageLoader, page, retries)));
     }
     return future;
   }

--- a/src/main/java/org/folio/service/holdings/AbstractLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/AbstractLoadServiceFacade.java
@@ -53,9 +53,9 @@ public abstract class AbstractLoadServiceFacade implements LoadServiceFacade {
   protected AbstractLoadServiceFacade(@Value("${holdings.status.check.delay}") long statusRetryDelay,
                                       @Value("${holdings.status.retry.count}") int statusRetryCount,
                                       @Value("${holdings.page.retry.delay}") int loadPageRetryDelay,
-                                      @Value("${holdings.snapshot.refresh.period}") int snapshotRefreshPeriod,
                                       @Value("${holdings.page.retry.count}") int loadPageRetryCount,
                                       @Value("${holdings.page.size.min}") int loadPageSizeMin,
+                                      @Value("${holdings.snapshot.refresh.period}") int snapshotRefreshPeriod,
                                       Vertx vertx) {
     this.loadPageSizeMin = loadPageSizeMin;
     this.loadPageDelay = loadPageRetryDelay;

--- a/src/main/java/org/folio/service/holdings/AbstractLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/AbstractLoadServiceFacade.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiPredicate;
 import java.util.function.IntFunction;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
@@ -29,7 +28,6 @@ import org.folio.holdingsiq.service.impl.LoadServiceImpl;
 import org.folio.repository.holdings.LoadStatus;
 import org.folio.service.holdings.message.ConfigurationMessage;
 import org.folio.service.holdings.message.LoadHoldingsMessage;
-import org.glassfish.jersey.internal.util.Producer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
@@ -46,9 +44,10 @@ public abstract class AbstractLoadServiceFacade implements LoadServiceFacade {
   protected final HoldingsService holdingsService;
   protected final int loadPageRetries;
   protected final int loadPageDelay;
-  private final long statusRetryDelay;
+  private final int loadPageSizeMin;
   private final int statusRetryCount;
   private final int snapshotRefreshPeriod;
+  private final long statusRetryDelay;
   private final Vertx vertx;
 
   protected AbstractLoadServiceFacade(@Value("${holdings.status.check.delay}") long statusRetryDelay,
@@ -56,7 +55,9 @@ public abstract class AbstractLoadServiceFacade implements LoadServiceFacade {
                                       @Value("${holdings.page.retry.delay}") int loadPageRetryDelay,
                                       @Value("${holdings.snapshot.refresh.period}") int snapshotRefreshPeriod,
                                       @Value("${holdings.page.retry.count}") int loadPageRetryCount,
+                                      @Value("${holdings.page.size.min}") int loadPageSizeMin,
                                       Vertx vertx) {
+    this.loadPageSizeMin = loadPageSizeMin;
     this.loadPageDelay = loadPageRetryDelay;
     this.loadPageRetries = loadPageRetryCount;
     this.statusRetryDelay = statusRetryDelay;
@@ -158,57 +159,57 @@ public abstract class AbstractLoadServiceFacade implements LoadServiceFacade {
   }
 
   /**
-   * Runs action provided by futureProducer, if future is completed exceptionally then futureProducer
+   * Runs action provided by futureFunction, if future is completed exceptionally then futureFunction
    * will be called again after given delay.
    *
    * @param retries        Amount of times action will be retried
-   *                       (e.g. if retries = 2 then futureProducer will be called 2 times)
+   *                       (e.g. if retries = 2 then futureFunction will be called 2 times)
    * @param delay          delay in milliseconds before action is executed again after failure
-   * @param futureProducer provides an asynchronous action
+   * @param futureFunction provides an asynchronous action
    * @return future returned by
    */
   private <T> CompletableFuture<T> retryOnFailure(int retries, long delay,
-                                                  Producer<CompletableFuture<T>> futureProducer) {
+                                                  IntFunction<CompletableFuture<T>> futureFunction) {
     CompletableFuture<T> future = new CompletableFuture<>();
-    retryOnFailure(retries, delay, future, futureProducer);
+    retryOnFailure(retries, delay, future, futureFunction);
     return future;
   }
 
   private <T> void retryOnFailure(int retries, long delay, CompletableFuture<T> future,
-                                  Producer<CompletableFuture<T>> futureProducer) {
-    doUntilResultMatches(retries, delay, future, futureProducer, (result, ex) -> ex == null);
+                                  IntFunction<CompletableFuture<T>> futureFunction) {
+    doUntilResultMatches(retries, delay, future, futureFunction, (result, ex) -> ex == null);
   }
 
   /**
-   * Runs action provided by futureProducer, when future completes the result is passed to matcher,
-   * if matcher returns false then futureProducer will be called again after delay.
+   * Runs action provided by futureFunction, when future completes the result is passed to matcher,
+   * if matcher returns false then futureFunction will be called again after delay.
    * if matcher returns true then the result is propagated to returned CompletableFuture
    * if matcher throws exception then exception is propagated to returned CompletableFuture and action is not retried
    *
-   * @param retries        Amount of times action will be retried (e.g. if retries = 2 then futureProducer
+   * @param retries        Amount of times action will be retried (e.g. if retries = 2 then futureFunction
    *                       will be called 2 times)
    * @param delay          delay in milliseconds before action is executed again after failure
-   * @param matcher        predicate that determines if futureProducer should be called again after delay
-   * @param futureProducer provides an asynchronous action to be executed
+   * @param matcher        predicate that determines if futureFunction should be called again after delay
+   * @param futureFunction provides an asynchronous action to be executed
    */
   protected <T> CompletableFuture<T> doUntilResultMatches(int retries, long delay,
-                                                          Producer<CompletableFuture<T>> futureProducer,
+                                                          IntFunction<CompletableFuture<T>> futureFunction,
                                                           BiPredicate<T, Throwable> matcher) {
     CompletableFuture<T> future = new CompletableFuture<>();
-    doUntilResultMatches(retries, delay, future, futureProducer, matcher);
+    doUntilResultMatches(retries, delay, future, futureFunction, matcher);
     return future;
   }
 
   private <T> void doUntilResultMatches(int retries, long delay, CompletableFuture<T> future,
-                                        Producer<CompletableFuture<T>> futureProducer,
+                                        IntFunction<CompletableFuture<T>> futureFunction,
                                         BiPredicate<T, Throwable> matcher) {
-    futureProducer.call()
+    futureFunction.apply(retries)
       .handle((result, ex) -> {
         if (matcher.test(result, ex)) {
           future.complete(result);
         } else {
           if (retries > 1) {
-            vertx.setTimer(delay, timerId -> doUntilResultMatches(retries - 1, delay, future, futureProducer, matcher));
+            vertx.setTimer(delay, timerId -> doUntilResultMatches(retries - 1, delay, future, futureFunction, matcher));
           } else {
             future.completeExceptionally(
               ex != null ? ex : new IllegalStateException("Action failed with result " + result));
@@ -250,12 +251,20 @@ public abstract class AbstractLoadServiceFacade implements LoadServiceFacade {
   protected CompletableFuture<Void> loadWithPagination(Integer totalPages,
                                                        IntFunction<CompletableFuture<Void>> pageLoader) {
     CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
-    List<Integer> pagesToLoad = IntStream.range(1, totalPages + 1).boxed().collect(Collectors.toList());
+    List<Integer> pagesToLoad = IntStream.range(1, totalPages + 1).boxed().toList();
     for (Integer page : pagesToLoad) {
-      future = future
-        .thenCompose(o -> retryOnFailure(loadPageRetries, loadPageDelay, () -> pageLoader.apply(page)));
+      future = future.thenCompose(o -> retryOnFailure(loadPageRetries, loadPageDelay,
+        (retries) -> calculatePage(pageLoader, page, retries)));
     }
     return future;
+  }
+
+  protected CompletableFuture<Void> calculatePage(IntFunction<CompletableFuture<Void>> pageLoader,
+                                                  Integer page, Integer retries) {
+    if (loadPageRetries > retries) {
+      page = Math.max(page / 2, loadPageSizeMin);
+    }
+    return pageLoader.apply(page);
   }
 
   /**

--- a/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
@@ -40,7 +40,7 @@ public class DefaultLoadServiceFacade extends AbstractLoadServiceFacade {
 
   @Override
   protected CompletableFuture<String> populateHoldings(LoadService loadingService) {
-    return loadingService.populateHoldingsForce().thenApply(o -> null);
+    return loadingService.populateHoldings().thenApply(o -> null);
   }
 
   @Override

--- a/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
@@ -40,7 +40,7 @@ public class DefaultLoadServiceFacade extends AbstractLoadServiceFacade {
 
   @Override
   protected CompletableFuture<String> populateHoldings(LoadService loadingService) {
-    return loadingService.populateHoldings().thenApply(o -> null);
+    return loadingService.populateHoldingsForce().thenApply(o -> null);
   }
 
   @Override

--- a/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
@@ -38,10 +38,9 @@ public class DefaultLoadServiceFacade extends AbstractLoadServiceFacade {
           new HoldingsMessage(holdings.getHoldingsList(), message.getTenantId(), null, message.getCredentialsId()))));
   }
 
-  //TODO: force
   @Override
   protected CompletableFuture<String> populateHoldings(LoadService loadingService) {
-    return loadingService.populateHoldings().thenApply(o -> null);
+    return loadingService.populateHoldingsForce().thenApply(o -> null);
   }
 
   @Override

--- a/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
@@ -23,8 +23,10 @@ public class DefaultLoadServiceFacade extends AbstractLoadServiceFacade {
                                   @Value("${holdings.snapshot.refresh.period}") int snapshotRefreshPeriod,
                                   @Value("${holdings.page.retry.count}") int loadPageRetryCount,
                                   @Value("${holdings.page.size:2500}") int loadPageSize,
+                                  @Value("${holdings.page.size.min}") int loadPageSizeMin,
                                   Vertx vertx) {
-    super(statusRetryDelay, statusRetryCount, loadPageRetryDelay, snapshotRefreshPeriod, loadPageRetryCount, vertx);
+    super(statusRetryDelay, statusRetryCount, loadPageRetryDelay, loadPageRetryCount, loadPageSizeMin,
+      snapshotRefreshPeriod, vertx);
     this.loadPageSize = loadPageSize;
   }
 
@@ -36,6 +38,7 @@ public class DefaultLoadServiceFacade extends AbstractLoadServiceFacade {
           new HoldingsMessage(holdings.getHoldingsList(), message.getTenantId(), null, message.getCredentialsId()))));
   }
 
+  //TODO: force
   @Override
   protected CompletableFuture<String> populateHoldings(LoadService loadingService) {
     return loadingService.populateHoldings().thenApply(o -> null);

--- a/src/main/java/org/folio/service/holdings/HoldingsServiceImpl.java
+++ b/src/main/java/org/folio/service/holdings/HoldingsServiceImpl.java
@@ -310,8 +310,8 @@ public class HoldingsServiceImpl implements HoldingsService {
           executeWithLock(START_LOADING_LOCK, () -> {
             final Integer totalCount = message.getTotalCount();
             final Integer totalPages = message.getTotalPages();
-            return tryChangingStatusToInProgress(getStatusLoadingHoldings(totalCount, totalPages), credentialsId,
-              tenantId)
+            return tryChangingStatusToInProgress(getStatusLoadingHoldings(totalCount, 0, totalPages, 0),
+              credentialsId, tenantId)
               .thenCompose(o3 ->
                 transactionIdRepository.getLastTransactionId(credentialsId, tenantId)
                   .thenAccept(previousTransactionId -> loadServiceFacade
@@ -419,7 +419,7 @@ public class HoldingsServiceImpl implements HoldingsService {
   }
 
   private CompletableFuture<Void> setStatusToFailed(UUID credentialsId, String tenantId, String message) {
-    return holdingsStatusRepository.update(getLoadStatusFailed(createError(message, null).getErrors()),
+    return holdingsStatusRepository.update(getLoadStatusFailed(createError(message).getErrors()),
         credentialsId, tenantId)
       .exceptionally(e -> {
         log.warn(FAILED_UPDATE_STATUS_TO_FAILED_MESSAGE, e);

--- a/src/main/java/org/folio/service/holdings/HoldingsServiceImpl.java
+++ b/src/main/java/org/folio/service/holdings/HoldingsServiceImpl.java
@@ -310,7 +310,7 @@ public class HoldingsServiceImpl implements HoldingsService {
           executeWithLock(START_LOADING_LOCK, () -> {
             final Integer totalCount = message.getTotalCount();
             final Integer totalPages = message.getTotalPages();
-            return tryChangingStatusToInProgress(getStatusLoadingHoldings(totalCount, 0, totalPages, 0), credentialsId,
+            return tryChangingStatusToInProgress(getStatusLoadingHoldings(totalCount, totalPages), credentialsId,
               tenantId)
               .thenCompose(o3 ->
                 transactionIdRepository.getLastTransactionId(credentialsId, tenantId)

--- a/src/main/java/org/folio/service/holdings/TransactionLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/TransactionLoadServiceFacade.java
@@ -149,7 +149,7 @@ public class TransactionLoadServiceFacade extends AbstractLoadServiceFacade {
   private CompletableFuture<DeltaReportStatus> waitForReportToComplete(LoadService loadingService,
                                                                        String deltaReportId) {
     return doUntilResultMatches(reportStatusRetryCount, reportStatusRetryDelay,
-      (retries) -> loadingService.getDeltaReportStatus(deltaReportId),
+      retries -> loadingService.getDeltaReportStatus(deltaReportId),
       (loadStatus, ex) -> ReportStatus.COMPLETED == ReportStatus.fromValue(loadStatus.getStatus())
     );
   }

--- a/src/main/java/org/folio/service/holdings/TransactionLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/TransactionLoadServiceFacade.java
@@ -49,17 +49,17 @@ public class TransactionLoadServiceFacade extends AbstractLoadServiceFacade {
   private final long reportStatusRetryDelay;
   private final int reportStatusRetryCount;
 
-  public TransactionLoadServiceFacade(
-    @Value("${holdings.status.check.delay}") long statusRetryDelay,
-    @Value("${holdings.status.retry.count}") int statusRetryCount,
-    @Value("${holdings.report.status.check.delay}") long reportStatusRetryDelay,
-    @Value("${holdings.report.status.retry.count}") int reportStatusRetryCount,
-    @Value("${holdings.page.retry.delay}") int loadPageRetryDelay,
-    @Value("${holdings.snapshot.refresh.period}") int snapshotRefreshPeriod,
-    @Value("${holdings.page.retry.count}") int loadPageRetryCount,
-
-    Vertx vertx) {
-    super(statusRetryDelay, statusRetryCount, loadPageRetryDelay, snapshotRefreshPeriod, loadPageRetryCount, vertx);
+  public TransactionLoadServiceFacade(@Value("${holdings.status.check.delay}") long statusRetryDelay,
+                                      @Value("${holdings.status.retry.count}") int statusRetryCount,
+                                      @Value("${holdings.report.status.check.delay}") long reportStatusRetryDelay,
+                                      @Value("${holdings.report.status.retry.count}") int reportStatusRetryCount,
+                                      @Value("${holdings.page.retry.delay}") int loadPageRetryDelay,
+                                      @Value("${holdings.snapshot.refresh.period}") int snapshotRefreshPeriod,
+                                      @Value("${holdings.page.retry.count}") int loadPageRetryCount,
+                                      @Value("${holdings.page.size.min}") int loadPageSizeMin,
+                                      Vertx vertx) {
+    super(statusRetryDelay, statusRetryCount, loadPageRetryDelay, loadPageRetryCount, loadPageSizeMin,
+      snapshotRefreshPeriod, vertx);
     this.reportStatusRetryDelay = reportStatusRetryDelay;
     this.reportStatusRetryCount = reportStatusRetryCount;
   }
@@ -149,7 +149,7 @@ public class TransactionLoadServiceFacade extends AbstractLoadServiceFacade {
   private CompletableFuture<DeltaReportStatus> waitForReportToComplete(LoadService loadingService,
                                                                        String deltaReportId) {
     return doUntilResultMatches(reportStatusRetryCount, reportStatusRetryDelay,
-      () -> loadingService.getDeltaReportStatus(deltaReportId),
+      (retries) -> loadingService.getDeltaReportStatus(deltaReportId),
       (loadStatus, ex) -> ReportStatus.COMPLETED == ReportStatus.fromValue(loadStatus.getStatus())
     );
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,7 @@ holdings.load.implementation.qualifier=DefaultLoadServiceFacade
 holdings.load.retry.count=3
 holdings.load.retry.delay=10800000
 holdings.page.size=2500
+holdings.page.size.min=100
 holdings.page.retry.count=3
 holdings.page.retry.delay=900000
 holdings.report.status.check.delay=120000

--- a/src/main/resources/templates/db_scripts/update_started_date_before_insertion.sql
+++ b/src/main/resources/templates/db_scripts/update_started_date_before_insertion.sql
@@ -1,3 +1,5 @@
+-- Custom script to add an additional column startedDate for holdings_status table.
+
 CREATE OR REPLACE FUNCTION update_started_date_before_insertion()
   RETURNS TRIGGER
 AS $$
@@ -16,7 +18,7 @@ AS $$
 $$
 language 'plpgsql';
 
-DROP TRIGGER IF EXISTS  update_started_date_before_insertion_trigger ON holdings_status CASCADE;
+DROP TRIGGER IF EXISTS update_started_date_before_insertion_trigger ON holdings_status CASCADE;
 
-CREATE TRIGGER  update_started_date_before_insertion_trigger BEFORE UPDATE ON holdings_status
+CREATE TRIGGER update_started_date_before_insertion_trigger BEFORE UPDATE ON holdings_status
 FOR EACH ROW EXECUTE PROCEDURE update_started_date_before_insertion();

--- a/src/main/resources/templates/db_scripts/update_started_date_before_insertion.sql
+++ b/src/main/resources/templates/db_scripts/update_started_date_before_insertion.sql
@@ -1,7 +1,3 @@
--- Custom script to add an additional column startedDate for holdings_status table.
--- Changes in this file will not result in an update of the function.
--- To change the function, update this script
-
 CREATE OR REPLACE FUNCTION update_started_date_before_insertion()
   RETURNS TRIGGER
 AS $$

--- a/src/main/resources/templates/db_scripts/update_started_date_before_insertion.sql
+++ b/src/main/resources/templates/db_scripts/update_started_date_before_insertion.sql
@@ -7,10 +7,12 @@ CREATE OR REPLACE FUNCTION update_started_date_before_insertion()
 AS $$
  DECLARE
     started text;
+    old_started text;
  BEGIN
    started = NEW.jsonb->'data'->'attributes'->>'started';
-   IF started IS NULL THEN
-     NEW.jsonb = jsonb_set(NEW.jsonb, '{data,attributes,started}' ,  to_json(OLD.jsonb->'data'->'attributes'->>'started')::jsonb);
+   old_started = OLD.jsonb->'data'->'attributes'->>'started';
+   IF started IS NULL AND old_started IS NOT NULL THEN
+     NEW.jsonb = jsonb_set(NEW.jsonb, '{data,attributes,started}', to_json(old_started)::jsonb);
    ELSE NEW.jsonb = NEW.jsonb;
    end IF;
  RETURN NEW;

--- a/src/test/java/org/folio/service/holdings/AbstractLoadServiceFacadeTest.java
+++ b/src/test/java/org/folio/service/holdings/AbstractLoadServiceFacadeTest.java
@@ -36,8 +36,7 @@ public class AbstractLoadServiceFacadeTest {
   private final Vertx vertx = Vertx.vertx();
 
   private final AbstractLoadServiceFacade loadServiceFacadeSpy =
-    Mockito.spy(new AbstractLoadServiceFacade(1L, 3, 1,
-      1, 1, vertx) {
+    Mockito.spy(new AbstractLoadServiceFacade(1L, 3, 1, 1, 1, 1, vertx) {
       @Override
       protected CompletableFuture<String> populateHoldings(LoadService loadingService) {
         return CompletableFuture.completedFuture(TEST);

--- a/src/test/java/org/folio/service/holdings/DefaultLoadServiceFacadeTest.java
+++ b/src/test/java/org/folio/service/holdings/DefaultLoadServiceFacadeTest.java
@@ -22,9 +22,7 @@ public class DefaultLoadServiceFacadeTest {
   private final Vertx vertx = Vertx.vertx();
 
   private final DefaultLoadServiceFacade defaultLoadServiceFacade =
-    new DefaultLoadServiceFacade(1L, 1, 1,
-      1, 1, 1,
-      vertx);
+    new DefaultLoadServiceFacade(1L, 1, 1, 1, 1, 1, 1, vertx);
 
   @Test
   @SneakyThrows

--- a/src/test/resources/test-application.properties
+++ b/src/test/resources/test-application.properties
@@ -6,6 +6,7 @@ holdings.load.implementation.qualifier=DefaultLoadServiceFacade
 holdings.load.retry.count=2
 holdings.load.retry.delay=1
 holdings.page.size=2500
+holdings.page.size.min=100
 holdings.page.retry.count=2
 holdings.page.retry.delay=1
 holdings.report.status.check.delay=120000


### PR DESCRIPTION
- Fix trigger before updating holdings_status
- Reduce the size of the page by half after failed retry
- Use the parameter "forse=true" for creating a snapshot.  [FHIQC-33](https://github.com/folio-org/folio-holdingsiq-client/pull/79)

Closes: MODKBEKBJ-747
