### PR TITLE
fix(load-holdings) Reduce the size of the page by half after failed retry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <rmb.version>35.0.6</rmb.version>
     <folio-di-support.version>1.7.0</folio-di-support.version>
     <folio-service-tools.version>1.10.1</folio-service-tools.version>
-    <folio-holdingsiq-client.version>2.3.0</folio-holdingsiq-client.version>
+    <folio-holdingsiq-client.version>2.3.1</folio-holdingsiq-client.version>
     <folio-liquibase-util.version>1.6.0</folio-liquibase-util.version>
     <mod-configuration-client.version>5.9.1</mod-configuration-client.version>
 

--- a/src/main/java/org/folio/service/holdings/AbstractLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/AbstractLoadServiceFacade.java
@@ -30,7 +30,6 @@ import org.folio.holdingsiq.service.impl.LoadServiceImpl;
 import org.folio.repository.holdings.LoadStatus;
 import org.folio.service.holdings.message.ConfigurationMessage;
 import org.folio.service.holdings.message.LoadHoldingsMessage;
-import org.glassfish.jersey.internal.util.Producer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
@@ -47,17 +46,20 @@ public abstract class AbstractLoadServiceFacade implements LoadServiceFacade {
   protected final HoldingsService holdingsService;
   protected final int loadPageRetries;
   protected final int loadPageDelay;
-  private final long statusRetryDelay;
+  private final int loadPageSizeMin;
   private final int statusRetryCount;
   private final int snapshotRefreshPeriod;
+  private final long statusRetryDelay;
   private final Vertx vertx;
 
   protected AbstractLoadServiceFacade(@Value("${holdings.status.check.delay}") long statusRetryDelay,
                                       @Value("${holdings.status.retry.count}") int statusRetryCount,
                                       @Value("${holdings.page.retry.delay}") int loadPageRetryDelay,
-                                      @Value("${holdings.snapshot.refresh.period}") int snapshotRefreshPeriod,
                                       @Value("${holdings.page.retry.count}") int loadPageRetryCount,
+                                      @Value("${holdings.page.size.min}") int loadPageSizeMin,
+                                      @Value("${holdings.snapshot.refresh.period}") int snapshotRefreshPeriod,
                                       Vertx vertx) {
+    this.loadPageSizeMin = loadPageSizeMin;
     this.loadPageDelay = loadPageRetryDelay;
     this.loadPageRetries = loadPageRetryCount;
     this.statusRetryDelay = statusRetryDelay;
@@ -154,57 +156,57 @@ public abstract class AbstractLoadServiceFacade implements LoadServiceFacade {
   }
 
   /**
-   * Runs action provided by futureProducer, if future is completed exceptionally then futureProducer
+   * Runs action provided by futureFunction, if future is completed exceptionally then futureFunction
    * will be called again after given delay.
    *
    * @param retries        Amount of times action will be retried
-   *                       (e.g. if retries = 2 then futureProducer will be called 2 times)
+   *                       (e.g. if retries = 2 then futureFunction will be called 2 times)
    * @param delay          delay in milliseconds before action is executed again after failure
-   * @param futureProducer provides an asynchronous action
+   * @param futureFunction provides an asynchronous action
    * @return future returned by
    */
   private <T> CompletableFuture<T> retryOnFailure(int retries, long delay,
-                                                  Producer<CompletableFuture<T>> futureProducer) {
+                                                  IntFunction<CompletableFuture<T>> futureFunction) {
     CompletableFuture<T> future = new CompletableFuture<>();
-    retryOnFailure(retries, delay, future, futureProducer);
+    retryOnFailure(retries, delay, future, futureFunction);
     return future;
   }
 
   private <T> void retryOnFailure(int retries, long delay, CompletableFuture<T> future,
-                                  Producer<CompletableFuture<T>> futureProducer) {
-    doUntilResultMatches(retries, delay, future, futureProducer, (result, ex) -> ex == null);
+                                  IntFunction<CompletableFuture<T>> futureFunction) {
+    doUntilResultMatches(retries, delay, future, futureFunction, (result, ex) -> ex == null);
   }
 
   /**
-   * Runs action provided by futureProducer, when future completes the result is passed to matcher,
-   * if matcher returns false then futureProducer will be called again after delay.
+   * Runs action provided by futureFunction, when future completes the result is passed to matcher,
+   * if matcher returns false then futureFunction will be called again after delay.
    * if matcher returns true then the result is propagated to returned CompletableFuture
    * if matcher throws exception then exception is propagated to returned CompletableFuture and action is not retried
    *
-   * @param retries        Amount of times action will be retried (e.g. if retries = 2 then futureProducer
+   * @param retries        Amount of times action will be retried (e.g. if retries = 2 then futureFunction
    *                       will be called 2 times)
    * @param delay          delay in milliseconds before action is executed again after failure
-   * @param matcher        predicate that determines if futureProducer should be called again after delay
-   * @param futureProducer provides an asynchronous action to be executed
+   * @param matcher        predicate that determines if futureFunction should be called again after delay
+   * @param futureFunction provides an asynchronous action to be executed
    */
   protected <T> CompletableFuture<T> doUntilResultMatches(int retries, long delay,
-                                                          Producer<CompletableFuture<T>> futureProducer,
+                                                          IntFunction<CompletableFuture<T>> futureFunction,
                                                           BiPredicate<T, Throwable> matcher) {
     CompletableFuture<T> future = new CompletableFuture<>();
-    doUntilResultMatches(retries, delay, future, futureProducer, matcher);
+    doUntilResultMatches(retries, delay, future, futureFunction, matcher);
     return future;
   }
 
   private <T> void doUntilResultMatches(int retries, long delay, CompletableFuture<T> future,
-                                        Producer<CompletableFuture<T>> futureProducer,
+                                        IntFunction<CompletableFuture<T>> futureFunction,
                                         BiPredicate<T, Throwable> matcher) {
-    futureProducer.call()
+    futureFunction.apply(retries)
       .handle((result, ex) -> {
         if (matcher.test(result, ex)) {
           future.complete(result);
         } else {
           if (retries > 1) {
-            vertx.setTimer(delay, timerId -> doUntilResultMatches(retries - 1, delay, future, futureProducer, matcher));
+            vertx.setTimer(delay, timerId -> doUntilResultMatches(retries - 1, delay, future, futureFunction, matcher));
           } else {
             future.completeExceptionally(
               ex != null ? ex : new IllegalStateException("Action failed with result " + result));
@@ -248,10 +250,18 @@ public abstract class AbstractLoadServiceFacade implements LoadServiceFacade {
     CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
     List<Integer> pagesToLoad = IntStream.range(1, totalPages + 1).boxed().collect(Collectors.toList());
     for (Integer page : pagesToLoad) {
-      future = future
-        .thenCompose(o -> retryOnFailure(loadPageRetries, loadPageDelay, () -> pageLoader.apply(page)));
+      future = future.thenCompose(
+        o -> retryOnFailure(loadPageRetries, loadPageDelay, retries -> calculatePage(pageLoader, page, retries)));
     }
     return future;
+  }
+
+  protected CompletableFuture<Void> calculatePage(IntFunction<CompletableFuture<Void>> pageLoader,
+                                                  Integer page, Integer retries) {
+    if (loadPageRetries > retries) {
+      page = Math.max(page / 2, loadPageSizeMin);
+    }
+    return pageLoader.apply(page);
   }
 
   /**

--- a/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
@@ -23,8 +23,10 @@ public class DefaultLoadServiceFacade extends AbstractLoadServiceFacade {
                                   @Value("${holdings.snapshot.refresh.period}") int snapshotRefreshPeriod,
                                   @Value("${holdings.page.retry.count}") int loadPageRetryCount,
                                   @Value("${holdings.page.size:2500}") int loadPageSize,
+                                  @Value("${holdings.page.size.min}") int loadPageSizeMin,
                                   Vertx vertx) {
-    super(statusRetryDelay, statusRetryCount, loadPageRetryDelay, snapshotRefreshPeriod, loadPageRetryCount, vertx);
+    super(statusRetryDelay, statusRetryCount, loadPageRetryDelay, loadPageRetryCount, loadPageSizeMin,
+      snapshotRefreshPeriod, vertx);
     this.loadPageSize = loadPageSize;
   }
 

--- a/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/DefaultLoadServiceFacade.java
@@ -40,7 +40,7 @@ public class DefaultLoadServiceFacade extends AbstractLoadServiceFacade {
 
   @Override
   protected CompletableFuture<String> populateHoldings(LoadService loadingService) {
-    return loadingService.populateHoldings().thenApply(o -> null);
+    return loadingService.populateHoldingsForce().thenApply(o -> null);
   }
 
   @Override

--- a/src/main/java/org/folio/service/holdings/HoldingsServiceImpl.java
+++ b/src/main/java/org/folio/service/holdings/HoldingsServiceImpl.java
@@ -1,6 +1,7 @@
 package org.folio.service.holdings;
 
 import static java.lang.Integer.parseInt;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.folio.db.RowSetUtils.toUUID;
 import static org.folio.holdingsiq.model.HoldingChangeType.HOLDING_ADDED;
 import static org.folio.holdingsiq.model.HoldingChangeType.HOLDING_DELETED;
@@ -439,6 +440,7 @@ public class HoldingsServiceImpl implements HoldingsService {
                                                String tenantId) {
     Set<DbHoldingInfo> dbHoldings = holdings.stream()
       .filter(distinctByKey(this::getHoldingsId))
+      .filter(holding -> isNotEmpty(holding.getPackageId()))
       .map(holding -> DbHoldingInfo.builder()
         .titleId(parseInt(holding.getTitleId()))
         .packageId(parseInt(holding.getPackageId()))

--- a/src/main/java/org/folio/service/holdings/HoldingsServiceImpl.java
+++ b/src/main/java/org/folio/service/holdings/HoldingsServiceImpl.java
@@ -454,13 +454,9 @@ public class HoldingsServiceImpl implements HoldingsService {
   }
 
   private boolean isHoldingsValid(Holding holding) {
-    var holdingId = getHoldingsId(holding);
-    if (isEmpty(holding.getPackageId())) {
-      logger.info("packageId is empty for holding {}, skipping.", holdingId);
-      return false;
-    }
-    if (isEmpty(holding.getTitleId())) {
-      logger.info("titleId is empty for holding {}, skipping.", holdingId);
+    if (isEmpty(holding.getPackageId()) || isEmpty(holding.getTitleId())) {
+      var holdingId = getHoldingsId(holding);
+      logger.info("holdingsId parameter missing (vendorId-packageId-titleId): {}, skipping.", holdingId);
       return false;
     }
 

--- a/src/main/java/org/folio/service/holdings/TransactionLoadServiceFacade.java
+++ b/src/main/java/org/folio/service/holdings/TransactionLoadServiceFacade.java
@@ -47,17 +47,17 @@ public class TransactionLoadServiceFacade extends AbstractLoadServiceFacade {
   private final long reportStatusRetryDelay;
   private final int reportStatusRetryCount;
 
-  public TransactionLoadServiceFacade(
-    @Value("${holdings.status.check.delay}") long statusRetryDelay,
-    @Value("${holdings.status.retry.count}") int statusRetryCount,
-    @Value("${holdings.report.status.check.delay}") long reportStatusRetryDelay,
-    @Value("${holdings.report.status.retry.count}") int reportStatusRetryCount,
-    @Value("${holdings.page.retry.delay}") int loadPageRetryDelay,
-    @Value("${holdings.snapshot.refresh.period}") int snapshotRefreshPeriod,
-    @Value("${holdings.page.retry.count}") int loadPageRetryCount,
-
-    Vertx vertx) {
-    super(statusRetryDelay, statusRetryCount, loadPageRetryDelay, snapshotRefreshPeriod, loadPageRetryCount, vertx);
+  public TransactionLoadServiceFacade(@Value("${holdings.status.check.delay}") long statusRetryDelay,
+                                      @Value("${holdings.status.retry.count}") int statusRetryCount,
+                                      @Value("${holdings.report.status.check.delay}") long reportStatusRetryDelay,
+                                      @Value("${holdings.report.status.retry.count}") int reportStatusRetryCount,
+                                      @Value("${holdings.page.retry.delay}") int loadPageRetryDelay,
+                                      @Value("${holdings.snapshot.refresh.period}") int snapshotRefreshPeriod,
+                                      @Value("${holdings.page.retry.count}") int loadPageRetryCount,
+                                      @Value("${holdings.page.size.min}") int loadPageSizeMin,
+                                      Vertx vertx) {
+    super(statusRetryDelay, statusRetryCount, loadPageRetryDelay, loadPageRetryCount, loadPageSizeMin,
+      snapshotRefreshPeriod, vertx);
     this.reportStatusRetryDelay = reportStatusRetryDelay;
     this.reportStatusRetryCount = reportStatusRetryCount;
   }
@@ -144,7 +144,7 @@ public class TransactionLoadServiceFacade extends AbstractLoadServiceFacade {
   private CompletableFuture<DeltaReportStatus> waitForReportToComplete(LoadService loadingService,
                                                                        String deltaReportId) {
     return doUntilResultMatches(reportStatusRetryCount, reportStatusRetryDelay,
-      () -> loadingService.getDeltaReportStatus(deltaReportId),
+      retries -> loadingService.getDeltaReportStatus(deltaReportId),
       (loadStatus, ex) -> ReportStatus.COMPLETED == ReportStatus.fromValue(loadStatus.getStatus())
     );
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,7 @@ holdings.load.implementation.qualifier=DefaultLoadServiceFacade
 holdings.load.retry.count=3
 holdings.load.retry.delay=10800000
 holdings.page.size=2500
+holdings.page.size.min=100
 holdings.page.retry.count=3
 holdings.page.retry.delay=900000
 holdings.report.status.check.delay=120000

--- a/src/main/resources/templates/db_scripts/update_started_date_before_insertion.sql
+++ b/src/main/resources/templates/db_scripts/update_started_date_before_insertion.sql
@@ -1,16 +1,16 @@
 -- Custom script to add an additional column startedDate for holdings_status table.
--- Changes in this file will not result in an update of the function.
--- To change the function, update this script
 
 CREATE OR REPLACE FUNCTION update_started_date_before_insertion()
   RETURNS TRIGGER
 AS $$
  DECLARE
     started text;
+    old_started text;
  BEGIN
    started = NEW.jsonb->'data'->'attributes'->>'started';
-   IF started IS NULL THEN
-     NEW.jsonb = jsonb_set(NEW.jsonb, '{data,attributes,started}' ,  to_json(OLD.jsonb->'data'->'attributes'->>'started')::jsonb);
+   old_started = OLD.jsonb->'data'->'attributes'->>'started';
+   IF started IS NULL AND old_started IS NOT NULL THEN
+     NEW.jsonb = jsonb_set(NEW.jsonb, '{data,attributes,started}', to_json(old_started)::jsonb);
    ELSE NEW.jsonb = NEW.jsonb;
    end IF;
  RETURN NEW;

--- a/src/test/java/org/folio/service/holdings/AbstractLoadServiceFacadeTest.java
+++ b/src/test/java/org/folio/service/holdings/AbstractLoadServiceFacadeTest.java
@@ -36,8 +36,7 @@ public class AbstractLoadServiceFacadeTest {
   private final Vertx vertx = Vertx.vertx();
 
   private final AbstractLoadServiceFacade loadServiceFacadeSpy =
-    Mockito.spy(new AbstractLoadServiceFacade(1L, 3, 1,
-      1, 1, vertx) {
+    Mockito.spy(new AbstractLoadServiceFacade(1L, 3, 1, 1, 1, 1, vertx) {
       @Override
       protected CompletableFuture<String> populateHoldings(LoadService loadingService) {
         return CompletableFuture.completedFuture(TEST);

--- a/src/test/java/org/folio/service/holdings/DefaultLoadServiceFacadeTest.java
+++ b/src/test/java/org/folio/service/holdings/DefaultLoadServiceFacadeTest.java
@@ -22,9 +22,7 @@ public class DefaultLoadServiceFacadeTest {
   private final Vertx vertx = Vertx.vertx();
 
   private final DefaultLoadServiceFacade defaultLoadServiceFacade =
-    new DefaultLoadServiceFacade(1L, 1, 1,
-      1, 1, 1,
-      vertx);
+    new DefaultLoadServiceFacade(1L, 1, 1, 1, 1, 1, 1, vertx);
 
   @Test
   @SneakyThrows

--- a/src/test/resources/test-application.properties
+++ b/src/test/resources/test-application.properties
@@ -6,6 +6,7 @@ holdings.load.implementation.qualifier=DefaultLoadServiceFacade
 holdings.load.retry.count=2
 holdings.load.retry.delay=1
 holdings.page.size=2500
+holdings.page.size.min=100
 holdings.page.retry.count=2
 holdings.page.retry.delay=1
 holdings.report.status.check.delay=120000


### PR DESCRIPTION
- Fix trigger before updating holdings_status
- Reduce the size of the page by half after failed retry
- Use the parameter "forse=true" for creating a snapshot

Closes: MODKBEKBJ-747