### PR TITLE
feat(packages)!: drop `visibilityData` field from packages request/response

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,9 @@
-## v7.1.0 YYYY-mm-DD
+## v8.0.0 YYYY-mm-DD
 ### Breaking changes
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Drop `visibilityData` field from packages request/response ([MODKBEKBJ-835](https://folio-org.atlassian.net/browse/MODKBEKBJ-835))
 
 ### New APIs versions
-* Provides `API_NAME vX.Y`
+* Provides `eholdings v5.0`
 * Requires `API_NAME vX.Y`
 
 ### Features

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "eholdings",
-      "version": "4.0",
+      "version": "5.0",
       "handlers": [
         {
           "methods": ["GET"],

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-kb-ebsco-java</artifactId>
-  <version>7.1.0-SNAPSHOT</version>
+  <version>8.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>EBSCO KB Broker</name>

--- a/ramls/types/packages/packageDataAttributes.json
+++ b/ramls/types/packages/packageDataAttributes.json
@@ -142,11 +142,6 @@
         "type": "object"
       },
       "type": "array"
-    },
-    "visibilityData": {
-      "type": "object",
-      "description": "Visibility data",
-      "$ref": "../visibilityData.json"
     }
   }
 }

--- a/ramls/types/packages/packagePutDataAttributes.json
+++ b/ramls/types/packages/packagePutDataAttributes.json
@@ -91,11 +91,6 @@
         "type": "object"
       },
       "type": "array"
-    },
-    "visibilityData": {
-      "type": "object",
-      "description": "Visibility data",
-      "$ref": "../visibilityData.json"
     }
   }
 }

--- a/src/main/java/org/folio/rest/converter/packages/CommonPackagePutRequestConverter.java
+++ b/src/main/java/org/folio/rest/converter/packages/CommonPackagePutRequestConverter.java
@@ -2,7 +2,6 @@ package org.folio.rest.converter.packages;
 
 import static org.folio.common.ListUtils.mapItems;
 
-import java.util.Arrays;
 import java.util.List;
 import org.folio.holdingsiq.model.AlternateName;
 import org.folio.holdingsiq.model.CoverageDates;
@@ -10,8 +9,6 @@ import org.folio.holdingsiq.model.PackagePut;
 import org.folio.holdingsiq.model.Proxy;
 import org.folio.holdingsiq.model.Visibility;
 import org.folio.rest.jaxrs.model.PackagePutDataAttributes;
-import org.folio.rest.jaxrs.model.PackageVisibility;
-import org.folio.rest.jaxrs.model.VisibilityData;
 
 public abstract class CommonPackagePutRequestConverter {
 
@@ -32,13 +29,8 @@ public abstract class CommonPackagePutRequestConverter {
       builder.customAltNames(convertCustomAltNames(attributes));
     }
 
-    var visibilityData = attributes.getVisibilityData();
-    if (visibilityData == null || visibilityData.getIsHidden() == null) {
-      builder.visibilityDetails(mapItems(attributes.getVisibility(),
-        pv -> new Visibility(pv.getCategory().value(), pv.getHidden(), pv.getReason())));
-    } else {
-      builder.visibilityDetails(convertVisibilities(visibilityData));
-    }
+    builder.visibilityDetails(mapItems(attributes.getVisibility(),
+      pv -> new Visibility(pv.getCategory().value(), pv.getHidden(), pv.getReason())));
 
     return builder;
   }
@@ -50,12 +42,6 @@ public abstract class CommonPackagePutRequestConverter {
     builder.customDisplayName(attributes.getCustomDisplayName());
     builder.packageFreeAccess(attributes.getIsFreeAccess());
     builder.packageUrl(attributes.getUrl());
-  }
-
-  private List<Visibility> convertVisibilities(VisibilityData visibilityData) {
-    return Arrays.stream(PackageVisibility.Category.values())
-      .map(category -> new Visibility(category.value(), visibilityData.getIsHidden(), visibilityData.getReason()))
-      .toList();
   }
 
   private List<AlternateName> convertCustomAltNames(PackagePutDataAttributes attributes) {

--- a/src/main/java/org/folio/rest/converter/packages/PackageCollectionItemConverter.java
+++ b/src/main/java/org/folio/rest/converter/packages/PackageCollectionItemConverter.java
@@ -13,7 +13,6 @@ import org.folio.rest.jaxrs.model.PackageAltName;
 import org.folio.rest.jaxrs.model.PackageCollectionItem;
 import org.folio.rest.jaxrs.model.PackageDataAttributes;
 import org.folio.rest.jaxrs.model.PackageVisibility;
-import org.folio.rest.jaxrs.model.VisibilityData;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
@@ -54,20 +53,7 @@ public class PackageCollectionItemConverter implements Converter<PackageData, Pa
       .withSelectedCount(packageData.getSelectedCount())
       .withTitleCount(packageData.getTitleCount())
       .withUrl(packageData.getPackageUrl())
-      .withVisibility(mapItemsNullable(packageData.getVisibilityDetails(), this::convertVisibility))
-      .withVisibilityData(convertVisibilityData(packageData));
-  }
-
-  private VisibilityData convertVisibilityData(PackageData packageData) {
-    var isHidden = packageData.getVisibilityDetails().stream()
-      .map(Visibility::hidden)
-      .reduce(Boolean::logicalOr);
-    var hiddenByEp = packageData.getVisibilityDetails().stream()
-      .map(Visibility::reason)
-      .filter("Hidden by EP"::equals)
-      .findAny();
-    return new VisibilityData().withIsHidden(isHidden.orElse(false))
-      .withReason(hiddenByEp.isPresent() ? "Set by system" : "");
+      .withVisibility(mapItemsNullable(packageData.getVisibilityDetails(), this::convertVisibility));
   }
 
   private PackageVisibility convertVisibility(Visibility visibility) {

--- a/src/test/resources/responses/kb-ebsco/packages/expected-package-by-id-with-provider.json
+++ b/src/test/resources/responses/kb-ebsco/packages/expected-package-by-id-with-provider.json
@@ -37,11 +37,7 @@
           "reason": "Hidden by customer",
           "hidden": false
         }
-      ],
-      "visibilityData": {
-        "isHidden": false,
-        "reason": ""
-      }
+      ]
     },
     "relationships": {
       "resources": {

--- a/src/test/resources/responses/kb-ebsco/packages/expected-package-collection-with-five-elements.json
+++ b/src/test/resources/responses/kb-ebsco/packages/expected-package-collection-with-five-elements.json
@@ -40,11 +40,7 @@
             "reason": "Hidden by customer",
             "hidden": false
           }
-        ],
-        "visibilityData": {
-          "isHidden": false,
-          "reason": ""
-        }
+        ]
       },
       "relationships": {
         "resources": {
@@ -90,11 +86,7 @@
             "category": "MARC",
             "hidden": true
           }
-        ],
-        "visibilityData": {
-          "isHidden": true,
-          "reason": ""
-        }
+        ]
       },
       "relationships": {
         "resources": {
@@ -144,11 +136,7 @@
             "category": "MARC",
             "hidden": true
           }
-        ],
-        "visibilityData": {
-          "isHidden": true,
-          "reason": ""
-        }
+        ]
       },
       "relationships": {
         "resources": {
@@ -189,11 +177,7 @@
             "category": "FTF",
             "hidden": false
           }
-        ],
-        "visibilityData": {
-          "isHidden": false,
-          "reason": ""
-        }
+        ]
       },
       "relationships": {
         "resources": {
@@ -235,11 +219,7 @@
             "reason": "Hidden by customer",
             "hidden": false
           }
-        ],
-        "visibilityData": {
-          "isHidden": false,
-          "reason": ""
-        }
+        ]
       },
       "relationships": {
         "resources": {

--- a/src/test/resources/responses/kb-ebsco/packages/expected-package-collection-with-one-element.json
+++ b/src/test/resources/responses/kb-ebsco/packages/expected-package-collection-with-one-element.json
@@ -24,11 +24,7 @@
             "reason": "Hidden by customer",
             "hidden": false
           }
-        ],
-        "visibilityData": {
-          "isHidden": false,
-          "reason": ""
-        }
+        ]
       },
       "relationships": {
         "resources": {

--- a/src/test/resources/responses/kb-ebsco/resources/expected-resource-by-id-with-all-objects.json
+++ b/src/test/resources/responses/kb-ebsco/resources/expected-resource-by-id-with-all-objects.json
@@ -211,11 +211,7 @@
             "reason": "Hidden by customer",
             "hidden": false
           }
-        ],
-        "visibilityData": {
-          "isHidden": false,
-          "reason": ""
-        }
+        ]
       },
       "relationships": {
         "resources": {

--- a/src/test/resources/responses/kb-ebsco/resources/expected-resource-by-id-with-package.json
+++ b/src/test/resources/responses/kb-ebsco/resources/expected-resource-by-id-with-package.json
@@ -134,11 +134,7 @@
             "reason": "Hidden by customer",
             "hidden": false
           }
-        ],
-        "visibilityData": {
-          "isHidden": false,
-          "reason": ""
-        }
+        ]
       },
       "relationships": {
         "resources": {


### PR DESCRIPTION
### Purpose
Drop backward compatible visibilityData

### Approach
Drop visibilityData field from packages request/response

### Changes Checklist
- [x] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [x] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODKBEKBJ-835

Have to be merged together with 
https://github.com/folio-org/ui-plugin-find-package-title/pull/177
https://github.com/folio-org/mod-agreements/pull/1047
https://github.com/folio-org/mod-data-export-worker/pull/748
